### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/api-ref/ext/rest_parameters.py
+++ b/api-ref/ext/rest_parameters.py
@@ -89,7 +89,7 @@ class RestMethodDirective(Directive):
 
         # We need to build a temporary target that we can replace
         # later in the processing to get the TOC to resolve correctly.
-        temp_target = "%s-selector" % node['target']
+        temp_target = "{0!s}-selector".format(node['target'])
         target = nodes.target(ids=[temp_target])
         self.state.add_target(temp_target, '', target, lineno)
         section += node
@@ -199,7 +199,7 @@ class RestParametersDirective(Table):
                 desc = values.get('description', '')
                 classes = []
                 if min_version:
-                    desc += ("\n\n**New in version %s**\n" % min_version)
+                    desc += ("\n\n**New in version {0!s}**\n".format(min_version))
                     min_ver_css_name = ("rp_min_ver_" +
                                         str(min_version).replace('.', '_'))
                     classes.append(min_ver_css_name)
@@ -213,8 +213,7 @@ class RestParametersDirective(Table):
                 trow += add_col(desc)
                 rows.append(trow)
         except AttributeError as exc:
-            self.app.warn("Failure on key: %s, values: %s. %s" %
-                          (key, values, exc))
+            self.app.warn("Failure on key: {0!s}, values: {1!s}. {2!s}".format(key, values, exc))
             raise
         return rows, groups
 
@@ -296,7 +295,7 @@ def resolve_rest_references(app, doctree):
             # until this point just to keep it from colliding with
             # it's parent.
             rest_section.attributes['ids'][0] = (
-                "%s-detail" % rest_section.attributes['ids'][0])
+                "{0!s}-detail".format(rest_section.attributes['ids'][0]))
             rest_method_section.attributes['ids'][0] = rest_node['target']
 
             # Pop the overall section into it's grand parent,

--- a/doc/ext/support_matrix.py
+++ b/doc/ext/support_matrix.py
@@ -179,8 +179,7 @@ class SupportMatrixDirective(rst.Directive):
                                              name[1],
                                              name[2])
             else:
-                raise Exception("'%s' field is malformed in '[%s]' section" %
-                                (item, "DEFAULT"))
+                raise Exception("'{0!s}' field is malformed in '[{1!s}]' section".format(item, "DEFAULT"))
 
             targets[key] = target
 
@@ -197,7 +196,7 @@ class SupportMatrixDirective(rst.Directive):
                 continue
             if not cfg.has_option(section, "title"):
                 raise Exception(
-                    "'title' field missing in '[%s]' section" % section)
+                    "'title' field missing in '[{0!s}]' section".format(section))
 
             title = cfg.get(section, "title")
 
@@ -241,14 +240,12 @@ class SupportMatrixDirective(rst.Directive):
                 key = item[12:]
                 if key not in targets:
                     raise Exception(
-                        "Driver impl '%s' in '[%s]' not declared" %
-                        (item, section))
+                        "Driver impl '{0!s}' in '[{1!s}]' not declared".format(item, section))
 
                 status = cfg.get(section, item)
                 if status not in SupportMatrixImplementation.STATUS_ALL:
                     raise Exception(
-                        "'%s' value '%s' in '[%s]' section must be %s" %
-                        (item, status, section,
+                        "'{0!s}' value '{1!s}' in '[{2!s}]' section must be {3!s}".format(item, status, section,
                          ",".join(SupportMatrixImplementation.STATUS_ALL)))
 
                 noteskey = "driver-notes-" + item[12:]
@@ -263,8 +260,7 @@ class SupportMatrixDirective(rst.Directive):
 
             for key in targets:
                 if key not in feature.implementations:
-                    raise Exception("'%s' missing in '[%s]' section" %
-                                    (target.key, section))
+                    raise Exception("'{0!s}' missing in '[{1!s}]' section".format(target.key, section))
 
             features.append(feature)
 

--- a/nova/api/ec2/ec2utils.py
+++ b/nova/api/ec2/ec2utils.py
@@ -43,7 +43,7 @@ def memoize(func):
         global _CACHE
         if not _CACHE:
             _CACHE = cache_utils.get_client(expiration_time=_CACHE_TIME)
-        key = "%s:%s" % (func.__name__, reqid)
+        key = "{0!s}:{1!s}".format(func.__name__, reqid)
         key = str(key)
         value = _CACHE.get(key)
         if value is None:
@@ -458,9 +458,9 @@ def regex_from_ec2_regex(ec2_re):
             except StopIteration:
                 next_char = ''
             if next_char == '*' or next_char == '?':
-                py_re += '[%s]' % next_char
+                py_re += '[{0!s}]'.format(next_char)
             else:
                 py_re += '\\\\' + next_char
         else:
             py_re += re.escape(char)
-    return '\A%s\Z(?s)' % py_re
+    return '\A{0!s}\Z(?s)'.format(py_re)

--- a/nova/api/metadata/base.py
+++ b/nova/api/metadata/base.py
@@ -169,19 +169,19 @@ class InstanceMetadata(object):
         cfg = netutils.get_injected_network_template(network_info)
 
         if cfg:
-            key = "%04i" % len(self.content)
+            key = "{0:04d}".format(len(self.content))
             self.content[key] = cfg
             self.network_config = {"name": "network_config",
-                'content_path': "/%s/%s" % (CONTENT_DIR, key)}
+                'content_path': "/{0!s}/{1!s}".format(CONTENT_DIR, key)}
 
         # 'content' is passed in from the configdrive code in
         # nova/virt/libvirt/driver.py.  That's how we get the injected files
         # (personalities) in. AFAIK they're not stored in the db at all,
         # so are not available later (web service metadata time).
         for (path, contents) in content:
-            key = "%04i" % len(self.content)
+            key = "{0:04d}".format(len(self.content))
             self.files.append({'path': path,
-                'content_path': "/%s/%s" % (CONTENT_DIR, key)})
+                'content_path': "/{0!s}/{1!s}".format(CONTENT_DIR, key)})
             self.content[key] = contents
 
         if vd_driver is None:
@@ -349,9 +349,9 @@ class InstanceMetadata(object):
 
     def _handle_content(self, path_tokens):
         if len(path_tokens) == 1:
-            raise KeyError("no listing for %s" % "/".join(path_tokens))
+            raise KeyError("no listing for {0!s}".format("/".join(path_tokens)))
         if len(path_tokens) != 2:
-            raise KeyError("Too many tokens for /%s" % CONTENT_DIR)
+            raise KeyError("Too many tokens for /{0!s}".format(CONTENT_DIR))
         return self.content[path_tokens[1]]
 
     def _handle_version(self, version, path):
@@ -396,7 +396,7 @@ class InstanceMetadata(object):
         return self._check_version(required, requested, OPENSTACK_VERSIONS)
 
     def _get_hostname(self):
-        return "%s%s%s" % (self.instance.hostname,
+        return "{0!s}{1!s}{2!s}".format(self.instance.hostname,
                            '.' if CONF.dhcp_domain else '',
                            CONF.dhcp_domain)
 
@@ -469,23 +469,23 @@ class InstanceMetadata(object):
 
         ALL_OPENSTACK_VERSIONS = OPENSTACK_VERSIONS + ["latest"]
         for version in ALL_OPENSTACK_VERSIONS:
-            path = 'openstack/%s/%s' % (version, MD_JSON_NAME)
+            path = 'openstack/{0!s}/{1!s}'.format(version, MD_JSON_NAME)
             yield (path, self.lookup(path))
 
-            path = 'openstack/%s/%s' % (version, UD_NAME)
+            path = 'openstack/{0!s}/{1!s}'.format(version, UD_NAME)
             if self.userdata_raw is not None:
                 yield (path, self.lookup(path))
 
             if self._check_version(HAVANA, version, ALL_OPENSTACK_VERSIONS):
-                path = 'openstack/%s/%s' % (version, VD_JSON_NAME)
+                path = 'openstack/{0!s}/{1!s}'.format(version, VD_JSON_NAME)
                 yield (path, self.lookup(path))
 
             if self._check_version(LIBERTY, version, ALL_OPENSTACK_VERSIONS):
-                path = 'openstack/%s/%s' % (version, NW_JSON_NAME)
+                path = 'openstack/{0!s}/{1!s}'.format(version, NW_JSON_NAME)
                 yield (path, self.lookup(path))
 
         for (cid, content) in six.iteritems(self.content):
-            yield ('%s/%s/%s' % ("openstack", CONTENT_DIR, cid), content)
+            yield ('{0!s}/{1!s}/{2!s}'.format("openstack", CONTENT_DIR, cid), content)
 
 
 class RouteConfiguration(object):

--- a/nova/api/metadata/handler.py
+++ b/nova/api/metadata/handler.py
@@ -79,7 +79,7 @@ class MetadataRequestHandler(wsgi.Application):
         if not address:
             raise exception.FixedIpNotFoundForAddress(address=address)
 
-        cache_key = 'metadata-%s' % address
+        cache_key = 'metadata-{0!s}'.format(address)
         data = self._cache.get(cache_key)
         if data:
             LOG.debug("Using cached metadata for %s", address)
@@ -96,7 +96,7 @@ class MetadataRequestHandler(wsgi.Application):
         return data
 
     def get_metadata_by_instance_id(self, instance_id, address):
-        cache_key = 'metadata-%s' % instance_id
+        cache_key = 'metadata-{0!s}'.format(instance_id)
         data = self._cache.get(cache_key)
         if data:
             LOG.debug("Using cached metadata for instance %s", instance_id)

--- a/nova/api/metadata/password.py
+++ b/nova/api/metadata/password.py
@@ -44,7 +44,7 @@ def convert_password(context, password):
     password = password or ''
     meta = {}
     for i in range(CHUNKS):
-        meta['password_%d' % i] = password[:CHUNK_LENGTH]
+        meta['password_{0:d}'.format(i)] = password[:CHUNK_LENGTH]
         password = password[CHUNK_LENGTH:]
     return meta
 

--- a/nova/api/metadata/vendordata_json.py
+++ b/nova/api/metadata/vendordata_json.py
@@ -37,7 +37,7 @@ class JsonFileVendorData(base.VendorDataDriver):
         super(JsonFileVendorData, self).__init__(*args, **kwargs)
         data = {}
         fpath = CONF.vendordata_jsonfile_path
-        logprefix = "%s[%s]:" % (file_opt.name, fpath)
+        logprefix = "{0!s}[{1!s}]:".format(file_opt.name, fpath)
         if fpath:
             try:
                 with open(fpath, "r") as fp:

--- a/nova/api/openstack/__init__.py
+++ b/nova/api/openstack/__init__.py
@@ -122,7 +122,7 @@ class FaultWrapper(base_wsgi.Middleware):
         if safe:
             user_locale = req.best_match_language()
             inner_msg = translate(inner.message, user_locale)
-            outer.explanation = '%s: %s' % (inner.__class__.__name__,
+            outer.explanation = '{0!s}: {1!s}'.format(inner.__class__.__name__,
                                             inner_msg)
 
         notifications.send_api_fault(req.url, status, inner)
@@ -203,14 +203,14 @@ class ProjectMapper(APIMapper):
         if CONF.osapi_v21.project_id_regex:
             project_id_regex = CONF.osapi_v21.project_id_regex
 
-        project_id_token = '{project_id:%s}' % project_id_regex
+        project_id_token = '{{project_id:{0!s}}}'.format(project_id_regex)
         if 'parent_resource' not in kwargs:
-            kwargs['path_prefix'] = '%s/' % project_id_token
+            kwargs['path_prefix'] = '{0!s}/'.format(project_id_token)
         else:
             parent_resource = kwargs['parent_resource']
             p_collection = parent_resource['collection_name']
             p_member = parent_resource['member_name']
-            kwargs['path_prefix'] = '%s/%s/:%s_id' % (
+            kwargs['path_prefix'] = '{0!s}/{1!s}/:{2!s}_id'.format(
                 project_id_token,
                 p_collection,
                 p_member)
@@ -228,7 +228,7 @@ class ProjectMapper(APIMapper):
             parent_resource = kwargs['parent_resource']
             p_collection = parent_resource['collection_name']
             p_member = parent_resource['member_name']
-            kwargs['path_prefix'] = '%s/:%s_id' % (p_collection,
+            kwargs['path_prefix'] = '{0!s}/:{1!s}_id'.format(p_collection,
                                                    p_member)
         routes.Mapper.resource(self, member_name,
                                      collection_name,
@@ -241,7 +241,7 @@ class PlainMapper(APIMapper):
             parent_resource = kwargs['parent_resource']
             p_collection = parent_resource['collection_name']
             p_member = parent_resource['member_name']
-            kwargs['path_prefix'] = '%s/:%s_id' % (p_collection, p_member)
+            kwargs['path_prefix'] = '{0!s}/:{1!s}_id'.format(p_collection, p_member)
         routes.Mapper.resource(self, member_name,
                                      collection_name,
                                      **kwargs)

--- a/nova/api/openstack/api_version_request.py
+++ b/nova/api/openstack/api_version_request.py
@@ -141,8 +141,7 @@ class APIVersionRequest(object):
 
     def __str__(self):
         """Debug/Logging representation of object."""
-        return ("API Version Request Major: %s, Minor: %s"
-                % (self.ver_major, self.ver_minor))
+        return ("API Version Request Major: {0!s}, Minor: {1!s}".format(self.ver_major, self.ver_minor))
 
     def is_null(self):
         return self.ver_major == 0 and self.ver_minor == 0
@@ -212,4 +211,4 @@ class APIVersionRequest(object):
         """
         if self.is_null():
             raise ValueError
-        return "%s.%s" % (self.ver_major, self.ver_minor)
+        return "{0!s}.{1!s}".format(self.ver_major, self.ver_minor)

--- a/nova/api/openstack/auth.py
+++ b/nova/api/openstack/auth.py
@@ -41,7 +41,7 @@ class NoAuthMiddlewareBase(base_wsgi.Middleware):
             # NOTE(vish): This is expecting and returning Auth(1.1), whereas
             #             keystone uses 2.0 auth.  We should probably allow
             #             2.0 auth here as well.
-            res.headers['X-Auth-Token'] = '%s:%s' % (user_id, project_id)
+            res.headers['X-Auth-Token'] = '{0!s}:{1!s}'.format(user_id, project_id)
             res.headers['X-Server-Management-Url'] = os_url
             res.content_type = 'text/plain'
             res.status = '204'

--- a/nova/api/openstack/common.py
+++ b/nova/api/openstack/common.py
@@ -272,7 +272,7 @@ def get_id_from_href(href):
     Returns: 'abc123'
 
     """
-    return urlparse.urlsplit("%s" % href).path.split('/')[-1]
+    return urlparse.urlsplit("{0!s}".format(href)).path.split('/')[-1]
 
 
 def remove_trailing_version_from_href(href):
@@ -439,7 +439,7 @@ class ViewBuilder(object):
         url = url_join(prefix,
                        self._get_project_id(request),
                        collection_name)
-        return "%s?%s" % (url, urlparse.urlencode(params))
+        return "{0!s}?{1!s}".format(url, urlparse.urlencode(params))
 
     def _get_href_link(self, request, identifier, collection_name):
         """Return an href string pointing to this object."""

--- a/nova/api/openstack/compute/extended_availability_zone.py
+++ b/nova/api/openstack/compute/extended_availability_zone.py
@@ -29,7 +29,7 @@ class ExtendedAZController(wsgi.Controller):
         # NOTE(mriedem): The OS-EXT-AZ prefix should not be used for new
         # attributes after v2.1. They are only in v2.1 for backward compat
         # with v2.0.
-        key = "%s:availability_zone" % PREFIX
+        key = "{0!s}:availability_zone".format(PREFIX)
         az = avail_zone.get_instance_availability_zone(context, instance)
         server[key] = az or ''
 

--- a/nova/api/openstack/compute/extended_server_attributes.py
+++ b/nova/api/openstack/compute/extended_server_attributes.py
@@ -46,11 +46,11 @@ class ExtendedServerAttributesController(wsgi.Controller):
                            'root_device_name', 'user_data']
         for attr in properties:
             if attr == 'name':
-                key = "OS-EXT-SRV-ATTR:instance_%s" % attr
+                key = "OS-EXT-SRV-ATTR:instance_{0!s}".format(attr)
             else:
                 # NOTE(mriedem): Nothing after microversion 2.3 should use the
                 # OS-EXT-SRV-ATTR prefix for the attribute key name.
-                key = "OS-EXT-SRV-ATTR:%s" % attr
+                key = "OS-EXT-SRV-ATTR:{0!s}".format(attr)
             server[key] = instance[attr]
 
     def _server_host_status(self, context, server, instance, req):

--- a/nova/api/openstack/compute/extended_status.py
+++ b/nova/api/openstack/compute/extended_status.py
@@ -33,7 +33,7 @@ class ExtendedStatusController(wsgi.Controller):
             # NOTE(mriedem): The OS-EXT-STS prefix should not be used for new
             # attributes after v2.1. They are only in v2.1 for backward compat
             # with v2.0.
-            key = "%s:%s" % ('OS-EXT-STS', state)
+            key = "{0!s}:{1!s}".format('OS-EXT-STS', state)
             server[key] = instance[state]
 
     @wsgi.extends

--- a/nova/api/openstack/compute/extended_volumes.py
+++ b/nova/api/openstack/compute/extended_volumes.py
@@ -38,7 +38,7 @@ class ExtendedVolumesController(wsgi.Controller):
         # NOTE(mriedem): The os-extended-volumes prefix should not be used for
         # new attributes after v2.1. They are only in v2.1 for backward compat
         # with v2.0.
-        key = "%s:volumes_attached" % ExtendedVolumes.alias
+        key = "{0!s}:volumes_attached".format(ExtendedVolumes.alias)
         server[key] = volumes_attached
 
     @wsgi.extends

--- a/nova/api/openstack/compute/extension_info.py
+++ b/nova/api/openstack/compute/extension_info.py
@@ -241,8 +241,7 @@ class LoadedExtensionInfo(object):
         alias = ext.alias
 
         if alias in self.extensions:
-            raise exception.NovaException("Found duplicate extension: %s"
-                                          % alias)
+            raise exception.NovaException("Found duplicate extension: {0!s}".format(alias))
         self.extensions[alias] = ext
         return True
 

--- a/nova/api/openstack/compute/flavor_access.py
+++ b/nova/api/openstack/compute/flavor_access.py
@@ -66,7 +66,7 @@ class FlavorAccessController(wsgi.Controller):
 class FlavorActionController(wsgi.Controller):
     """The flavor access API controller for the OpenStack API."""
     def _extend_flavor(self, flavor_rval, flavor_ref):
-        key = "%s:is_public" % (FlavorAccess.alias)
+        key = "{0!s}:is_public".format((FlavorAccess.alias))
         flavor_rval[key] = flavor_ref['is_public']
 
     @wsgi.extends

--- a/nova/api/openstack/compute/instance_usage_audit_log.py
+++ b/nova/api/openstack/compute/instance_usage_audit_log.py
@@ -109,9 +109,9 @@ class InstanceUsageAuditLogController(wsgi.Controller):
                                 message=tl['message'])
                for tl in task_logs}
         missing_hosts = hosts - seen_hosts
-        overall_status = "%s hosts done. %s errors." % (
+        overall_status = "{0!s} hosts done. {1!s} errors.".format(
                     'ALL' if len(done_hosts) == len(hosts)
-                    else "%s of %s" % (len(done_hosts), len(hosts)),
+                    else "{0!s} of {1!s}".format(len(done_hosts), len(hosts)),
                     total_errors)
         return dict(period_beginning=str(begin),
                     period_ending=str(end),

--- a/nova/api/openstack/compute/legacy_v2/contrib/admin_actions.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/admin_actions.py
@@ -37,7 +37,7 @@ state_map = dict(active=vm_states.ACTIVE, error=vm_states.ERROR)
 
 
 def authorize(context, action_name):
-    action = 'admin_actions:%s' % action_name
+    action = 'admin_actions:{0!s}'.format(action_name)
     extensions.extension_authorizer('compute', action)(context)
 
 

--- a/nova/api/openstack/compute/legacy_v2/contrib/disk_config.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/disk_config.py
@@ -23,7 +23,7 @@ from nova.i18n import _
 
 ALIAS = 'OS-DCF'
 XMLNS_DCF = "http://docs.openstack.org/compute/ext/disk_config/api/v1.1"
-API_DISK_CONFIG = "%s:diskConfig" % ALIAS
+API_DISK_CONFIG = "{0!s}:diskConfig".format(ALIAS)
 INTERNAL_DISK_CONFIG = "auto_disk_config"
 authorize = extensions.soft_extension_authorizer('compute', 'disk_config')
 

--- a/nova/api/openstack/compute/legacy_v2/contrib/extended_availability_zone.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/extended_availability_zone.py
@@ -25,7 +25,7 @@ authorize = extensions.soft_extension_authorizer('compute',
 
 class ExtendedAZController(wsgi.Controller):
     def _extend_server(self, context, server, instance):
-        key = "%s:availability_zone" % Extended_availability_zone.alias
+        key = "{0!s}:availability_zone".format(Extended_availability_zone.alias)
         az = avail_zone.get_instance_availability_zone(context, instance)
         server[key] = az or ''
 

--- a/nova/api/openstack/compute/legacy_v2/contrib/extended_ips.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/extended_ips.py
@@ -30,7 +30,7 @@ class ExtendedIpsController(wsgi.Controller):
         self.compute_api = compute.API()
 
     def _extend_server(self, context, server, instance):
-        key = "%s:type" % Extended_ips.alias
+        key = "{0!s}:type".format(Extended_ips.alias)
         networks = common.get_networks_for_instance(context, instance)
         for label, network in networks.items():
             # NOTE(vish): ips are hidden in some states via the

--- a/nova/api/openstack/compute/legacy_v2/contrib/extended_ips_mac.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/extended_ips_mac.py
@@ -28,7 +28,7 @@ class ExtendedIpsMacController(wsgi.Controller):
         super(ExtendedIpsMacController, self).__init__(*args, **kwargs)
 
     def _extend_server(self, context, server, instance):
-        key = "%s:mac_addr" % Extended_ips_mac.alias
+        key = "{0!s}:mac_addr".format(Extended_ips_mac.alias)
         networks = common.get_networks_for_instance(context, instance)
         for label, network in networks.items():
             # NOTE(vish): ips are hidden in some states via the

--- a/nova/api/openstack/compute/legacy_v2/contrib/extended_server_attributes.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/extended_server_attributes.py
@@ -23,15 +23,15 @@ authorize = extensions.soft_extension_authorizer('compute',
 
 class ExtendedServerAttributesController(wsgi.Controller):
     def _extend_server(self, context, server, instance):
-        key = "%s:hypervisor_hostname" % Extended_server_attributes.alias
+        key = "{0!s}:hypervisor_hostname".format(Extended_server_attributes.alias)
         server[key] = instance.node
 
         for attr in ['host', 'name']:
             if attr == 'name':
-                key = "%s:instance_%s" % (Extended_server_attributes.alias,
+                key = "{0!s}:instance_{1!s}".format(Extended_server_attributes.alias,
                                           attr)
             else:
-                key = "%s:%s" % (Extended_server_attributes.alias, attr)
+                key = "{0!s}:{1!s}".format(Extended_server_attributes.alias, attr)
             server[key] = instance[attr]
 
     @wsgi.extends

--- a/nova/api/openstack/compute/legacy_v2/contrib/extended_status.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/extended_status.py
@@ -26,7 +26,7 @@ class ExtendedStatusController(wsgi.Controller):
 
     def _extend_server(self, server, instance):
         for state in ['task_state', 'vm_state', 'power_state']:
-            key = "%s:%s" % (Extended_status.alias, state)
+            key = "{0!s}:{1!s}".format(Extended_status.alias, state)
             server[key] = instance[state]
 
     @wsgi.extends

--- a/nova/api/openstack/compute/legacy_v2/contrib/extended_virtual_interfaces_net.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/extended_virtual_interfaces_net.py
@@ -27,7 +27,7 @@ class ExtendedServerVIFNetController(wsgi.Controller):
 
     @wsgi.extends
     def index(self, req, resp_obj, server_id):
-        key = "%s:net_id" % Extended_virtual_interfaces_net.alias
+        key = "{0!s}:net_id".format(Extended_virtual_interfaces_net.alias)
         context = req.environ['nova.context']
         if authorize(context):
             for vif in resp_obj.obj['virtual_interfaces']:

--- a/nova/api/openstack/compute/legacy_v2/contrib/extended_volumes.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/extended_volumes.py
@@ -27,7 +27,7 @@ class ExtendedVolumesController(wsgi.Controller):
 
     def _extend_server(self, context, server, bdms):
         volume_ids = [bdm.volume_id for bdm in bdms if bdm.volume_id]
-        key = "%s:volumes_attached" % Extended_volumes.alias
+        key = "{0!s}:volumes_attached".format(Extended_volumes.alias)
         server[key] = [{'id': volume_id} for volume_id in volume_ids]
 
     @wsgi.extends

--- a/nova/api/openstack/compute/legacy_v2/contrib/flavor_access.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/flavor_access.py
@@ -72,7 +72,7 @@ class FlavorActionController(wsgi.Controller):
             raise webob.exc.HTTPBadRequest(explanation=_("No request body"))
 
     def _extend_flavor(self, flavor_rval, flavor_ref):
-        key = "%s:is_public" % (Flavor_access.alias)
+        key = "{0!s}:is_public".format((Flavor_access.alias))
         flavor_rval[key] = flavor_ref['is_public']
 
     @wsgi.extends

--- a/nova/api/openstack/compute/legacy_v2/contrib/flavor_disabled.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/flavor_disabled.py
@@ -25,7 +25,7 @@ class FlavorDisabledController(wsgi.Controller):
     def _extend_flavors(self, req, flavors):
         for flavor in flavors:
             db_flavor = req.get_db_flavor(flavor['id'])
-            key = "%s:disabled" % Flavor_disabled.alias
+            key = "{0!s}:disabled".format(Flavor_disabled.alias)
             flavor[key] = db_flavor['disabled']
 
     def _show(self, req, resp_obj):

--- a/nova/api/openstack/compute/legacy_v2/contrib/flavorextradata.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/flavorextradata.py
@@ -33,7 +33,7 @@ class FlavorextradataController(wsgi.Controller):
     def _extend_flavors(self, req, flavors):
         for flavor in flavors:
             db_flavor = req.get_db_flavor(flavor['id'])
-            key = "%s:ephemeral" % Flavorextradata.alias
+            key = "{0!s}:ephemeral".format(Flavorextradata.alias)
             flavor[key] = db_flavor['ephemeral_gb']
 
     def _show(self, req, resp_obj):

--- a/nova/api/openstack/compute/legacy_v2/contrib/image_size.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/image_size.py
@@ -22,7 +22,7 @@ authorize = extensions.soft_extension_authorizer('compute', 'image_size')
 class ImageSizeController(wsgi.Controller):
 
     def _extend_image(self, image, image_cache):
-        key = "%s:size" % Image_size.alias
+        key = "{0!s}:size".format(Image_size.alias)
         image[key] = image_cache['size']
 
     @wsgi.extends

--- a/nova/api/openstack/compute/legacy_v2/contrib/instance_usage_audit_log.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/instance_usage_audit_log.py
@@ -110,9 +110,9 @@ class InstanceUsageAuditLogController(object):
                                 message=tl['message'])
                for tl in task_logs}
         missing_hosts = hosts - seen_hosts
-        overall_status = "%s hosts done. %s errors." % (
+        overall_status = "{0!s} hosts done. {1!s} errors.".format(
                     'ALL' if len(done_hosts) == len(hosts)
-                    else "%s of %s" % (len(done_hosts), len(hosts)),
+                    else "{0!s} of {1!s}".format(len(done_hosts), len(hosts)),
                     total_errors)
         return dict(period_beginning=str(begin),
                     period_ending=str(end),

--- a/nova/api/openstack/compute/legacy_v2/contrib/migrations.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/migrations.py
@@ -21,7 +21,7 @@ ALIAS = "os-migrations"
 
 
 def authorize(context, action_name):
-    action = 'migrations:%s' % action_name
+    action = 'migrations:{0!s}'.format(action_name)
     extensions.extension_authorizer('compute', action)(context)
 
 

--- a/nova/api/openstack/compute/legacy_v2/contrib/scheduler_hints.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/scheduler_hints.py
@@ -25,7 +25,7 @@ class SchedulerHintsController(wsgi.Controller):
     def _extract_scheduler_hints(body):
         hints = {}
 
-        attr = '%s:scheduler_hints' % Scheduler_hints.alias
+        attr = '{0!s}:scheduler_hints'.format(Scheduler_hints.alias)
         try:
             if 'os:scheduler_hints' in body:
                 # NOTE(vish): This is for legacy support

--- a/nova/api/openstack/compute/legacy_v2/contrib/server_usage.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/server_usage.py
@@ -26,7 +26,7 @@ class ServerUsageController(wsgi.Controller):
 
     def _extend_server(self, server, instance):
         for k in ['launched_at', 'terminated_at']:
-            key = "%s:%s" % (Server_usage.alias, k)
+            key = "{0!s}:{1!s}".format(Server_usage.alias, k)
             # NOTE(danms): Historically, this timestamp has been generated
             # merely by grabbing str(datetime) of a TZ-naive object. The
             # only way we can keep that with instance objects is to strip

--- a/nova/api/openstack/compute/legacy_v2/contrib/volumes.py
+++ b/nova/api/openstack/compute/legacy_v2/contrib/volumes.py
@@ -200,7 +200,7 @@ class VolumeController(wsgi.Controller):
         retval = _translate_volume_detail_view(context, dict(new_volume))
         result = {'volume': retval}
 
-        location = '%s/%s' % (req.url, new_volume['id'])
+        location = '{0!s}/{1!s}'.format(req.url, new_volume['id'])
 
         return wsgi.ResponseObject(result, headers=dict(location=location))
 

--- a/nova/api/openstack/compute/legacy_v2/limits.py
+++ b/nova/api/openstack/compute/legacy_v2/limits.py
@@ -407,7 +407,7 @@ class WsgiLimiter(object):
         delay, error = self._limiter.check_for_delay(verb, path, username)
 
         if delay:
-            headers = {"X-Wait-Seconds": "%.2f" % delay}
+            headers = {"X-Wait-Seconds": "{0:.2f}".format(delay)}
             return webob.exc.HTTPForbidden(headers=headers, explanation=error)
         else:
             return webob.exc.HTTPNoContent()
@@ -430,7 +430,7 @@ class WsgiLimiterProxy(object):
         conn = httplib.HTTPConnection(self.limiter_address)
 
         if username:
-            conn.request("POST", "/%s" % (username), body, headers)
+            conn.request("POST", "/{0!s}".format((username)), body, headers)
         else:
             conn.request("POST", "/", body, headers)
 

--- a/nova/api/openstack/compute/legacy_v2/servers.py
+++ b/nova/api/openstack/compute/legacy_v2/servers.py
@@ -648,11 +648,11 @@ class Controller(wsgi.Controller):
             raise exc.HTTPForbidden(
                 explanation=error.format_message())
         except messaging.RemoteError as err:
-            msg = "%(err_type)s: %(err_msg)s" % {'err_type': err.exc_type,
-                                                 'err_msg': err.value}
+            msg = "{err_type!s}: {err_msg!s}".format(**{'err_type': err.exc_type,
+                                                 'err_msg': err.value})
             raise exc.HTTPBadRequest(explanation=msg)
         except UnicodeDecodeError as error:
-            msg = "UnicodeError: %s" % error
+            msg = "UnicodeError: {0!s}".format(error)
             raise exc.HTTPBadRequest(explanation=msg)
         except Exception:
             # The remaining cases can be handled in a standard fashion.

--- a/nova/api/openstack/compute/pci.py
+++ b/nova/api/openstack/compute/pci.py
@@ -37,7 +37,7 @@ class PciServerController(wsgi.Controller):
         dev_id = []
         for dev in instance.pci_devices:
             dev_id.append({'id': dev.id})
-        server['%s:pci_devices' % Pci.alias] = dev_id
+        server['{0!s}:pci_devices'.format(Pci.alias)] = dev_id
 
     @wsgi.extends
     def show(self, req, resp_obj, id):
@@ -64,7 +64,7 @@ class PciHypervisorController(wsgi.Controller):
                          for pci_pool in compute_node.pci_device_pools]
         else:
             pci_pools = []
-        hypervisor['%s:pci_stats' % Pci.alias] = pci_pools
+        hypervisor['{0!s}:pci_stats'.format(Pci.alias)] = pci_pools
 
     @wsgi.extends
     def show(self, req, resp_obj, id):

--- a/nova/api/openstack/compute/server_usage.py
+++ b/nova/api/openstack/compute/server_usage.py
@@ -26,7 +26,7 @@ class ServerUsageController(wsgi.Controller):
 
     def _extend_server(self, server, instance):
         for k in ['launched_at', 'terminated_at']:
-            key = "%s:%s" % (resp_topic, k)
+            key = "{0!s}:{1!s}".format(resp_topic, k)
             # NOTE(danms): Historically, this timestamp has been generated
             # merely by grabbing str(datetime) of a TZ-naive object. The
             # only way we can keep that with instance objects is to strip

--- a/nova/api/openstack/compute/servers.py
+++ b/nova/api/openstack/compute/servers.py
@@ -646,11 +646,11 @@ class ServersController(wsgi.Controller):
         except exception.ExternalNetworkAttachForbidden as error:
             raise exc.HTTPForbidden(explanation=error.format_message())
         except messaging.RemoteError as err:
-            msg = "%(err_type)s: %(err_msg)s" % {'err_type': err.exc_type,
-                                                 'err_msg': err.value}
+            msg = "{err_type!s}: {err_msg!s}".format(**{'err_type': err.exc_type,
+                                                 'err_msg': err.value})
             raise exc.HTTPBadRequest(explanation=msg)
         except UnicodeDecodeError as error:
-            msg = "UnicodeError: %s" % error
+            msg = "UnicodeError: {0!s}".format(error)
             raise exc.HTTPBadRequest(explanation=msg)
         except (exception.ImageNotActive,
                 exception.ImageBadRequest,

--- a/nova/api/openstack/compute/volumes.py
+++ b/nova/api/openstack/compute/volumes.py
@@ -194,7 +194,7 @@ class VolumeController(wsgi.Controller):
         retval = _translate_volume_detail_view(context, dict(new_volume))
         result = {'volume': retval}
 
-        location = '%s/%s' % (req.url, new_volume['id'])
+        location = '{0!s}/{1!s}'.format(req.url, new_volume['id'])
 
         return wsgi.ResponseObject(result, headers=dict(location=location))
 

--- a/nova/api/openstack/extensions.py
+++ b/nova/api/openstack/extensions.py
@@ -79,7 +79,7 @@ class ExtensionDescriptor(object):
         return controller_exts
 
     def __repr__(self):
-        return "<Extension: name=%s, alias=%s, updated=%s>" % (
+        return "<Extension: name={0!s}, alias={1!s}, updated={2!s}>".format(
             self.name, self.alias, self.updated)
 
     def is_valid(self):
@@ -89,7 +89,7 @@ class ExtensionDescriptor(object):
         """
         for attr in ('name', 'alias', 'updated', 'namespace'):
             if getattr(self, attr) is None:
-                raise AttributeError("%s is None, needs to be defined" % attr)
+                raise AttributeError("{0!s} is None, needs to be defined".format(attr))
         return True
 
 
@@ -155,8 +155,7 @@ class ExtensionManager(object):
 
         alias = ext.alias
         if alias in self.extensions:
-            raise exception.NovaException("Found duplicate extension: %s"
-                                          % alias)
+            raise exception.NovaException("Found duplicate extension: {0!s}".format(alias))
         self.extensions[alias] = ext
         self.sorted_ext_list = None
 
@@ -284,7 +283,7 @@ def load_standard_extensions(ext_mgr, logger, path, package, ext_list=None):
         if relpath == '.':
             relpkg = ''
         else:
-            relpkg = '.%s' % '.'.join(relpath.split(os.sep))
+            relpkg = '.{0!s}'.format('.'.join(relpath.split(os.sep)))
 
         # Now, consider each file in turn, only considering .py files
         for fname in filenames:
@@ -295,12 +294,11 @@ def load_standard_extensions(ext_mgr, logger, path, package, ext_list=None):
                 continue
 
             # Try loading it
-            classname = "%s%s" % (root[0].upper(), root[1:])
-            classpath = ("%s%s.%s.%s" %
-                         (package, relpkg, root, classname))
+            classname = "{0!s}{1!s}".format(root[0].upper(), root[1:])
+            classpath = ("{0!s}{1!s}.{2!s}.{3!s}".format(package, relpkg, root, classname))
 
             if ext_list is not None and classname not in ext_list:
-                logger.debug("Skipping extension: %s" % classpath)
+                logger.debug("Skipping extension: {0!s}".format(classpath))
                 continue
 
             try:
@@ -318,7 +316,7 @@ def load_standard_extensions(ext_mgr, logger, path, package, ext_list=None):
                 continue
 
             # If it has extension(), delegate...
-            ext_name = "%s%s.%s.extension" % (package, relpkg, dname)
+            ext_name = "{0!s}{1!s}.{2!s}.extension".format(package, relpkg, dname)
             try:
                 ext = importutils.import_class(ext_name)
             except ImportError:
@@ -348,9 +346,9 @@ def core_authorizer(api_name, extension_name):
             target = {'project_id': context.project_id,
                       'user_id': context.user_id}
         if action is None:
-            act = '%s:%s' % (api_name, extension_name)
+            act = '{0!s}:{1!s}'.format(api_name, extension_name)
         else:
-            act = '%s:%s:%s' % (api_name, extension_name, action)
+            act = '{0!s}:{1!s}:{2!s}'.format(api_name, extension_name, action)
         nova.policy.enforce(context, act, target)
     return authorize
 
@@ -358,7 +356,7 @@ def core_authorizer(api_name, extension_name):
 # This is only used for Nova V2 API, after v2 API depreciated, this will be
 # deprecated also.
 def extension_authorizer(api_name, extension_name):
-    return core_authorizer('%s_extension' % api_name, extension_name)
+    return core_authorizer('{0!s}_extension'.format(api_name), extension_name)
 
 
 def _soft_authorizer(hard_authorizer, api_name, extension_name):
@@ -386,7 +384,7 @@ def soft_core_authorizer(api_name, extension_name):
 
 # This will be deprecated after ec2 old style policy removed in later release
 def check_compute_policy(context, action, target, scope='compute'):
-    _action = '%s:%s' % (scope, action)
+    _action = '{0!s}:{1!s}'.format(scope, action)
     nova.policy.enforce(context, _action, target)
 
 
@@ -450,7 +448,7 @@ class V21APIExtensionBase(object):
         pass
 
     def __repr__(self):
-        return "<Extension: name=%s, alias=%s, version=%s>" % (
+        return "<Extension: name={0!s}, alias={1!s}, version={2!s}>".format(
             self.name, self.alias, self.version)
 
     def is_valid(self):
@@ -460,7 +458,7 @@ class V21APIExtensionBase(object):
         """
         for attr in ('name', 'alias', 'version'):
             if getattr(self, attr) is None:
-                raise AttributeError("%s is None, needs to be defined" % attr)
+                raise AttributeError("{0!s} is None, needs to be defined".format(attr))
         return True
 
 

--- a/nova/api/openstack/versioned_method.py
+++ b/nova/api/openstack/versioned_method.py
@@ -31,5 +31,4 @@ class VersionedMethod(object):
         self.func = func
 
     def __str__(self):
-        return ("Version Method %s: min: %s, max: %s"
-                % (self.name, self.start_version, self.end_version))
+        return ("Version Method {0!s}: min: {1!s}, max: {2!s}".format(self.name, self.start_version, self.end_version))

--- a/nova/api/openstack/wsgi.py
+++ b/nova/api/openstack/wsgi.py
@@ -1115,7 +1115,7 @@ class RateLimitFault(webob.exc.HTTPException):
     def _retry_after(retry_time):
         delay = int(math.ceil(retry_time - time.time()))
         retry_after = delay if delay > 0 else 0
-        headers = {'Retry-After': '%d' % retry_after}
+        headers = {'Retry-After': '{0:d}'.format(retry_after)}
         return headers
 
     @webob.dec.wsgify(RequestClass=Request)

--- a/nova/api/validation/validators.py
+++ b/nova/api/validation/validators.py
@@ -218,7 +218,7 @@ class FormatChecker(jsonschema.FormatChecker):
         except raises as e:
             cause = e
         if not result:
-            msg = "%r is not a %r" % (instance, format)
+            msg = "{0!r} is not a {1!r}".format(instance, format)
             raise jsonschema_exc.FormatError(msg, cause=cause)
 
 

--- a/nova/availability_zones.py
+++ b/nova/availability_zones.py
@@ -49,7 +49,7 @@ def reset_cache():
 
 
 def _make_cache_key(host):
-    return "azcache-%s" % host.encode('utf-8')
+    return "azcache-{0!s}".format(host.encode('utf-8'))
 
 
 def _build_metadata_by_host(aggregates, hosts=None):

--- a/nova/block_device.py
+++ b/nova/block_device.py
@@ -543,7 +543,7 @@ def instance_block_mapping(instance, bdms):
     if ebs_devices:
         ebs_devices.sort()
         for nebs, ebs in enumerate(ebs_devices):
-            mappings['ebs%d' % nebs] = ebs
+            mappings['ebs{0:d}'.format(nebs)] = ebs
 
     swap = [bdm for bdm in blanks if bdm.guest_format == 'swap']
     if swap:
@@ -552,7 +552,7 @@ def instance_block_mapping(instance, bdms):
     ephemerals = [bdm for bdm in blanks if bdm.guest_format != 'swap']
     if ephemerals:
         for num, eph in enumerate(ephemerals):
-            mappings['ephemeral%d' % num] = eph.device_name
+            mappings['ephemeral{0:d}'.format(num)] = eph.device_name
 
     return mappings
 

--- a/nova/cells/filters/image_properties.py
+++ b/nova/cells/filters/image_properties.py
@@ -63,5 +63,5 @@ class ImagePropertiesFilter(filters.BaseCellFilter):
 
     def _matches_version(self, version, version_requires):
         predicate = versionpredicate.VersionPredicate(
-                             'prop (%s)' % version_requires)
+                             'prop ({0!s})'.format(version_requires))
         return predicate.satisfied_by(version)

--- a/nova/cells/manager.py
+++ b/nova/cells/manager.py
@@ -445,7 +445,7 @@ class CellsManager(manager.Manager):
         target_cell = None
         if "cell_name" in filters:
             _path_cell_sep = cells_utils.PATH_CELL_SEP
-            target_cell = '%s%s%s' % (CONF.cells.name, _path_cell_sep,
+            target_cell = '{0!s}{1!s}{2!s}'.format(CONF.cells.name, _path_cell_sep,
                                       filters['cell_name'])
 
         responses = self.msg_runner.get_migrations(ctxt, target_cell,

--- a/nova/cells/messaging.py
+++ b/nova/cells/messaging.py
@@ -167,7 +167,7 @@ class _BaseMessage(object):
     def __repr__(self):
         _dict = self._to_dict()
         _dict.pop('method_kwargs')
-        return "<%s: %s>" % (self.__class__.__name__, _dict)
+        return "<{0!s}: {1!s}>".format(self.__class__.__name__, _dict)
 
     def _append_hop(self):
         """Add our hop to the routing_path."""
@@ -330,7 +330,7 @@ class _TargetedMessage(_BaseMessage):
             if target_cell.is_me:
                 target_cell = self.our_path_part
             else:
-                target_cell = '%s%s%s' % (self.our_path_part,
+                target_cell = '{0!s}{1!s}{2!s}'.format(self.our_path_part,
                                           _PATH_CELL_SEP,
                                           target_cell.name)
         # NOTE(alaski): This occurs when hosts are specified with no cells
@@ -1935,7 +1935,7 @@ def deserialize_remote_exception(data, allowed_remote_exmods):
     str_override = lambda self: message
     new_ex_type = type(ex_type.__name__ + _REMOTE_POSTFIX, (ex_type,),
                        {'__str__': str_override, '__unicode__': str_override})
-    new_ex_type.__module__ = '%s%s' % (module, _REMOTE_POSTFIX)
+    new_ex_type.__module__ = '{0!s}{1!s}'.format(module, _REMOTE_POSTFIX)
     try:
         # NOTE(ameade): Dynamically create a new exception type and swap it in
         # as the new type for the exception. This only works on user defined

--- a/nova/cells/rpc_driver.py
+++ b/nova/cells/rpc_driver.py
@@ -57,7 +57,7 @@ class CellsRPCDriver(driver.BaseCellsDriver):
         topic_base = CONF.cells.rpc_driver_queue_base
         proxy_manager = InterCellRPCDispatcher(msg_runner)
         for msg_type in msg_runner.get_message_types():
-            target = messaging.Target(topic='%s.%s' % (topic_base, msg_type),
+            target = messaging.Target(topic='{0!s}.{1!s}'.format(topic_base, msg_type),
                                       server=CONF.host)
             # NOTE(comstud): We do not need to use the object serializer
             # on this because object serialization is taken care for us in
@@ -136,7 +136,7 @@ class InterCellRPCAPI(object):
         'CONF.rpc_driver_queue_base.<message_type>'.
         """
         topic_base = CONF.cells.rpc_driver_queue_base
-        topic = '%s.%s' % (topic_base, message.message_type)
+        topic = '{0!s}.{1!s}'.format(topic_base, message.message_type)
         cctxt = self._get_client(cell_state, topic)
         if message.fanout:
             cctxt = cctxt.prepare(fanout=message.fanout)

--- a/nova/cells/state.py
+++ b/nova/cells/state.py
@@ -103,7 +103,7 @@ class CellState(object):
 
     def __repr__(self):
         me = "me" if self.is_me else "not_me"
-        return "Cell '%s' (%s)" % (self.name, me)
+        return "Cell '{0!s}' ({1!s})".format(self.name, me)
 
 
 def sync_before(f):

--- a/nova/cells/weights/__init__.py
+++ b/nova/cells/weights/__init__.py
@@ -22,7 +22,7 @@ from nova import weights
 
 class WeightedCell(weights.WeighedObject):
     def __repr__(self):
-        return "WeightedCell [cell: %s, weight: %s]" % (
+        return "WeightedCell [cell: {0!s}, weight: {1!s}]".format(
                 self.obj.name, self.weight)
 
 

--- a/nova/cloudpipe/pipelib.py
+++ b/nova/cloudpipe/pipelib.py
@@ -118,7 +118,7 @@ class CloudPipe(object):
         key_name = self.setup_key_pair(context)
         group_name = self.setup_security_group(context)
         flavor = flavors.get_flavor_by_name(CONF.vpn_flavor)
-        instance_name = '%s%s' % (context.project_id, CONF.vpn_key_suffix)
+        instance_name = '{0!s}{1!s}'.format(context.project_id, CONF.vpn_key_suffix)
         user_data = self.get_encoded_zip(context.project_id)
         return self.compute_api.create(context,
                                        flavor,
@@ -129,7 +129,7 @@ class CloudPipe(object):
                                        security_group=[group_name])
 
     def setup_security_group(self, context):
-        group_name = '%s%s' % (context.project_id, CONF.vpn_key_suffix)
+        group_name = '{0!s}{1!s}'.format(context.project_id, CONF.vpn_key_suffix)
         group = {'user_id': context.user_id,
                  'project_id': context.project_id,
                  'name': group_name,
@@ -155,7 +155,7 @@ class CloudPipe(object):
         return group_name
 
     def setup_key_pair(self, context):
-        key_name = '%s%s' % (context.project_id, CONF.vpn_key_suffix)
+        key_name = '{0!s}{1!s}'.format(context.project_id, CONF.vpn_key_suffix)
         try:
             keypair_api = compute.api.KeypairAPI()
             result, private_key = keypair_api.create_key_pair(context,
@@ -163,7 +163,7 @@ class CloudPipe(object):
                                                               key_name)
             key_dir = os.path.join(CONF.keys_path, context.user_id)
             fileutils.ensure_tree(key_dir)
-            key_path = os.path.join(key_dir, '%s.pem' % key_name)
+            key_path = os.path.join(key_dir, '{0!s}.pem'.format(key_name))
             with open(key_path, 'w') as f:
                 f.write(private_key)
         except (exception.KeyPairExists, os.error, IOError):

--- a/nova/cmd/baseproxy.py
+++ b/nova/cmd/baseproxy.py
@@ -46,11 +46,11 @@ def exit_with_error(msg, errno=-1):
 def proxy(host, port):
 
     if CONF.ssl_only and not os.path.exists(CONF.cert):
-        exit_with_error("SSL only and %s not found" % CONF.cert)
+        exit_with_error("SSL only and {0!s} not found".format(CONF.cert))
 
     # Check to see if tty html/js/css files are present
     if CONF.web and not os.path.exists(CONF.web):
-        exit_with_error("Can not find html/js files at %s." % CONF.web)
+        exit_with_error("Can not find html/js files at {0!s}.".format(CONF.web))
 
     logging.setup(CONF, "nova")
 

--- a/nova/cmd/idmapshift.py
+++ b/nova/cmd/idmapshift.py
@@ -101,7 +101,7 @@ def find_target_id(fsid, mappings, nobody, memo):
 
 
 def print_chown(path, uid, gid, target_uid, target_gid):
-    print('%s %s:%s -> %s:%s' % (path, uid, gid, target_uid, target_gid))
+    print('{0!s} {1!s}:{2!s} -> {3!s}:{4!s}'.format(path, uid, gid, target_uid, target_gid))
 
 
 def shift_path(path, uid_mappings, gid_mappings, nobody, uid_memo, gid_memo,
@@ -195,7 +195,7 @@ def id_map_type(val):
         try:
             vals = [int(i) for i in map_vals]
         except ValueError:
-            msg = 'Invalid id map %s, values must be integers' % val
+            msg = 'Invalid id map {0!s}, values must be integers'.format(val)
             raise argparse.ArgumentTypeError(msg)
 
         id_maps.append(tuple(vals))

--- a/nova/cmd/manage.py
+++ b/nova/cmd/manage.py
@@ -346,7 +346,7 @@ class FixedIpCommands(object):
         for instance in instances:
             instances_by_uuid[instance['uuid']] = instance
 
-        print("%-18s\t%-15s\t%-15s\t%s" % (_('network'),
+        print("{0:<18!s}\t{1:<15!s}\t{2:<15!s}\t{3!s}".format(_('network'),
                                               _('IP address'),
                                               _('hostname'),
                                               _('host')))
@@ -379,7 +379,7 @@ class FixedIpCommands(object):
                     else:
                         print(_('WARNING: fixed IP %s allocated to missing'
                                 ' instance') % str(fixed_ip['address']))
-                print("%-18s\t%-15s\t%-15s\t%s" % (
+                print("{0:<18!s}\t{1:<15!s}\t{2:<15!s}\t{3!s}".format(
                         network['cidr'],
                         fixed_ip['address'],
                         hostname, host))
@@ -465,7 +465,7 @@ class FloatingIpCommands(object):
             # NOTE(simplylizz): Maybe logging would be better here
             # instead of printing, but logging isn't used here and I
             # don't know why.
-            print('error: %s' % exc)
+            print('error: {0!s}'.format(exc))
             return(1)
 
     @args('--ip_range', metavar='<range>', help='IP range')
@@ -498,7 +498,7 @@ class FloatingIpCommands(object):
                 fixed_ip = db.fixed_ip_get(ctxt, floating_ip['fixed_ip_id'])
                 instance_uuid = fixed_ip['instance_uuid']
 
-            print("%s\t%s\t%s\t%s\t%s" % (floating_ip['project_id'],
+            print("{0!s}\t{1!s}\t{2!s}\t{3!s}\t{4!s}".format(floating_ip['project_id'],
                                           floating_ip['address'],
                                           instance_uuid,
                                           floating_ip['pool'],
@@ -855,22 +855,22 @@ class ServiceCommands(object):
         else:
             # Printing a total and used_now
             # (NOTE)The host name width 16 characters
-            print('%(a)-25s%(b)16s%(c)8s%(d)8s%(e)8s' % {"a": _('HOST'),
+            print('{a:<25!s}{b:16!s}{c:8!s}{d:8!s}{e:8!s}'.format(**{"a": _('HOST'),
                                                          "b": _('PROJECT'),
                                                          "c": _('cpu'),
                                                          "d": _('mem(mb)'),
-                                                         "e": _('hdd')})
-            print(('%(a)-16s(total)%(b)26s%(c)8s%(d)8s' %
+                                                         "e": _('hdd')}))
+            print(('{a:<16!s}(total){b:26!s}{c:8!s}{d:8!s}'.format(**
                    {"a": host,
                     "b": result['resource']['vcpus'],
                     "c": result['resource']['memory_mb'],
-                    "d": result['resource']['local_gb']}))
+                    "d": result['resource']['local_gb']})))
 
-            print(('%(a)-16s(used_now)%(b)23s%(c)8s%(d)8s' %
+            print(('{a:<16!s}(used_now){b:23!s}{c:8!s}{d:8!s}'.format(**
                    {"a": host,
                     "b": result['resource']['vcpus_used'],
                     "c": result['resource']['memory_mb_used'],
-                    "d": result['resource']['local_gb_used']}))
+                    "d": result['resource']['local_gb_used']})))
 
             # Printing a used_max
             cpu_sum = 0
@@ -881,18 +881,18 @@ class ServiceCommands(object):
                 mem_sum += val['memory_mb']
                 hdd_sum += val['root_gb']
                 hdd_sum += val['ephemeral_gb']
-            print('%(a)-16s(used_max)%(b)23s%(c)8s%(d)8s' % {"a": host,
+            print('{a:<16!s}(used_max){b:23!s}{c:8!s}{d:8!s}'.format(**{"a": host,
                                                              "b": cpu_sum,
                                                              "c": mem_sum,
-                                                             "d": hdd_sum})
+                                                             "d": hdd_sum}))
 
             for p_id, val in result['usage'].items():
-                print('%(a)-25s%(b)16s%(c)8s%(d)8s%(e)8s' % {
+                print('{a:<25!s}{b:16!s}{c:8!s}{d:8!s}{e:8!s}'.format(**{
                         "a": host,
                         "b": p_id,
                         "c": val['vcpus'],
                         "d": val['memory_mb'],
-                        "e": val['root_gb'] + val['ephemeral_gb']})
+                        "e": val['root_gb'] + val['ephemeral_gb']}))
 
 
 class HostCommands(object):
@@ -902,7 +902,7 @@ class HostCommands(object):
         """Show a list of all physical hosts. Filter by zone.
         args: [zone]
         """
-        print("%-25s\t%-15s" % (_('host'),
+        print("{0:<25!s}\t{1:<15!s}".format(_('host'),
                                 _('zone')))
         ctxt = context.get_admin_context()
         services = db.service_get_all(ctxt)
@@ -915,7 +915,7 @@ class HostCommands(object):
                 hosts.append(srv)
 
         for h in hosts:
-            print("%-25s\t%-15s" % (h['host'], h['availability_zone']))
+            print("{0:<25!s}\t{1:<15!s}".format(h['host'], h['availability_zone']))
 
 
 class DbCommands(object):
@@ -1115,7 +1115,7 @@ class AgentBuildCommands(object):
             for agent_build in buildlist:
                 print(fmt % (agent_build.os, agent_build.architecture,
                              agent_build.version, agent_build.md5hash))
-                print('    %s' % agent_build.url)
+                print('    {0!s}'.format(agent_build.url))
 
             print()
 
@@ -1184,7 +1184,7 @@ class GetLogCommands(object):
         for line in lines:
             if line.find("nova") > 0:
                 count += 1
-                print("%s" % (line))
+                print("{0!s}".format((line)))
             if count == entries:
                 break
 
@@ -1350,7 +1350,7 @@ class CellV2Commands(object):
                 mapping.create()
             except db_exc.DBDuplicateEntry:
                 if verbose:
-                    print("%s already mapped to cell" % instance.uuid)
+                    print("{0!s} already mapped to cell".format(instance.uuid))
                 continue
             mapped += 1
 
@@ -1358,7 +1358,7 @@ class CellV2Commands(object):
         print(fmt % (mapped, cell_mapping.uuid))
         if instances:
             instance = instances[-1]
-            print('Next marker: - %s' % instance.uuid)
+            print('Next marker: - {0!s}'.format(instance.uuid))
 
     # TODO(melwitt): Remove this when the oslo.messaging function
     # for assembling a transport url from ConfigOpts is available
@@ -1521,7 +1521,7 @@ def main():
             st = os.stat(cfgfile)
             print(_("Could not read %s. Re-running with sudo") % cfgfile)
             try:
-                os.execvp('sudo', ['sudo', '-u', '#%s' % st.st_uid] + sys.argv)
+                os.execvp('sudo', ['sudo', '-u', '#{0!s}'.format(st.st_uid)] + sys.argv)
             except OSError:
                 print(_('sudo failed, continuing as if nothing happened'))
 

--- a/nova/compute/api.py
+++ b/nova/compute/api.py
@@ -177,7 +177,7 @@ wrap_check_security_groups_policy = policy_decorator(
 
 
 def check_policy(context, action, target, scope='compute'):
-    _action = '%s:%s' % (scope, action)
+    _action = '{0!s}:{1!s}'.format(scope, action)
     nova.policy.enforce(context, _action, target)
 
 
@@ -354,7 +354,7 @@ class API(base.Base):
                        allowed)
 
             num_instances = (str(min_count) if min_count == max_count else
-                "%s-%s" % (min_count, max_count))
+                "{0!s}-{1!s}".format(min_count, max_count))
             requested = dict(instances=num_instances, cores=req_cores,
                              ram=req_ram)
             (overs, reqs, total_alloweds, useds) = self._get_over_quota_detail(
@@ -1384,10 +1384,10 @@ class API(base.Base):
                                                         default_hostname)
 
     def _default_display_name(self, instance_uuid):
-        return "Server %s" % instance_uuid
+        return "Server {0!s}".format(instance_uuid)
 
     def _default_host_name(self, instance_uuid):
-        return "Server-%s" % instance_uuid
+        return "Server-{0!s}".format(instance_uuid)
 
     def _populate_instance_for_create(self, context, instance, image,
                                       index, security_groups, instance_type):
@@ -1652,11 +1652,11 @@ class API(base.Base):
                 try:
                     compute_utils.notify_about_instance_usage(
                             self.notifier, context, instance,
-                            "%s.start" % delete_type)
+                            "{0!s}.start".format(delete_type))
                     instance.destroy()
                     compute_utils.notify_about_instance_usage(
                             self.notifier, context, instance,
-                            "%s.end" % delete_type,
+                            "{0!s}.end".format(delete_type),
                             system_metadata=instance.system_metadata)
                     quotas.commit()
                     return
@@ -1822,7 +1822,7 @@ class API(base.Base):
             LOG.warning(_LW("instance's host %s is down, deleting from "
                             "database"), instance.host, instance=instance)
         compute_utils.notify_about_instance_usage(
-            self.notifier, context, instance, "%s.start" % delete_type)
+            self.notifier, context, instance, "{0!s}.start".format(delete_type))
 
         elevated = context.elevated()
         if self.cell_type != 'api':
@@ -1851,7 +1851,7 @@ class API(base.Base):
         sys_meta = instance.system_metadata
         instance.destroy()
         compute_utils.notify_about_instance_usage(
-            self.notifier, context, instance, "%s.end" % delete_type,
+            self.notifier, context, instance, "{0!s}.end".format(delete_type),
             system_metadata=sys_meta)
 
     def _do_delete(self, context, instance, bdms, reservations=None,
@@ -2077,7 +2077,7 @@ class API(base.Base):
         def _remap_fixed_ip_filter(fixed_ip):
             # Turn fixed_ip into a regexp match. Since '.' matches
             # any character, we need to use regexp escaping for it.
-            filters['ip'] = '^%s$' % fixed_ip.replace('.', '\\.')
+            filters['ip'] = '^{0!s}$'.format(fixed_ip.replace('.', '\\.'))
 
         def _remap_metadata_filter(metadata):
             filters['metadata'] = jsonutils.loads(metadata)
@@ -2722,7 +2722,7 @@ class API(base.Base):
         self._record_action_start(context, instance, instance_actions.SHELVE)
 
         if not self.is_volume_backed_instance(context, instance):
-            name = '%s-shelved' % instance.display_name
+            name = '{0!s}-shelved'.format(instance.display_name)
             image_meta = self._create_image(context, instance, name,
                     'snapshot')
             image_id = image_meta['id']
@@ -3278,7 +3278,7 @@ class API(base.Base):
                                                    sort_dirs=['desc'])
         for instance in instances:
             try:
-                check_policy(context, 'get_all_instance_%s' % metadata_type,
+                check_policy(context, 'get_all_instance_{0!s}'.format(metadata_type),
                              instance)
             except exception.PolicyNotAuthorized:
                 # failed policy check - not allowed to
@@ -3968,7 +3968,7 @@ class KeypairAPI(base.Base):
             'key_name': keypair_name,
         }
         notify = self.get_notifier()
-        notify.info(context, 'keypair.%s' % event_suffix, payload)
+        notify.info(context, 'keypair.{0!s}'.format(event_suffix), payload)
 
     def _validate_new_key_pair(self, context, user_id, key_name, key_type):
         safe_chars = "_- " + string.digits + string.ascii_letters

--- a/nova/compute/cells_api.py
+++ b/nova/compute/cells_api.py
@@ -104,7 +104,7 @@ class RPCClientCellsProxy(object):
         version = kwargs.pop('version', None)
 
         if kwargs:
-            raise ValueError("Unsupported kwargs: %s" % kwargs.keys())
+            raise ValueError("Unsupported kwargs: {0!s}".format(kwargs.keys()))
 
         if server:
             ret._server = server
@@ -131,7 +131,7 @@ class RPCClientCellsProxy(object):
 
     def _get_topic(self):
         if self._server is not None:
-            return '%s.%s' % (self.target.topic, self._server)
+            return '{0!s}.{1!s}'.format(self.target.topic, self._server)
         else:
             return self.target.topic
 

--- a/nova/compute/claims.py
+++ b/nova/compute/claims.py
@@ -60,7 +60,7 @@ class NopClaim(object):
         pass
 
     def __str__(self):
-        return "[Claim: %d MB memory, %d GB disk]" % (self.memory_mb,
+        return "[Claim: {0:d} MB memory, {1:d} GB disk]".format(self.memory_mb,
                 self.disk_gb)
 
 

--- a/nova/compute/flavors.py
+++ b/nova/compute/flavors.py
@@ -254,7 +254,7 @@ def extract_flavor(instance, prefix=''):
         return None
 
     for key in system_metadata_flavor_props.keys():
-        type_key = '%sinstance_type_%s' % (prefix, key)
+        type_key = '{0!s}instance_type_{1!s}'.format(prefix, key)
         setattr(flavor, key, sys_meta[type_key])
 
     # NOTE(danms): We do NOT save all of extra_specs, but only the
@@ -262,11 +262,11 @@ def extract_flavor(instance, prefix=''):
     # should be replaced by a general split-out of flavor information from
     # system_metadata very soon.
     extra_specs = [(k, v) for k, v in sys_meta.items()
-                   if k.startswith('%sinstance_type_extra_' % prefix)]
+                   if k.startswith('{0!s}instance_type_extra_'.format(prefix))]
     if extra_specs:
         flavor.extra_specs = {}
         for key, value in extra_specs:
-            extra_key = key[len('%sinstance_type_extra_' % prefix):]
+            extra_key = key[len('{0!s}instance_type_extra_'.format(prefix)):]
             flavor.extra_specs[extra_key] = value
 
     return flavor
@@ -287,7 +287,7 @@ def save_flavor_info(metadata, instance_type, prefix=''):
     """
 
     for key in system_metadata_flavor_props.keys():
-        to_key = '%sinstance_type_%s' % (prefix, key)
+        to_key = '{0!s}instance_type_{1!s}'.format(prefix, key)
         metadata[to_key] = instance_type[key]
 
     # NOTE(danms): We do NOT save all of extra_specs here, but only the
@@ -298,7 +298,7 @@ def save_flavor_info(metadata, instance_type, prefix=''):
     for extra_prefix in system_metadata_flavor_extra_props:
         for key in extra_specs:
             if key.startswith(extra_prefix):
-                to_key = '%sinstance_type_extra_%s' % (prefix, key)
+                to_key = '{0!s}instance_type_extra_{1!s}'.format(prefix, key)
                 metadata[to_key] = extra_specs[key]
 
     return metadata
@@ -313,7 +313,7 @@ def delete_flavor_info(metadata, *prefixes):
 
     for key in system_metadata_flavor_props.keys():
         for prefix in prefixes:
-            to_key = '%sinstance_type_%s' % (prefix, key)
+            to_key = '{0!s}instance_type_{1!s}'.format(prefix, key)
             del metadata[to_key]
 
     # NOTE(danms): We do NOT save all of extra_specs, but only the
@@ -322,7 +322,7 @@ def delete_flavor_info(metadata, *prefixes):
     # system_metadata very soon.
     for key in list(metadata.keys()):
         for prefix in prefixes:
-            if key.startswith('%sinstance_type_extra_' % prefix):
+            if key.startswith('{0!s}instance_type_extra_'.format(prefix)):
                 del metadata[key]
 
     return metadata

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -482,7 +482,7 @@ class InstanceEvents(object):
 
     @staticmethod
     def _lock_name(instance):
-        return '%s-%s' % (instance.uuid, 'events')
+        return '{0!s}-{1!s}'.format(instance.uuid, 'events')
 
     def prepare_for_instance_event(self, instance, event_name):
         """Prepare to receive an event for an instance.
@@ -1352,7 +1352,7 @@ class ComputeManager(manager.Manager):
 
         """
         # TODO(mdragon): perhaps make this variable by console_type?
-        return '%s.%s' % (CONF.console_topic, CONF.console_host)
+        return '{0!s}.{1!s}'.format(CONF.console_topic, CONF.console_host)
 
     @wrap_exception()
     def get_console_pool_info(self, context, console_type):
@@ -4497,9 +4497,9 @@ class ComputeManager(manager.Manager):
         if console_type == 'novnc':
             # For essex, novncproxy_base_url must include the full path
             # including the html file (like http://myhost/vnc_auto.html)
-            access_url = '%s?token=%s' % (CONF.vnc.novncproxy_base_url, token)
+            access_url = '{0!s}?token={1!s}'.format(CONF.vnc.novncproxy_base_url, token)
         elif console_type == 'xvpvnc':
-            access_url = '%s?token=%s' % (CONF.vnc.xvpvncproxy_base_url, token)
+            access_url = '{0!s}?token={1!s}'.format(CONF.vnc.xvpvncproxy_base_url, token)
         else:
             raise exception.ConsoleTypeInvalid(console_type=console_type)
 
@@ -4534,7 +4534,7 @@ class ComputeManager(manager.Manager):
         if console_type == 'spice-html5':
             # For essex, spicehtml5proxy_base_url must include the full path
             # including the html file (like http://myhost/spice_auto.html)
-            access_url = '%s?token=%s' % (CONF.spice.html5proxy_base_url,
+            access_url = '{0!s}?token={1!s}'.format(CONF.spice.html5proxy_base_url,
                                           token)
         else:
             raise exception.ConsoleTypeInvalid(console_type=console_type)
@@ -4568,7 +4568,7 @@ class ComputeManager(manager.Manager):
             raise exception.ConsoleTypeUnavailable(console_type=console_type)
 
         if console_type == 'rdp-html5':
-            access_url = '%s?token=%s' % (CONF.rdp.html5_proxy_base_url,
+            access_url = '{0!s}?token={1!s}'.format(CONF.rdp.html5_proxy_base_url,
                                           token)
         else:
             raise exception.ConsoleTypeInvalid(console_type=console_type)
@@ -4602,7 +4602,7 @@ class ComputeManager(manager.Manager):
             raise exception.ConsoleTypeUnavailable(console_type=console_type)
 
         if console_type == 'webmks':
-            access_url = '%s?token=%s' % (CONF.mks.mksproxy_base_url,
+            access_url = '{0!s}?token={1!s}'.format(CONF.mks.mksproxy_base_url,
                                           token)
         else:
             raise exception.ConsoleTypeInvalid(console_type=console_type)
@@ -4641,7 +4641,7 @@ class ComputeManager(manager.Manager):
         context = context.elevated()
 
         token = str(uuid.uuid4())
-        access_url = '%s?token=%s' % (CONF.serial_console.base_url, token)
+        access_url = '{0!s}?token={1!s}'.format(CONF.serial_console.base_url, token)
 
         try:
             # Retrieve connect info from driver, and then decorate with our
@@ -5219,7 +5219,7 @@ class ComputeManager(manager.Manager):
                                        network_info,
                                        disk,
                                        migrate_data)
-        LOG.debug('driver pre_live_migration data is %s' % migrate_data)
+        LOG.debug('driver pre_live_migration data is {0!s}'.format(migrate_data))
 
         # NOTE(tr3buchet): setup networks on destination host
         self.network_api.setup_networks_on_host(context, instance,
@@ -6014,8 +6014,7 @@ class ComputeManager(manager.Manager):
                 errors += 1
         task_log.errors = errors
         task_log.message = (
-            'Instance usage audit ran for host %s, %s instances in %s seconds.'
-            % (self.host, num_instances, time.time() - start_time))
+            'Instance usage audit ran for host {0!s}, {1!s} instances in {2!s} seconds.'.format(self.host, num_instances, time.time() - start_time))
         task_log.end_task()
 
     @periodic_task.periodic_task(spacing=CONF.bandwidth_poll_interval)
@@ -6207,9 +6206,9 @@ class ComputeManager(manager.Manager):
             # block entire periodic task thread
             uuid = db_instance.uuid
             if uuid in self._syncs_in_progress:
-                LOG.debug('Sync already in progress for %s' % uuid)
+                LOG.debug('Sync already in progress for {0!s}'.format(uuid))
             else:
-                LOG.debug('Triggering sync for uuid %s' % uuid)
+                LOG.debug('Triggering sync for uuid {0!s}'.format(uuid))
                 self._syncs_in_progress[uuid] = True
                 self._sync_power_pool.spawn_n(_sync, db_instance)
 

--- a/nova/compute/resource_tracker.py
+++ b/nova/compute/resource_tracker.py
@@ -912,7 +912,7 @@ class ResourceTracker(object):
         """Get the instance type from instance."""
         stashed_flavors = migration.migration_type in ('resize',)
         if stashed_flavors:
-            return getattr(instance, '%sflavor' % prefix)
+            return getattr(instance, '{0!s}flavor'.format(prefix))
         else:
             # NOTE(ndipanov): Certain migration types (all but resize)
             # do not change flavors so there is no need to stash

--- a/nova/compute/stats.py
+++ b/nova/compute/stats.py
@@ -46,7 +46,7 @@ class Stats(dict):
         """Calculate an I/O based load by counting I/O heavy operations."""
 
         def _get(state, state_type):
-            key = "num_%s_%s" % (state_type, state)
+            key = "num_{0!s}_{1!s}".format(state_type, state)
             return self.get(key, 0)
 
         num_builds = _get(vm_states.BUILDING, "vm")
@@ -76,11 +76,11 @@ class Stats(dict):
         return self.get("num_instances", 0)
 
     def num_instances_for_project(self, project_id):
-        key = "num_proj_%s" % project_id
+        key = "num_proj_{0!s}".format(project_id)
         return self.get(key, 0)
 
     def num_os_type(self, os_type):
-        key = "num_os_type_%s" % os_type
+        key = "num_os_type_{0!s}".format(os_type)
         return self.get(key, 0)
 
     def update_stats_for_instance(self, instance, is_removed=False):
@@ -93,10 +93,10 @@ class Stats(dict):
         if uuid in self.states:
             old_state = self.states[uuid]
 
-            self._decrement("num_vm_%s" % old_state['vm_state'])
-            self._decrement("num_task_%s" % old_state['task_state'])
-            self._decrement("num_os_type_%s" % old_state['os_type'])
-            self._decrement("num_proj_%s" % old_state['project_id'])
+            self._decrement("num_vm_{0!s}".format(old_state['vm_state']))
+            self._decrement("num_task_{0!s}".format(old_state['task_state']))
+            self._decrement("num_os_type_{0!s}".format(old_state['os_type']))
+            self._decrement("num_proj_{0!s}".format(old_state['project_id']))
         else:
             # new instance
             self._increment("num_instances")
@@ -109,10 +109,10 @@ class Stats(dict):
             self._decrement("num_instances")
             self.states.pop(uuid)
         else:
-            self._increment("num_vm_%s" % vm_state)
-            self._increment("num_task_%s" % task_state)
-            self._increment("num_os_type_%s" % os_type)
-            self._increment("num_proj_%s" % project_id)
+            self._increment("num_vm_{0!s}".format(vm_state))
+            self._increment("num_task_{0!s}".format(task_state))
+            self._increment("num_os_type_{0!s}".format(os_type))
+            self._increment("num_proj_{0!s}".format(project_id))
 
         # save updated I/O workload in stats:
         self["io_workload"] = self.io_workload

--- a/nova/compute/utils.py
+++ b/nova/compute/utils.py
@@ -289,7 +289,7 @@ def notify_about_instance_usage(notifier, context, instance, event_suffix,
     else:
         method = notifier.info
 
-    method(context, 'compute.instance.%s' % event_suffix, usage_info)
+    method(context, 'compute.instance.{0!s}'.format(event_suffix), usage_info)
 
 
 def notify_about_server_group_update(context, event_suffix, sg_payload):
@@ -300,7 +300,7 @@ def notify_about_server_group_update(context, event_suffix, sg_payload):
     """
     notifier = rpc.get_notifier(service='servergroup')
 
-    notifier.info(context, 'servergroup.%s' % event_suffix, sg_payload)
+    notifier.info(context, 'servergroup.{0!s}'.format(event_suffix), sg_payload)
 
 
 def notify_about_aggregate_update(context, event_suffix, aggregate_payload):
@@ -320,7 +320,7 @@ def notify_about_aggregate_update(context, event_suffix, aggregate_payload):
     notifier = rpc.get_notifier(service='aggregate',
                                 host=aggregate_identifier)
 
-    notifier.info(context, 'aggregate.%s' % event_suffix, aggregate_payload)
+    notifier.info(context, 'aggregate.{0!s}'.format(event_suffix), aggregate_payload)
 
 
 def notify_about_host_update(context, event_suffix, host_payload):
@@ -339,7 +339,7 @@ def notify_about_host_update(context, event_suffix, host_payload):
 
     notifier = rpc.get_notifier(service='api', host=host_identifier)
 
-    notifier.info(context, 'HostAPI.%s' % event_suffix, host_payload)
+    notifier.info(context, 'HostAPI.{0!s}'.format(event_suffix), host_payload)
 
 
 def get_nw_info_for_instance(instance):

--- a/nova/conductor/manager.py
+++ b/nova/conductor/manager.py
@@ -126,7 +126,7 @@ class ConductorManager(manager.Manager):
                   {'obj': objinst.obj_name(),
                    'ver': target,
                    'manifest': ','.join(
-                       ['%s=%s' % (name, ver)
+                       ['{0!s}={1!s}'.format(name, ver)
                        for name, ver in object_versions.items()])})
         return objinst.obj_to_primitive(target_version=target,
                                         version_manifest=object_versions)

--- a/nova/console/websocketproxy.py
+++ b/nova/console/websocketproxy.py
@@ -143,8 +143,8 @@ class NovaProxyRequestHandlerBase(object):
 
         # Handshake as necessary
         if connect_info.get('internal_access_path'):
-            tsock.send("CONNECT %s HTTP/1.1\r\n\r\n" %
-                        connect_info['internal_access_path'])
+            tsock.send("CONNECT {0!s} HTTP/1.1\r\n\r\n".format(
+                        connect_info['internal_access_path']))
             while True:
                 data = tsock.recv(4096, socket.MSG_PEEK)
                 if data.find("\r\n\r\n") != -1:

--- a/nova/context.py
+++ b/nova/context.py
@@ -218,7 +218,7 @@ class RequestContext(context.RequestContext):
         return context
 
     def __str__(self):
-        return "<Context %s>" % self.to_dict()
+        return "<Context {0!s}>".format(self.to_dict())
 
 
 def get_admin_context(read_deleted="no"):

--- a/nova/crypto.py
+++ b/nova/crypto.py
@@ -186,7 +186,7 @@ def generate_key_pair(bits=2048):
     keyout = six.StringIO()
     key.write_private_key(keyout)
     private_key = keyout.getvalue()
-    public_key = '%s %s Generated-by-Nova' % (key.get_name(), key.get_base64())
+    public_key = '{0!s} {1!s} Generated-by-Nova'.format(key.get_name(), key.get_base64())
     fingerprint = generate_fingerprint(public_key)
     return (private_key, public_key, fingerprint)
 
@@ -296,7 +296,7 @@ def generate_x509_cert(user_id, project_id, bits=2048):
             csr = f.read()
 
     (serial, signed_csr) = sign_csr(csr, project_id)
-    fname = os.path.join(ca_folder(project_id), 'newcerts/%s.pem' % serial)
+    fname = os.path.join(ca_folder(project_id), 'newcerts/{0!s}.pem'.format(serial))
     cert = {'user_id': user_id,
             'project_id': project_id,
             'file_name': fname}
@@ -306,8 +306,8 @@ def generate_x509_cert(user_id, project_id, bits=2048):
 
 def generate_winrm_x509_cert(user_id, bits=2048):
     """Generate a cert for passwordless auth for user in project."""
-    subject = '/CN=%s' % user_id
-    upn = '%s@localhost' % user_id
+    subject = '/CN={0!s}'.format(user_id)
+    upn = '{0!s}@localhost'.format(user_id)
 
     with utils.tempdir() as tmpdir:
         keyfile = os.path.abspath(os.path.join(tmpdir, 'temp.key'))
@@ -317,7 +317,7 @@ def generate_winrm_x509_cert(user_id, bits=2048):
 
         (certificate, _err) = utils.execute(
              'openssl', 'req', '-x509', '-nodes', '-days', '3650',
-             '-config', conffile, '-newkey', 'rsa:%s' % bits,
+             '-config', conffile, '-newkey', 'rsa:{0!s}'.format(bits),
              '-outform', 'PEM', '-keyout', keyfile, '-subj', subject,
              '-extensions', 'v3_req_client',
              binary=True)

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -847,7 +847,7 @@ def compute_node_get_all(context):
 def compute_node_search_by_hypervisor(context, hypervisor_match):
     field = models.ComputeNode.hypervisor_hostname
     return model_query(context, models.ComputeNode).\
-            filter(field.like('%%%s%%' % hypervisor_match)).\
+            filter(field.like('%{0!s}%'.format(hypervisor_match))).\
             all()
 
 
@@ -2756,7 +2756,7 @@ def _instance_update(context, instance_uuid, values, expected, original=None):
     # Extract 'expected_' values from values dict, as these aren't actually
     # updates
     for field in ('task_state', 'vm_state'):
-        expected_field = 'expected_%s' % field
+        expected_field = 'expected_{0!s}'.format(field)
         if expected_field in values:
             value = values.pop(expected_field, None)
             # Coerce all single values to singleton lists

--- a/nova/db/sqlalchemy/migrate_repo/versions/216_havana.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/216_havana.py
@@ -1569,8 +1569,8 @@ def upgrade(migrate_engine):
             'ALTER TABLE migrate_version CONVERT TO CHARACTER SET utf8')
         # Set default DB charset to UTF8.
         migrate_engine.execute(
-            'ALTER DATABASE %s DEFAULT CHARACTER SET utf8' %
-            migrate_engine.url.database)
+            'ALTER DATABASE {0!s} DEFAULT CHARACTER SET utf8'.format(
+            migrate_engine.url.database))
 
     _create_shadow_tables(migrate_engine)
 

--- a/nova/db/sqlalchemy/migrate_repo/versions/277_add_fixed_ip_updated_index.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/277_add_fixed_ip_updated_index.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
 
 
 INDEX_COLUMNS = ['deleted', 'allocated', 'updated_at']
-INDEX_NAME = 'fixed_ips_%s_idx' % ('_'.join(INDEX_COLUMNS),)
+INDEX_NAME = 'fixed_ips_{0!s}_idx'.format('_'.join(INDEX_COLUMNS))
 
 
 def _get_table_index(migrate_engine):

--- a/nova/db/sqlalchemy/migrate_repo/versions/314_add_resource_provider_tables.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/314_add_resource_provider_tables.py
@@ -80,5 +80,5 @@ def upgrade(migrate_engine):
 
     for table_name in ('', 'shadow_'):
         uuid_column = Column('uuid', String(36))
-        compute_nodes = Table('%scompute_nodes' % table_name, meta)
+        compute_nodes = Table('{0!s}compute_nodes'.format(table_name), meta)
         compute_nodes.create_column(uuid_column)

--- a/nova/db/sqlalchemy/migrate_repo/versions/317_add_aggregate_uuid.py
+++ b/nova/db/sqlalchemy/migrate_repo/versions/317_add_aggregate_uuid.py
@@ -24,7 +24,7 @@ def upgrade(migrate_engine):
 
     for table_prefix in ('', 'shadow_'):
         uuid_column = Column('uuid', String(36))
-        aggregates = Table('%saggregates' % table_prefix, meta)
+        aggregates = Table('{0!s}aggregates'.format(table_prefix), meta)
         if not hasattr(aggregates.c, 'uuid'):
             aggregates.create_column(uuid_column)
             if not table_prefix:

--- a/nova/db/sqlalchemy/utils.py
+++ b/nova/db/sqlalchemy/utils.py
@@ -42,7 +42,7 @@ class DeleteFromSelect(UpdateBase):
 # 'LIMIT & IN/ALL/ANY/SOME' We need work around this with nesting select .
 @compiles(DeleteFromSelect)
 def visit_delete_from_select(element, compiler, **kw):
-    return "DELETE FROM %s WHERE %s in (SELECT T1.%s FROM (%s) as T1)" % (
+    return "DELETE FROM {0!s} WHERE {1!s} in (SELECT T1.{2!s} FROM ({3!s}) as T1)".format(
         compiler.process(element.table, asfrom=True),
         compiler.process(element.column),
         element.column.name,

--- a/nova/exception.py
+++ b/nova/exception.py
@@ -145,7 +145,7 @@ class NovaException(Exception):
                 # log the issue and the kwargs
                 LOG.exception(_LE('Exception in string format operation'))
                 for name, value in six.iteritems(kwargs):
-                    LOG.error("%s: %s" % (name, value))    # noqa
+                    LOG.error("{0!s}: {1!s}".format(name, value))    # noqa
 
                 if CONF.fatal_exception_format_errors:
                     six.reraise(*exc_info)

--- a/nova/hacking/checks.py
+++ b/nova/hacking/checks.py
@@ -178,7 +178,7 @@ def use_timeutils_utcnow(logical_line, filename):
 
     datetime_funcs = ['now', 'utcnow']
     for f in datetime_funcs:
-        pos = logical_line.find('datetime.%s' % f)
+        pos = logical_line.find('datetime.{0!s}'.format(f))
         if pos != -1:
             yield (pos, msg % f)
 
@@ -396,7 +396,7 @@ def use_jsonutils(logical_line, filename):
     if "json." in logical_line:
         json_funcs = ['dumps(', 'dump(', 'loads(', 'load(']
         for f in json_funcs:
-            pos = logical_line.find('json.%s' % f)
+            pos = logical_line.find('json.{0!s}'.format(f))
             if pos != -1:
                 yield (pos, msg % {'fun': f[:-1]})
 

--- a/nova/image/glance.py
+++ b/nova/image/glance.py
@@ -58,7 +58,7 @@ def generate_glance_url():
 
 def generate_image_url(image_ref):
     """Generate an image URL from an image_ref."""
-    return "%s/images/%s" % (generate_glance_url(), image_ref)
+    return "{0!s}/images/{1!s}".format(generate_glance_url(), image_ref)
 
 
 def _endpoint_from_image_ref(image_href):

--- a/nova/image/s3.py
+++ b/nova/image/s3.py
@@ -179,7 +179,7 @@ class S3ImageService(object):
         #             checked in nova-objectstore
         access = CONF.s3_access_key
         if CONF.s3_affix_tenant:
-            access = '%s:%s' % (access, context.project_id)
+            access = '{0!s}:{1!s}'.format(access, context.project_id)
         secret = CONF.s3_secret_key
         calling = boto.s3.connection.OrdinaryCallingFormat()
         return boto.s3.connection.S3Connection(aws_access_key_id=access,
@@ -411,10 +411,10 @@ class S3ImageService(object):
         try:
             utils.execute('openssl', 'enc',
                           '-d', '-aes-128-cbc',
-                          '-in', '%s' % (encrypted_filename,),
-                          '-K', '%s' % (key,),
-                          '-iv', '%s' % (iv,),
-                          '-out', '%s' % (decrypted_filename,))
+                          '-in', '{0!s}'.format(encrypted_filename),
+                          '-K', '{0!s}'.format(key),
+                          '-iv', '{0!s}'.format(iv),
+                          '-out', '{0!s}'.format(decrypted_filename))
         except processutils.ProcessExecutionError as exc:
             raise exception.NovaException(_('Failed to decrypt image file '
                                     '%(image_file)s: %(err)s') %

--- a/nova/ipv6/account_identifier.py
+++ b/nova/ipv6/account_identifier.py
@@ -31,7 +31,7 @@ def to_global(prefix, mac, project_id):
 
     try:
         mac_suffix = netaddr.EUI(mac).words[3:]
-        int_addr = int(''.join(['%02x' % i for i in mac_suffix]), 16)
+        int_addr = int(''.join(['{0:02x}'.format(i) for i in mac_suffix]), 16)
         mac_addr = netaddr.IPAddress(int_addr)
         maskIP = netaddr.IPNetwork(prefix).ip
         return (project_hash ^ static_num ^ mac_addr | maskIP).format()
@@ -48,4 +48,4 @@ def to_mac(ipv6_address):
     address = netaddr.IPAddress(ipv6_address)
     mask1 = netaddr.IPAddress('::ff:ffff')
     mac = netaddr.EUI(int(address & mask1)).words
-    return ':'.join(['02', '16', '3e'] + ['%02x' % i for i in mac[3:6]])
+    return ':'.join(['02', '16', '3e'] + ['{0:02x}'.format(i) for i in mac[3:6]])

--- a/nova/ipv6/rfc2462.py
+++ b/nova/ipv6/rfc2462.py
@@ -25,7 +25,7 @@ from nova.i18n import _
 def to_global(prefix, mac, project_id):
     try:
         mac64 = netaddr.EUI(mac).eui64().words
-        int_addr = int(''.join(['%02x' % i for i in mac64]), 16)
+        int_addr = int(''.join(['{0:02x}'.format(i) for i in mac64]), 16)
         mac64_addr = netaddr.IPAddress(int_addr)
         maskIP = netaddr.IPNetwork(prefix).ip
         return (mac64_addr ^ netaddr.IPAddress('::0200:0:0:0') |
@@ -41,4 +41,4 @@ def to_mac(ipv6_address):
     mask1 = netaddr.IPAddress('::ffff:ffff:ffff:ffff')
     mask2 = netaddr.IPAddress('::0200:0:0:0')
     mac64 = netaddr.EUI(int(address & mask1 ^ mask2)).words
-    return ':'.join(['%02x' % i for i in mac64[0:3] + mac64[5:8]])
+    return ':'.join(['{0:02x}'.format(i) for i in mac64[0:3] + mac64[5:8]])

--- a/nova/keymgr/barbican.py
+++ b/nova/keymgr/barbican.py
@@ -180,7 +180,7 @@ class BarbicanKeyManager(key_mgr.KeyManager):
             elif (payload_content_type == 'application/octet-stream' and
                   not from_copy):
                 key_list = key.get_encoded()
-                string_key = ''.join(map(lambda byte: "%02x" % byte, key_list))
+                string_key = ''.join(map(lambda byte: "{0:02x}".format(byte), key_list))
                 encoded_key = base64.b64encode(binascii.unhexlify(string_key))
             else:
                 encoded_key = key.get_encoded()

--- a/nova/loadables.py
+++ b/nova/loadables.py
@@ -85,12 +85,12 @@ class BaseLoader(object):
             if relpath == '.':
                 relpkg = ''
             else:
-                relpkg = '.%s' % '.'.join(relpath.split(os.sep))
+                relpkg = '.{0!s}'.format('.'.join(relpath.split(os.sep)))
             for fname in filenames:
                 root, ext = os.path.splitext(fname)
                 if ext != '.py' or root == '__init__':
                     continue
-                module_name = "%s%s.%s" % (self.package, relpkg, root)
+                module_name = "{0!s}{1!s}.{2!s}".format(self.package, relpkg, root)
                 mod_classes = self._get_classes_from_module(module_name)
                 classes.extend(mod_classes)
         return classes

--- a/nova/network/api.py
+++ b/nova/network/api.py
@@ -56,7 +56,7 @@ def check_policy(context, action):
         'project_id': context.project_id,
         'user_id': context.user_id,
     }
-    _action = 'network:%s' % action
+    _action = 'network:{0!s}'.format(action)
     policy.enforce(context, _action, target)
 
 

--- a/nova/network/base_api.py
+++ b/nova/network/base_api.py
@@ -71,7 +71,7 @@ def refresh_cache(f):
             msg = _('instance is a required argument to use @refresh_cache')
             raise Exception(msg)
 
-        with lockutils.lock('refresh_cache-%s' % instance.uuid):
+        with lockutils.lock('refresh_cache-{0!s}'.format(instance.uuid)):
             # We need to call the wrapped function with the lock held to ensure
             # that it can call _get_instance_nw_info safely.
             res = f(self, context, *args, **kwargs)
@@ -249,7 +249,7 @@ class NetworkAPI(base.Base):
 
     def get_instance_nw_info(self, context, instance, **kwargs):
         """Returns all network info related to an instance."""
-        with lockutils.lock('refresh_cache-%s' % instance.uuid):
+        with lockutils.lock('refresh_cache-{0!s}'.format(instance.uuid)):
             result = self._get_instance_nw_info(context, instance, **kwargs)
             # NOTE(comstud): Don't update API cell with new info_cache every
             # time we pull network info for an instance.  The periodic healing

--- a/nova/network/manager.py
+++ b/nova/network/manager.py
@@ -875,8 +875,8 @@ class NetworkManager(manager.Manager):
                         self.instance_dns_manager.delete_entry,
                         instance_id, self.instance_dns_domain))
 
-            LOG.debug('Setting up network %(network)s on host %(host)s.' %
-                      {'network': network['id'], 'host': self.host},
+            LOG.debug('Setting up network {network!s} on host {host!s}.'.format(**
+                      {'network': network['id'], 'host': self.host}),
                       instance=instance)
             self._setup_network_on_host(context, network)
             cleanup.append(functools.partial(
@@ -1301,7 +1301,7 @@ class NetworkManager(manager.Manager):
             net.project_id = kwargs.get('project_id')
 
             if num_networks > 1:
-                net.label = '%s_%d' % (label, index)
+                net.label = '{0!s}_{1:d}'.format(label, index)
             else:
                 net.label = label
 
@@ -1358,7 +1358,7 @@ class NetworkManager(manager.Manager):
                 extra_reserved.append(str(net.vpn_private_address))
                 net.dhcp_start = net.dhcp_start + 1
                 net.vlan = vlan
-                net.bridge = 'br%s' % vlan
+                net.bridge = 'br{0!s}'.format(vlan)
 
                 # NOTE(vish): This makes ports unique across the cloud, a more
                 #             robust solution would be to make them uniq per ip

--- a/nova/network/minidns.py
+++ b/nova/network/minidns.py
@@ -62,7 +62,7 @@ class MiniDNS(dns_driver.DNSDriver):
 
     def qualify(self, name, domain):
         if domain:
-            qualified = "%s.%s" % (name, domain)
+            qualified = "{0!s}.{1!s}".format(name, domain)
         else:
             qualified = name
 
@@ -80,8 +80,7 @@ class MiniDNS(dns_driver.DNSDriver):
             raise exception.FloatingIpDNSExists(name=name, domain=domain)
 
         with open(self.filename, 'a+') as outfile:
-            outfile.write("%s   %s   %s\n" %
-                (address, self.qualify(name, domain), type))
+            outfile.write("{0!s}   {1!s}   {2!s}\n".format(address, self.qualify(name, domain), type))
 
     def parse_line(self, line):
         vals = line.split()
@@ -130,8 +129,7 @@ class MiniDNS(dns_driver.DNSDriver):
                 entry = self.parse_line(line)
                 if (entry and
                         entry['name'] == self.qualify(name, domain)):
-                    outfile.write("%s   %s   %s\n" %
-                        (address, self.qualify(name, domain), entry['type']))
+                    outfile.write("{0!s}   {1!s}   {2!s}\n".format(address, self.qualify(name, domain), entry['type']))
                 else:
                     outfile.write(line)
         outfile.close()
@@ -177,8 +175,7 @@ class MiniDNS(dns_driver.DNSDriver):
             raise exception.FloatingIpDNSExists(name=fqdomain, domain='')
 
         with open(self.filename, 'a+') as outfile:
-            outfile.write("%s   %s   %s\n" %
-                ('domain', fqdomain, 'domain'))
+            outfile.write("{0!s}   {1!s}   {2!s}\n".format('domain', fqdomain, 'domain'))
 
     def delete_domain(self, fqdomain):
         deleted = False

--- a/nova/network/neutronv2/api.py
+++ b/nova/network/neutronv2/api.py
@@ -637,7 +637,7 @@ class API(base_api.NetworkAPI):
                     and network.get('port_security_enabled', True))):
 
                 raise exception.SecurityGroupCannotBeApplied()
-            zone = 'compute:%s' % instance.availability_zone
+            zone = 'compute:{0!s}'.format(instance.availability_zone)
             port_req_body = {'port': {'device_id': instance.uuid,
                                       'device_owner': zone}}
             try:
@@ -712,7 +712,7 @@ class API(base_api.NetworkAPI):
             pci_dev = pci_manager.get_instance_pci_devs(
                 instance, pci_request_id).pop()
             devspec = pci_whitelist.get_pci_device_devspec(pci_dev)
-            profile = {'pci_vendor_info': "%s:%s" % (pci_dev.vendor_id,
+            profile = {'pci_vendor_info': "{0!s}:{1!s}".format(pci_dev.vendor_id,
                                                      pci_dev.product_id),
                        'pci_slot': pci_dev.address,
                        'physical_network':
@@ -1014,7 +1014,7 @@ class API(base_api.NetworkAPI):
             raise exception.NetworkNotFoundForInstance(
                 instance_id=instance.uuid)
 
-        zone = 'compute:%s' % instance.availability_zone
+        zone = 'compute:{0!s}'.format(instance.availability_zone)
         search_opts = {'device_id': instance.uuid,
                        'device_owner': zone,
                        'network_id': network_id}
@@ -1042,10 +1042,10 @@ class API(base_api.NetworkAPI):
     def remove_fixed_ip_from_instance(self, context, instance, address):
         """Remove a fixed IP from the instance."""
         neutron = get_client(context)
-        zone = 'compute:%s' % instance.availability_zone
+        zone = 'compute:{0!s}'.format(instance.availability_zone)
         search_opts = {'device_id': instance.uuid,
                        'device_owner': zone,
-                       'fixed_ips': 'ip_address=%s' % address}
+                       'fixed_ips': 'ip_address={0!s}'.format(address)}
         data = neutron.list_ports(**search_opts)
         ports = data['ports']
         for p in ports:
@@ -1168,8 +1168,8 @@ class API(base_api.NetworkAPI):
                         # TODO(jecarey) Need to look at consolidating list_port
                         # calls once able to OR filters.
                         search_opts = {'network_id': request.network_id,
-                                       'fixed_ips': 'ip_address=%s' % (
-                                           request.address),
+                                       'fixed_ips': 'ip_address={0!s}'.format((
+                                           request.address)),
                                        'fields': 'device_id'}
                         existing_ports = neutron.list_ports(
                                                     **search_opts)['ports']
@@ -1246,7 +1246,7 @@ class API(base_api.NetworkAPI):
         :returns: A list of dicts containing the uuids keyed by 'instance_uuid'
                   e.g. [{'instance_uuid': uuid}, ...]
         """
-        search_opts = {"fixed_ips": 'ip_address=%s' % address}
+        search_opts = {"fixed_ips": 'ip_address={0!s}'.format(address)}
         data = get_client(context).list_ports(**search_opts)
         ports = data.get('ports', [])
         return [{'instance_uuid': port['device_id']} for port in ports
@@ -1255,7 +1255,7 @@ class API(base_api.NetworkAPI):
     def _get_port_id_by_fixed_address(self, client,
                                       instance, address):
         """Return port_id from a fixed address."""
-        zone = 'compute:%s' % instance.availability_zone
+        zone = 'compute:{0!s}'.format(instance.availability_zone)
         search_opts = {'device_id': instance.uuid,
                        'device_owner': zone}
         data = client.list_ports(**search_opts)
@@ -1520,7 +1520,7 @@ class API(base_api.NetworkAPI):
                 return []
             with excutils.save_and_reraise_exception():
                 LOG.exception(_LE('Unable to access floating IP for %s'),
-                        ', '.join(['%s %s' % (k, v)
+                        ', '.join(['{0!s} {1!s}'.format(k, v)
                                    for k, v in six.iteritems(kwargs)]))
 
     def _get_floating_ip_by_address(self, client, address):

--- a/nova/notifications.py
+++ b/nova/notifications.py
@@ -329,7 +329,7 @@ def bandwidth_usage(instance_ref, audit_start,
 
     for b in bw_usages:
         if b.mac in macs:
-            label = 'net-name-not-found-%s' % b.mac
+            label = 'net-name-not-found-{0!s}'.format(b.mac)
             for vif in nw_info:
                 if vif['address'] == b.mac:
                     label = vif['network']['label']

--- a/nova/objects/base.py
+++ b/nova/objects/base.py
@@ -204,7 +204,7 @@ class ObjectListBase(ovoo_base.ObjectListBase):
     # base object and can be removed when we move to it.
     @classmethod
     def _obj_primitive_key(cls, field):
-        return 'nova_object.%s' % field
+        return 'nova_object.{0!s}'.format(field)
 
     @classmethod
     def _obj_primitive_field(cls, primitive, field,

--- a/nova/objects/block_device.py
+++ b/nova/objects/block_device.py
@@ -268,7 +268,7 @@ class BlockDeviceMapping(base.NovaPersistentObject, base.NovaObject,
         if attrname not in BLOCK_DEVICE_OPTIONAL_ATTRS:
             raise exception.ObjectActionError(
                 action='obj_load_attr',
-                reason='attribute %s not lazy-loadable' % attrname)
+                reason='attribute {0!s} not lazy-loadable'.format(attrname))
         if not self._context:
             raise exception.OrphanedObjectError(method='obj_load_attr',
                                                 objtype=self.obj_name())

--- a/nova/objects/build_request.py
+++ b/nova/objects/build_request.py
@@ -81,7 +81,7 @@ class BuildRequest(base.NovaObject):
         for key in req.fields:
             if isinstance(req.fields[key], fields.ObjectField):
                 try:
-                    getattr(req, '_load_%s' % key)(db_req[key])
+                    getattr(req, '_load_{0!s}'.format(key))(db_req[key])
                 except AttributeError:
                     LOG.exception(_LE('No load handler for %s'), key)
             elif key in JSON_FIELDS and db_req[key] is not None:

--- a/nova/objects/ec2.py
+++ b/nova/objects/ec2.py
@@ -203,13 +203,13 @@ class EC2Ids(base.NovaObject):
         ec2_ids['ami_id'] = ec2utils.glance_id_to_ec2_id(context,
                                                          instance.image_ref)
         for image_type in ['kernel', 'ramdisk']:
-            image_id = getattr(instance, '%s_id' % image_type)
+            image_id = getattr(instance, '{0!s}_id'.format(image_type))
             ec2_id = None
             if image_id is not None:
                 ec2_image_type = ec2utils.image_type(image_type)
                 ec2_id = ec2utils.glance_id_to_ec2_id(context, image_id,
                                                       ec2_image_type)
-            ec2_ids['%s_id' % image_type] = ec2_id
+            ec2_ids['{0!s}_id'.format(image_type)] = ec2_id
 
         return ec2_ids
 

--- a/nova/objects/external_event.py
+++ b/nova/objects/external_event.py
@@ -47,7 +47,7 @@ class InstanceExternalEvent(obj_base.NovaObject):
     @staticmethod
     def make_key(name, tag=None):
         if tag is not None:
-            return '%s-%s' % (name, tag)
+            return '{0!s}-{1!s}'.format(name, tag)
         else:
             return name
 

--- a/nova/objects/fields.py
+++ b/nova/objects/fields.py
@@ -623,8 +623,8 @@ class NetworkModel(FieldType):
         return network_model.NetworkInfo.hydrate(value)
 
     def stringify(self, value):
-        return 'NetworkModel(%s)' % (
-            ','.join([str(vif['id']) for vif in value]))
+        return 'NetworkModel({0!s})'.format((
+            ','.join([str(vif['id']) for vif in value])))
 
 
 class NonNegativeFloat(FieldType):

--- a/nova/objects/flavor.py
+++ b/nova/objects/flavor.py
@@ -353,7 +353,7 @@ class Flavor(base.NovaPersistentObject, base.NovaObject,
         # NOTE(danms): Only projects could be lazy-loaded right now
         if attrname != 'projects':
             raise exception.ObjectActionError(
-                action='obj_load_attr', reason='unable to load %s' % attrname)
+                action='obj_load_attr', reason='unable to load {0!s}'.format(attrname))
 
         self._load_projects()
 
@@ -739,8 +739,8 @@ def _adjust_autoincrement(context, value):
         # primary key. MySQL does not care about this, but since postgres does,
         # we need to reset this to avoid a failure on the next flavor creation.
         engine.execute(
-            text('ALTER SEQUENCE flavors_id_seq RESTART WITH %i;' % (
-                value)))
+            text('ALTER SEQUENCE flavors_id_seq RESTART WITH {0:d};'.format((
+                value))))
 
 
 @db_api.api_context_manager.reader

--- a/nova/objects/floating_ip.py
+++ b/nova/objects/floating_ip.py
@@ -69,7 +69,7 @@ class FloatingIP(obj_base.NovaPersistentObject, obj_base.NovaObject,
         if attrname not in FLOATING_IP_OPTIONAL_ATTRS:
             raise exception.ObjectActionError(
                 action='obj_load_attr',
-                reason='attribute %s is not lazy-loadable' % attrname)
+                reason='attribute {0!s} is not lazy-loadable'.format(attrname))
         if not self._context:
             raise exception.OrphanedObjectError(method='obj_load_attr',
                                                 objtype=self.obj_name())

--- a/nova/objects/image_meta.py
+++ b/nova/objects/image_meta.py
@@ -188,7 +188,7 @@ class ImageMetaProps(base.NovaObject):
             if bus in ('lxc', 'uml'):
                 raise exception.ObjectActionError(
                     action='obj_make_compatible',
-                    reason='hw_disk_bus=%s not supported in version %s' % (
+                    reason='hw_disk_bus={0!s} not supported in version {1!s}'.format(
                         bus, target_version))
 
     # Maximum number of NUMA nodes permitted for the guest topology
@@ -466,7 +466,7 @@ class ImageMetaProps(base.NovaObject):
         hw_numa_mem = []
         hw_numa_mem_set = False
         for cellid in range(ImageMetaProps.NUMA_NODES_MAX):
-            memprop = "hw_numa_mem.%d" % cellid
+            memprop = "hw_numa_mem.{0:d}".format(cellid)
             if memprop not in image_props:
                 break
             hw_numa_mem.append(int(image_props[memprop]))
@@ -480,7 +480,7 @@ class ImageMetaProps(base.NovaObject):
         hw_numa_cpus = []
         hw_numa_cpus_set = False
         for cellid in range(ImageMetaProps.NUMA_NODES_MAX):
-            cpuprop = "hw_numa_cpus.%d" % cellid
+            cpuprop = "hw_numa_cpus.{0:d}".format(cellid)
             if cpuprop not in image_props:
                 break
             hw_numa_cpus.append(

--- a/nova/objects/instance.py
+++ b/nova/objects/instance.py
@@ -70,7 +70,7 @@ def _expected_cols(expected_attrs):
     simple_cols = [attr for attr in expected_attrs
                    if attr in _INSTANCE_OPTIONAL_JOINED_FIELDS]
 
-    complex_cols = ['extra.%s' % field
+    complex_cols = ['extra.{0!s}'.format(field)
                     for field in _INSTANCE_EXTRA_FIELDS
                     if field in expected_attrs]
     if complex_cols:
@@ -644,7 +644,7 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
             if (self.obj_attr_is_set(field) and
                     isinstance(self.fields[field], fields.ObjectField)):
                 try:
-                    getattr(self, '_save_%s' % field)(context)
+                    getattr(self, '_save_{0!s}'.format(field))(context)
                 except AttributeError:
                     LOG.exception(_LE('No save handler for %s'), field,
                                   instance=self)
@@ -758,7 +758,7 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
         else:
             raise exception.ObjectActionError(
                 action='obj_load_attr',
-                reason='loading %s requires recursion' % attrname)
+                reason='loading {0!s} requires recursion'.format(attrname))
 
     def _load_fault(self):
         self.fault = objects.InstanceFault.get_latest_for_instance(
@@ -883,7 +883,7 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
         if attrname not in INSTANCE_OPTIONAL_ATTRS:
             raise exception.ObjectActionError(
                 action='obj_load_attr',
-                reason='attribute %s not lazy-loadable' % attrname)
+                reason='attribute {0!s} not lazy-loadable'.format(attrname))
 
         if not self._context:
             raise exception.OrphanedObjectError(method='obj_load_attr',
@@ -926,8 +926,8 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
         self.obj_reset_changes([attrname])
 
     def get_flavor(self, namespace=None):
-        prefix = ('%s_' % namespace) if namespace is not None else ''
-        attr = '%sflavor' % prefix
+        prefix = ('{0!s}_'.format(namespace)) if namespace is not None else ''
+        attr = '{0!s}flavor'.format(prefix)
         try:
             return getattr(self, attr)
         except exception.FlavorNotFound:
@@ -991,7 +991,7 @@ class Instance(base.NovaPersistentObject, base.NovaObject,
         cn_changed = 'cell_name' in self.obj_what_changed()
         if not self.obj_attr_is_set('cell_name') or self.cell_name is None:
             self.cell_name = ''
-        self.cell_name = '%s%s' % (cells_utils.BLOCK_SYNC_FLAG, self.cell_name)
+        self.cell_name = '{0!s}{1!s}'.format(cells_utils.BLOCK_SYNC_FLAG, self.cell_name)
         if not cn_changed:
             self.obj_reset_changes(['cell_name'])
         try:

--- a/nova/objects/instance_group.py
+++ b/nova/objects/instance_group.py
@@ -87,7 +87,7 @@ class InstanceGroup(base.NovaPersistentObject, base.NovaObject,
         # NOTE(sbauza): Only hosts could be lazy-loaded right now
         if attrname != 'hosts':
             raise exception.ObjectActionError(
-                action='obj_load_attr', reason='unable to load %s' % attrname)
+                action='obj_load_attr', reason='unable to load {0!s}'.format(attrname))
 
         self.hosts = self.get_hosts()
         self.obj_reset_changes(['hosts'])

--- a/nova/objects/migrate_data.py
+++ b/nova/objects/migrate_data.py
@@ -159,7 +159,7 @@ class LibvirtLiveMigrateData(LiveMigrateData):
             self.bdms.append(bdmi)
 
     def to_legacy_dict(self, pre_migration_result=False):
-        LOG.debug('Converting to legacy: %s' % self)
+        LOG.debug('Converting to legacy: {0!s}'.format(self))
         legacy = super(LibvirtLiveMigrateData, self).to_legacy_dict()
         keys = (set(self.fields.keys()) -
                 set(LiveMigrateData.fields.keys()) - {'bdms'})
@@ -182,11 +182,11 @@ class LibvirtLiveMigrateData(LiveMigrateData):
             legacy['pre_live_migration_result'] = live_result
             self._bdms_to_legacy(live_result)
 
-        LOG.debug('Legacy result: %s' % legacy)
+        LOG.debug('Legacy result: {0!s}'.format(legacy))
         return legacy
 
     def from_legacy_dict(self, legacy):
-        LOG.debug('Converting legacy dict to obj: %s' % legacy)
+        LOG.debug('Converting legacy dict to obj: {0!s}'.format(legacy))
         super(LibvirtLiveMigrateData, self).from_legacy_dict(legacy)
         keys = set(self.fields.keys()) - set(LiveMigrateData.fields.keys())
         for k in keys - {'bdms'}:
@@ -202,7 +202,7 @@ class LibvirtLiveMigrateData(LiveMigrateData):
             if 'serial_listen_addr' in pre_result:
                 self.serial_listen_addr = pre_result['serial_listen_addr']
             self._bdms_from_legacy(pre_result)
-        LOG.debug('Converted object: %s' % self)
+        LOG.debug('Converted object: {0!s}'.format(self))
 
     def is_on_shared_storage(self):
         return self.is_shared_block_storage or self.is_shared_instance_path

--- a/nova/objects/network.py
+++ b/nova/objects/network.py
@@ -93,7 +93,7 @@ class Network(obj_base.NovaPersistentObject, obj_base.NovaObject,
         """
         try:
             prefix = int(netmask)
-            return netaddr.IPNetwork('1::/%i' % prefix).netmask
+            return netaddr.IPNetwork('1::/{0:d}'.format(prefix)).netmask
         except ValueError:
             pass
 

--- a/nova/objects/notification.py
+++ b/nova/objects/notification.py
@@ -31,9 +31,9 @@ class EventType(base.NovaObject):
 
     def to_notification_event_type_field(self):
         """Serialize the object to the wire format."""
-        s = '%s.%s' % (self.object, self.action)
+        s = '{0!s}.{1!s}'.format(self.object, self.action)
         if self.obj_attr_is_set('phase'):
-            s += '.%s' % self.phase
+            s += '.{0!s}'.format(self.phase)
         return s
 
 
@@ -130,8 +130,7 @@ class NotificationBase(base.NovaObject):
         self._emit(context,
                    event_type=
                    self.event_type.to_notification_event_type_field(),
-                   publisher_id='%s:%s' %
-                                (self.publisher.binary,
+                   publisher_id='{0!s}:{1!s}'.format(self.publisher.binary,
                                  self.publisher.host),
                    payload=self.payload.obj_to_primitive())
 

--- a/nova/objects/pci_device.py
+++ b/nova/objects/pci_device.py
@@ -140,7 +140,7 @@ class PciDevice(base.NovaPersistentObject, base.NovaObject):
             if status in added_statuses:
                 raise exception.ObjectActionError(
                     action='obj_make_compatible',
-                    reason='status=%s not supported in version %s' % (
+                    reason='status={0!s} not supported in version {1!s}'.format(
                         status, target_version))
 
     def update_device(self, dev_dict):

--- a/nova/objects/service.py
+++ b/nova/objects/service.py
@@ -199,7 +199,7 @@ class Service(base.NovaPersistentObject, base.NovaObject,
         if attrname != 'compute_node':
             raise exception.ObjectActionError(
                 action='obj_load_attr',
-                reason='attribute %s not lazy-loadable' % attrname)
+                reason='attribute {0!s} not lazy-loadable'.format(attrname))
         if self.binary == 'nova-compute':
             # Only n-cpu services have attached compute_node(s)
             compute_nodes = objects.ComputeNodeList.get_all_by_host(

--- a/nova/openstack/common/cliutils.py
+++ b/nova/openstack/common/cliutils.py
@@ -263,7 +263,7 @@ def get_service_type(f):
 
 
 def pretty_choice_list(l):
-    return ', '.join("'%s'" % i for i in l)
+    return ', '.join("'{0!s}'".format(i) for i in l)
 
 
 def exit(msg=''):

--- a/nova/pci/devspec.py
+++ b/nova/pci/devspec.py
@@ -89,7 +89,7 @@ class PciAddress(object):
                 if f > MAX_FUNC:
                     raise exception.PciDeviceInvalidAddressField(
                         address=pci_addr, field="function")
-                self.func = "%1x" % f
+                self.func = "{0:1x}".format(f)
         if dbs:
             dbs_fields = dbs.split(':')
             if len(dbs_fields) > 3:

--- a/nova/pci/utils.py
+++ b/nova/pci/utils.py
@@ -71,14 +71,14 @@ def get_pci_address_fields(pci_addr):
 
 
 def get_pci_address(domain, bus, slot, func):
-    return '%s:%s:%s.%s' % (domain, bus, slot, func)
+    return '{0!s}:{1!s}:{2!s}.{3!s}'.format(domain, bus, slot, func)
 
 
 def get_function_by_ifname(ifname):
     """Given the device name, returns the PCI address of a device
     and returns True if the address in a physical function.
     """
-    dev_path = "/sys/class/net/%s/device" % ifname
+    dev_path = "/sys/class/net/{0!s}/device".format(ifname)
     sriov_totalvfs = 0
     if os.path.isdir(dev_path):
         try:
@@ -93,8 +93,8 @@ def get_function_by_ifname(ifname):
 
 
 def is_physical_function(domain, bus, slot, function):
-    dev_path = "/sys/bus/pci/devices/%(d)s:%(b)s:%(s)s.%(f)s/" % {
-        "d": domain, "b": bus, "s": slot, "f": function}
+    dev_path = "/sys/bus/pci/devices/{d!s}:{b!s}:{s!s}.{f!s}/".format(**{
+        "d": domain, "b": bus, "s": slot, "f": function})
     if os.path.isdir(dev_path):
         sriov_totalvfs = 0
         try:
@@ -112,8 +112,8 @@ def _get_sysfs_netdev_path(pci_addr, pf_interface):
     Assumes a networking device - will not check for the existence of the path.
     """
     if pf_interface:
-        return "/sys/bus/pci/devices/%s/physfn/net" % (pci_addr)
-    return "/sys/bus/pci/devices/%s/net" % (pci_addr)
+        return "/sys/bus/pci/devices/{0!s}/physfn/net".format((pci_addr))
+    return "/sys/bus/pci/devices/{0!s}/net".format((pci_addr))
 
 
 def get_ifname_by_pci_address(pci_addr, pf_interface=False):
@@ -158,7 +158,7 @@ def get_vf_num_by_pci_address(pci_addr):
     configure it. This number can be obtained from the PCI device filesystem.
     """
     VIRTFN_RE = re.compile("virtfn(\d+)")
-    virtfns_path = "/sys/bus/pci/devices/%s/physfn/virtfn*" % (pci_addr)
+    virtfns_path = "/sys/bus/pci/devices/{0!s}/physfn/virtfn*".format((pci_addr))
     vf_num = None
     try:
         for vf_path in glob.iglob(virtfns_path):

--- a/nova/rpc.py
+++ b/nova/rpc.py
@@ -184,7 +184,7 @@ def get_server(target, endpoints, serializer=None):
 def get_notifier(service, host=None, publisher_id=None):
     assert LEGACY_NOTIFIER is not None
     if not publisher_id:
-        publisher_id = "%s.%s" % (service, host or CONF.host)
+        publisher_id = "{0!s}.{1!s}".format(service, host or CONF.host)
     return LegacyValidatingNotifier(
             LEGACY_NOTIFIER.prepare(publisher_id=publisher_id))
 

--- a/nova/scheduler/filters/image_props_filter.py
+++ b/nova/scheduler/filters/image_props_filter.py
@@ -77,7 +77,7 @@ class ImagePropertiesFilter(filters.BaseHostFilter):
             if not(hypervisor_version and version_required):
                 return True
             img_prop_predicate = versionpredicate.VersionPredicate(
-                'image_prop (%s)' % version_required)
+                'image_prop ({0!s})'.format(version_required))
             hyper_ver_str = versionutils.convert_version_to_str(hyper_version)
             return img_prop_predicate.satisfied_by(hyper_ver_str)
 

--- a/nova/scheduler/filters/trusted_filter.py
+++ b/nova/scheduler/filters/trusted_filter.py
@@ -82,7 +82,7 @@ class AttestationService(object):
         # :returns: result data
         # :raises: IOError if the request fails
 
-        action_url = "https://%s:%s%s/%s" % (self.host, self.port,
+        action_url = "https://{0!s}:{1!s}{2!s}/{3!s}".format(self.host, self.port,
                                              self.api_url, action_url)
         try:
             res = requests.request(method, action_url, data=body,

--- a/nova/scheduler/utils.py
+++ b/nova/scheduler/utils.py
@@ -111,7 +111,7 @@ def set_vm_state_and_notify(context, instance_uuid, service, method, updates,
                     method=method,
                     reason=ex)
 
-    event_type = '%s.%s' % (service, method)
+    event_type = '{0!s}.{1!s}'.format(service, method)
     notifier.error(context, event_type, payload)
 
 

--- a/nova/scheduler/weights/__init__.py
+++ b/nova/scheduler/weights/__init__.py
@@ -27,7 +27,7 @@ class WeighedHost(weights.WeighedObject):
         return x
 
     def __repr__(self):
-        return "WeighedHost [host: %r, weight: %s]" % (
+        return "WeighedHost [host: {0!r}, weight: {1!s}]".format(
                 self.obj, self.weight)
 
 

--- a/nova/service.py
+++ b/nova/service.py
@@ -276,8 +276,8 @@ class Service(service.Service):
         if not topic:
             topic = binary.rpartition('nova-')[2]
         if not manager:
-            manager_cls = ('%s_manager' %
-                           binary.rpartition('nova-')[2])
+            manager_cls = ('{0!s}_manager'.format(
+                           binary.rpartition('nova-')[2]))
             manager = CONF.get(manager_cls, None)
         if report_interval is None:
             report_interval = CONF.report_interval
@@ -359,7 +359,7 @@ class WSGIService(service.Service):
         self.name = name
         # NOTE(danms): Name can be metadata, os_compute, or ec2, per
         # nova.service's enabled_apis
-        self.binary = 'nova-%s' % name
+        self.binary = 'nova-{0!s}'.format(name)
         self.topic = None
         self.manager = self._get_manager()
         self.loader = loader or wsgi.Loader()
@@ -369,12 +369,12 @@ class WSGIService(service.Service):
             wname = 'osapi_compute'
         else:
             wname = name
-        self.host = getattr(CONF, '%s_listen' % name, "0.0.0.0")
-        self.port = getattr(CONF, '%s_listen_port' % name, 0)
-        self.workers = (getattr(CONF, '%s_workers' % wname, None) or
+        self.host = getattr(CONF, '{0!s}_listen'.format(name), "0.0.0.0")
+        self.port = getattr(CONF, '{0!s}_listen_port'.format(name), 0)
+        self.workers = (getattr(CONF, '{0!s}_workers'.format(wname), None) or
                         processutils.get_worker_count())
         if self.workers and self.workers < 1:
-            worker_name = '%s_workers' % name
+            worker_name = '{0!s}_workers'.format(name)
             msg = (_("%(worker_name)s value of %(workers)s is invalid, "
                      "must be greater than 0") %
                    {'worker_name': worker_name,
@@ -409,7 +409,7 @@ class WSGIService(service.Service):
         :returns: a Manager instance, or None.
 
         """
-        fl = '%s_manager' % self.name
+        fl = '{0!s}_manager'.format(self.name)
         if fl not in CONF:
             return None
 

--- a/nova/servicegroup/drivers/mc.py
+++ b/nova/servicegroup/drivers/mc.py
@@ -61,17 +61,17 @@ class MemcachedDriver(base.Driver):
         """Moved from nova.utils
         Check whether a service is up based on last heartbeat.
         """
-        key = "%(topic)s:%(host)s" % service_ref
+        key = "{topic!s}:{host!s}".format(**service_ref)
         is_up = self.mc.get(str(key)) is not None
         if not is_up:
-            LOG.debug('Seems service %s is down' % key)
+            LOG.debug('Seems service {0!s} is down'.format(key))
 
         return is_up
 
     def _report_state(self, service):
         """Update the state of this service in the datastore."""
         try:
-            key = "%(topic)s:%(host)s" % service.service_ref
+            key = "{topic!s}:{host!s}".format(**service.service_ref)
             # memcached has data expiration time capability.
             # set(..., time=CONF.service_down_time) uses it and
             # reduces key-deleting code.

--- a/nova/test.py
+++ b/nova/test.py
@@ -150,8 +150,7 @@ def _patch_mock_to_raise_for_invalid_assert_calls():
                 'assert_any_calls']
 
             if name.startswith('assert') and name not in valid_asserts:
-                raise AttributeError('%s is not a valid mock assert method'
-                                     % name)
+                raise AttributeError('{0!s} is not a valid mock assert method'.format(name))
 
             return wrapped(_self, name)
         return wrapper
@@ -379,16 +378,15 @@ class TestCase(testtools.TestCase):
                 extranames.append(name)
 
         self.assertEqual([], extranames,
-                         "public APIs not listed in base class %s" %
-                         baseclass)
+                         "public APIs not listed in base class {0!s}".format(
+                         baseclass))
 
         for name in sorted(implmethods.keys()):
             baseargs = inspect.getargspec(basemethods[name])
             implargs = inspect.getargspec(implmethods[name])
 
             self.assertEqual(baseargs, implargs,
-                             "%s args don't match base class %s" %
-                             (name, baseclass))
+                             "{0!s} args don't match base class {1!s}".format(name, baseclass))
 
 
 class APICoverage(object):

--- a/nova/tests/fixtures.py
+++ b/nova/tests/fixtures.py
@@ -53,7 +53,7 @@ class ServiceFixture(fixtures.Fixture):
         # this is stable.
         host = host or name
         kwargs.setdefault('host', host)
-        kwargs.setdefault('binary', 'nova-%s' % name)
+        kwargs.setdefault('binary', 'nova-{0!s}'.format(name))
         self.kwargs = kwargs
 
     def setUp(self):
@@ -414,9 +414,9 @@ class OSAPIFixture(fixtures.Fixture):
         self.osapi = service.WSGIService("osapi_compute")
         self.osapi.start()
         self.addCleanup(self.osapi.stop)
-        self.auth_url = 'http://%(host)s:%(port)s/%(api_version)s' % ({
+        self.auth_url = 'http://{host!s}:{port!s}/{api_version!s}'.format(**({
             'host': self.osapi.host, 'port': self.osapi.port,
-            'api_version': self.api_version})
+            'api_version': self.api_version}))
         self.api = client.TestOpenStackClient('fake', 'fake', self.auth_url,
                                               self.project_id)
         self.admin_api = client.TestOpenStackClient(
@@ -523,17 +523,17 @@ class BannedDBSchemaOperations(fixtures.Fixture):
     @staticmethod
     def _explode(resource, op):
         raise exception.DBNotAllowed(
-            'Operation %s.%s() is not allowed in a database migration' % (
+            'Operation {0!s}.{1!s}() is not allowed in a database migration'.format(
                 resource, op))
 
     def setUp(self):
         super(BannedDBSchemaOperations, self).setUp()
         for thing in self._banned_resources:
             self.useFixture(fixtures.MonkeyPatch(
-                'sqlalchemy.%s.drop' % thing,
+                'sqlalchemy.{0!s}.drop'.format(thing),
                 lambda *a, **k: self._explode(thing, 'drop')))
             self.useFixture(fixtures.MonkeyPatch(
-                'sqlalchemy.%s.alter' % thing,
+                'sqlalchemy.{0!s}.alter'.format(thing),
                 lambda *a, **k: self._explode(thing, 'alter')))
 
 

--- a/nova/tests/functional/api/client.py
+++ b/nova/tests/functional/api/client.py
@@ -64,7 +64,7 @@ class APIResponse(object):
     def __str__(self):
         # because __str__ falls back to __repr__ we can still use repr
         # on self but add in the other attributes.
-        return "<Response body:%r, status_code:%s>" % (self.body, self.status)
+        return "<Response body:{0!r}, status_code:{1!s}>".format(self.body, self.status)
 
 
 class OpenStackApiException(Exception):
@@ -167,7 +167,7 @@ class TestOpenStackClient(object):
             # NOTE(vish): cut out version number and tenant_id
             base_uri = '/'.join(base_uri.split('/', 3)[:-1])
 
-        full_uri = '%s/%s' % (base_uri, relative_uri)
+        full_uri = '{0!s}/{1!s}'.format(base_uri, relative_uri)
 
         headers = kwargs.setdefault('headers', {})
         headers['X-Auth-Token'] = auth_result['x-auth-token']
@@ -244,7 +244,7 @@ class TestOpenStackClient(object):
     #####################################
 
     def get_server(self, server_id):
-        return self.api_get('/servers/%s' % server_id).body['server']
+        return self.api_get('/servers/{0!s}'.format(server_id)).body['server']
 
     def get_servers(self, detail=True, search_opts=None):
         rel_url = '/servers/detail' if detail else '/servers'
@@ -254,7 +254,7 @@ class TestOpenStackClient(object):
             for opt, val in six.iteritems(search_opts):
                 qparams[opt] = val
             if qparams:
-                query_string = "?%s" % urllib.urlencode(qparams)
+                query_string = "?{0!s}".format(urllib.urlencode(qparams))
                 rel_url += query_string
         return self.api_get(rel_url).body['servers']
 
@@ -266,16 +266,16 @@ class TestOpenStackClient(object):
             return response['server']
 
     def put_server(self, server_id, server):
-        return self.api_put('/servers/%s' % server_id, server).body
+        return self.api_put('/servers/{0!s}'.format(server_id), server).body
 
     def post_server_action(self, server_id, data):
-        return self.api_post('/servers/%s/action' % server_id, data).body
+        return self.api_post('/servers/{0!s}/action'.format(server_id), data).body
 
     def delete_server(self, server_id):
-        return self.api_delete('/servers/%s' % server_id)
+        return self.api_delete('/servers/{0!s}'.format(server_id))
 
     def get_image(self, image_id):
-        return self.api_get('/images/%s' % image_id).body['image']
+        return self.api_get('/images/{0!s}'.format(image_id)).body['image']
 
     def get_images(self, detail=True):
         rel_url = '/images/detail' if detail else '/images'
@@ -285,10 +285,10 @@ class TestOpenStackClient(object):
         return self.api_post('/images', image).body['image']
 
     def delete_image(self, image_id):
-        return self.api_delete('/images/%s' % image_id)
+        return self.api_delete('/images/{0!s}'.format(image_id))
 
     def get_flavor(self, flavor_id):
-        return self.api_get('/flavors/%s' % flavor_id).body['flavor']
+        return self.api_get('/flavors/{0!s}'.format(flavor_id)).body['flavor']
 
     def get_flavors(self, detail=True):
         rel_url = '/flavors/detail' if detail else '/flavors'
@@ -298,14 +298,14 @@ class TestOpenStackClient(object):
         return self.api_post('/flavors', flavor).body['flavor']
 
     def delete_flavor(self, flavor_id):
-        return self.api_delete('/flavors/%s' % flavor_id)
+        return self.api_delete('/flavors/{0!s}'.format(flavor_id))
 
     def post_extra_spec(self, flavor_id, spec):
-        return self.api_post('/flavors/%s/os-extra_specs' %
-                             flavor_id, spec)
+        return self.api_post('/flavors/{0!s}/os-extra_specs'.format(
+                             flavor_id), spec)
 
     def get_volume(self, volume_id):
-        return self.api_get('/os-volumes/%s' % volume_id).body['volume']
+        return self.api_get('/os-volumes/{0!s}'.format(volume_id)).body['volume']
 
     def get_volumes(self, detail=True):
         rel_url = '/os-volumes/detail' if detail else '/os-volumes'
@@ -315,30 +315,28 @@ class TestOpenStackClient(object):
         return self.api_post('/os-volumes', volume).body['volume']
 
     def delete_volume(self, volume_id):
-        return self.api_delete('/os-volumes/%s' % volume_id)
+        return self.api_delete('/os-volumes/{0!s}'.format(volume_id))
 
     def get_server_volume(self, server_id, attachment_id):
-        return self.api_get('/servers/%s/os-volume_attachments/%s' %
-                            (server_id, attachment_id)
+        return self.api_get('/servers/{0!s}/os-volume_attachments/{1!s}'.format(server_id, attachment_id)
                         ).body['volumeAttachment']
 
     def get_server_volumes(self, server_id):
-        return self.api_get('/servers/%s/os-volume_attachments' %
-                            (server_id)).body['volumeAttachments']
+        return self.api_get('/servers/{0!s}/os-volume_attachments'.format(
+                            (server_id))).body['volumeAttachments']
 
     def post_server_volume(self, server_id, volume_attachment):
-        return self.api_post('/servers/%s/os-volume_attachments' %
-                             (server_id), volume_attachment
+        return self.api_post('/servers/{0!s}/os-volume_attachments'.format(
+                             (server_id)), volume_attachment
                             ).body['volumeAttachment']
 
     def delete_server_volume(self, server_id, attachment_id):
-        return self.api_delete('/servers/%s/os-volume_attachments/%s' %
-                            (server_id, attachment_id))
+        return self.api_delete('/servers/{0!s}/os-volume_attachments/{1!s}'.format(server_id, attachment_id))
 
     def post_server_metadata(self, server_id, metadata):
         post_body = {'metadata': {}}
         post_body['metadata'].update(metadata)
-        return self.api_post('/servers/%s/metadata' % server_id,
+        return self.api_post('/servers/{0!s}/metadata'.format(server_id),
                              post_body).body['metadata']
 
     def get_server_groups(self, all_projects=None):
@@ -349,16 +347,16 @@ class TestOpenStackClient(object):
             return self.api_get('/os-server-groups').body['server_groups']
 
     def get_server_group(self, group_id):
-        return self.api_get('/os-server-groups/%s' %
-                            group_id).body['server_group']
+        return self.api_get('/os-server-groups/{0!s}'.format(
+                            group_id)).body['server_group']
 
     def post_server_groups(self, group):
         response = self.api_post('/os-server-groups', {"server_group": group})
         return response.body['server_group']
 
     def delete_server_group(self, group_id):
-        self.api_delete('/os-server-groups/%s' % group_id)
+        self.api_delete('/os-server-groups/{0!s}'.format(group_id))
 
     def get_instance_actions(self, server_id):
-        return self.api_get('/servers/%s/os-instance-actions' %
-                            (server_id)).body['instanceActions']
+        return self.api_get('/servers/{0!s}/os-instance-actions'.format(
+                            (server_id))).body['instanceActions']

--- a/nova/tests/functional/api_sample_tests/test_access_ips.py
+++ b/nova/tests/functional/api_sample_tests/test_access_ips.py
@@ -59,7 +59,7 @@ class AccessIPsSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
             'access_ip_v6': 'fe80::'
         }
         uuid = self._servers_post(subs)
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs['hostid'] = '[a-f0-9]+'
         subs['id'] = uuid
         self._verify_response('server-get-resp', subs, response, 200)
@@ -87,7 +87,7 @@ class AccessIPsSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
         uuid = self._servers_post(subs)
         subs['access_ip_v4'] = "4.3.2.1"
         subs['access_ip_v6'] = '80fe::'
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'server-action-rebuild', subs)
         subs['hostid'] = '[a-f0-9]+'
         subs['id'] = uuid

--- a/nova/tests/functional/api_sample_tests/test_admin_actions.py
+++ b/nova/tests/functional/api_sample_tests/test_admin_actions.py
@@ -42,18 +42,18 @@ class AdminActionsSamplesJsonTest(test_servers.ServersSampleBase):
 
     def test_post_reset_network(self):
         # Get api samples to reset server network request.
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'admin-actions-reset-network', {})
         self.assertEqual(202, response.status_code)
 
     def test_post_inject_network_info(self):
         # Get api samples to inject network info request.
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'admin-actions-inject-network-info', {})
         self.assertEqual(202, response.status_code)
 
     def test_post_reset_state(self):
         # get api samples to server reset state request.
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'admin-actions-reset-server-state', {})
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_admin_password.py
+++ b/nova/tests/functional/api_sample_tests/test_admin_password.py
@@ -28,7 +28,7 @@ class AdminPasswordJsonTest(test_servers.ServersSampleBase):
     def test_server_password(self):
         uuid = self._post_server()
         subs = {"password": "foo"}
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'admin-password-change-password',
                                  subs)
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_agents.py
+++ b/nova/tests/functional/api_sample_tests/test_agents.py
@@ -96,12 +96,12 @@ class AgentsJsonTest(api_sample_base.ApiSampleTestBaseV21):
         subs = {'version': '7.0',
                 'url': 'http://example.com/path/to/resource',
                 'md5hash': 'add6bb58e139be103324d04d82d8f545'}
-        response = self._do_put('os-agents/%s' % agent_id,
+        response = self._do_put('os-agents/{0!s}'.format(agent_id),
                                 'agent-update-put-req', subs)
         self._verify_response('agent-update-put-resp', subs, response, 200)
 
     def test_agent_delete(self):
         # Deletes an existing agent build.
         agent_id = 1
-        response = self._do_delete('os-agents/%s' % agent_id)
+        response = self._do_delete('os-agents/{0!s}'.format(agent_id))
         self.assertEqual(200, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_aggregates.py
+++ b/nova/tests/functional/api_sample_tests/test_aggregates.py
@@ -48,12 +48,12 @@ class AggregatesSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
 
     def test_aggregate_get(self):
         agg_id = self.test_aggregate_create()
-        response = self._do_get('os-aggregates/%s' % agg_id)
+        response = self._do_get('os-aggregates/{0!s}'.format(agg_id))
         self._verify_response('aggregates-get-resp', {}, response, 200)
 
     def test_add_metadata(self):
         agg_id = self.test_aggregate_create()
-        response = self._do_post('os-aggregates/%s/action' % agg_id,
+        response = self._do_post('os-aggregates/{0!s}/action'.format(agg_id),
                                  'aggregate-metadata-post-req',
                                  {'action': 'set_metadata'})
         self._verify_response('aggregates-metadata-post-resp', {},
@@ -64,7 +64,7 @@ class AggregatesSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
         subs = {
             "host_name": self.compute.host,
         }
-        response = self._do_post('os-aggregates/%s/action' % aggregate_id,
+        response = self._do_post('os-aggregates/{0!s}/action'.format(aggregate_id),
                                  'aggregate-add-host-post-req', subs)
         self._verify_response('aggregates-add-host-post-resp', subs,
                               response, 200)
@@ -81,7 +81,7 @@ class AggregatesSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
 
     def test_update_aggregate(self):
         aggregate_id = self.test_aggregate_create()
-        response = self._do_put('os-aggregates/%s' % aggregate_id,
+        response = self._do_put('os-aggregates/{0!s}'.format(aggregate_id),
                                   'aggregate-update-post-req', {})
         self._verify_response('aggregate-update-post-resp',
                               {}, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_attach_interfaces.py
+++ b/nova/tests/functional/api_sample_tests/test_attach_interfaces.py
@@ -114,8 +114,7 @@ class AttachInterfacesSampleJsonTest(test_servers.ServersSampleBase):
 
     def test_list_interfaces(self):
         instance_uuid = self._post_server()
-        response = self._do_get('servers/%s/os-interface'
-                                % instance_uuid)
+        response = self._do_get('servers/{0!s}/os-interface'.format(instance_uuid))
         subs = {
                 'ip_address': '192.168.1.3',
                 'subnet_id': 'f8a6e8f8-c2ec-497c-9f23-da9616de54ef',
@@ -137,8 +136,7 @@ class AttachInterfacesSampleJsonTest(test_servers.ServersSampleBase):
         instance_uuid = self._post_server()
         port_id = 'ce531f90-199f-48c0-816c-13e38010b442'
         self._stub_show_for_instance(instance_uuid, port_id)
-        response = self._do_get('servers/%s/os-interface/%s' %
-                                (instance_uuid, port_id))
+        response = self._do_get('servers/{0!s}/os-interface/{1!s}'.format(instance_uuid, port_id))
         subs = {
                 'ip_address': '192.168.1.3',
                 'subnet_id': 'f8a6e8f8-c2ec-497c-9f23-da9616de54ef',
@@ -162,8 +160,7 @@ class AttachInterfacesSampleJsonTest(test_servers.ServersSampleBase):
                 'mac_addr': 'fa:16:3e:4c:2c:30',
                 }
         self._stub_show_for_instance(instance_uuid, subs['port_id'])
-        response = self._do_post('servers/%s/os-interface'
-                                 % instance_uuid,
+        response = self._do_post('servers/{0!s}/os-interface'.format(instance_uuid),
                                  'attach-interfaces-create-req', subs)
         self._verify_response('attach-interfaces-create-resp', subs,
                               response, 200)
@@ -171,7 +168,6 @@ class AttachInterfacesSampleJsonTest(test_servers.ServersSampleBase):
     def test_delete_interfaces(self):
         instance_uuid = self._post_server()
         port_id = 'ce531f90-199f-48c0-816c-13e38010b442'
-        response = self._do_delete('servers/%s/os-interface/%s' %
-                                (instance_uuid, port_id))
+        response = self._do_delete('servers/{0!s}/os-interface/{1!s}'.format(instance_uuid, port_id))
         self.assertEqual(202, response.status_code)
         self.assertEqual('', response.content)

--- a/nova/tests/functional/api_sample_tests/test_cells.py
+++ b/nova/tests/functional/api_sample_tests/test_cells.py
@@ -63,8 +63,8 @@ class CellsSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
             our_id = self.cells_next_id
             self.cells_next_id += 1
             cell.update({'id': our_id,
-                         'name': 'cell%s' % our_id,
-                         'transport_url': 'rabbit://username%s@/' % our_id,
+                         'name': 'cell{0!s}'.format(our_id),
+                         'transport_url': 'rabbit://username{0!s}@/'.format(our_id),
                          'is_parent': our_id % 2 == 0})
             self.cell_list.append(cell)
 
@@ -89,8 +89,8 @@ class CellsSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
         self._mock_cell_capacity()
         state_manager = state.CellStateManager()
         my_state = state_manager.get_my_state()
-        response = self._do_get('os-cells/%s/capacities' %
-                my_state.name)
+        response = self._do_get('os-cells/{0!s}/capacities'.format(
+                my_state.name))
         return self._verify_response('cells-capacities-resp',
                                         {}, response, 200)
 

--- a/nova/tests/functional/api_sample_tests/test_config_drive.py
+++ b/nova/tests/functional/api_sample_tests/test_config_drive.py
@@ -49,7 +49,7 @@ class ConfigDriveSampleJsonTest(test_servers.ServersSampleBase):
 
     def test_config_drive_show(self):
         uuid = self._post_server(use_common_server_api_samples=False)
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         # config drive can be a string for True or empty value for False

--- a/nova/tests/functional/api_sample_tests/test_console_auth_tokens.py
+++ b/nova/tests/functional/api_sample_tests/test_console_auth_tokens.py
@@ -43,7 +43,7 @@ class ConsoleAuthTokensSampleJsonTests(test_servers.ServersSampleBase):
         return jsonutils.loads(data)["console"]["url"]
 
     def _get_console_token(self, uuid):
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'get-rdp-console-post-req',
                                  {'action': 'os-getRDPConsole'})
 
@@ -56,7 +56,7 @@ class ConsoleAuthTokensSampleJsonTests(test_servers.ServersSampleBase):
         uuid = self._post_server()
         token = self._get_console_token(uuid)
 
-        response = self._do_get('os-console-auth-tokens/%s' % token)
+        response = self._do_get('os-console-auth-tokens/{0!s}'.format(token))
 
         subs = {}
         subs["uuid"] = uuid

--- a/nova/tests/functional/api_sample_tests/test_console_output.py
+++ b/nova/tests/functional/api_sample_tests/test_console_output.py
@@ -35,6 +35,6 @@ class ConsoleOutputSampleJsonTest(test_servers.ServersSampleBase):
 
     def test_get_console_output(self):
         uuid = self._post_server()
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'console-output-post-req', {})
         self._verify_response('console-output-post-resp', {}, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_consoles.py
+++ b/nova/tests/functional/api_sample_tests/test_consoles.py
@@ -28,7 +28,7 @@ class ConsolesSamplesJsonTest(test_servers.ServersSampleBase):
         self.console = self.start_service('console', host='fake')
 
     def _create_consoles(self, server_uuid):
-        response = self._do_post('servers/%s/consoles' % server_uuid,
+        response = self._do_post('servers/{0!s}/consoles'.format(server_uuid),
                                  'consoles-create-req', {})
         self.assertEqual(response.status_code, 200)
 
@@ -39,17 +39,17 @@ class ConsolesSamplesJsonTest(test_servers.ServersSampleBase):
     def test_list_consoles(self):
         uuid = self._post_server()
         self._create_consoles(uuid)
-        response = self._do_get('servers/%s/consoles' % uuid)
+        response = self._do_get('servers/{0!s}/consoles'.format(uuid))
         self._verify_response('consoles-list-get-resp', {}, response, 200)
 
     def test_console_get(self):
         uuid = self._post_server()
         self._create_consoles(uuid)
-        response = self._do_get('servers/%s/consoles/1' % uuid)
+        response = self._do_get('servers/{0!s}/consoles/1'.format(uuid))
         self._verify_response('consoles-get-resp', {}, response, 200)
 
     def test_console_delete(self):
         uuid = self._post_server()
         self._create_consoles(uuid)
-        response = self._do_delete('servers/%s/consoles/1' % uuid)
+        response = self._do_delete('servers/{0!s}/consoles/1'.format(uuid))
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_create_backup.py
+++ b/nova/tests/functional/api_sample_tests/test_create_backup.py
@@ -46,6 +46,6 @@ class CreateBackupSamplesJsonTest(test_servers.ServersSampleBase):
     @mock.patch.object(fake._FakeImageService, 'detail', return_value=[])
     def test_post_backup_server(self, mock_method):
         # Get api samples to backup server request.
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'create-backup-req', {})
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_deferred_delete.py
+++ b/nova/tests/functional/api_sample_tests/test_deferred_delete.py
@@ -39,18 +39,18 @@ class DeferredDeleteSampleJsonTests(test_servers.ServersSampleBase):
 
     def test_restore(self):
         uuid = self._post_server()
-        self._do_delete('servers/%s' % uuid)
+        self._do_delete('servers/{0!s}'.format(uuid))
 
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'restore-post-req', {})
         self.assertEqual(202, response.status_code)
         self.assertEqual('', response.content)
 
     def test_force_delete(self):
         uuid = self._post_server()
-        self._do_delete('servers/%s' % uuid)
+        self._do_delete('servers/{0!s}'.format(uuid))
 
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'force-delete-post-req', {})
         self.assertEqual(202, response.status_code)
         self.assertEqual('', response.content)

--- a/nova/tests/functional/api_sample_tests/test_disk_config.py
+++ b/nova/tests/functional/api_sample_tests/test_disk_config.py
@@ -54,7 +54,7 @@ class DiskConfigJsonTest(test_servers.ServersSampleBase):
 
     def test_get_server(self):
         uuid = self._post_server(use_common_server_api_samples=False)
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['access_ip_v4'] = ''
@@ -64,7 +64,7 @@ class DiskConfigJsonTest(test_servers.ServersSampleBase):
     def test_resize_server(self):
         self.flags(allow_resize_to_same_host=True)
         uuid = self._post_server(use_common_server_api_samples=False)
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'server-resize-post-req', {})
         self.assertEqual(202, response.status_code)
         # NOTE(tmello): Resize does not return response body
@@ -77,7 +77,7 @@ class DiskConfigJsonTest(test_servers.ServersSampleBase):
             'image_id': fake.get_valid_image_id(),
             'compute_endpoint': self._get_compute_endpoint(),
         }
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'server-action-rebuild-req', subs)
         subs['hostid'] = '[a-f0-9]+'
         subs['access_ip_v4'] = ''

--- a/nova/tests/functional/api_sample_tests/test_evacuate.py
+++ b/nova/tests/functional/api_sample_tests/test_evacuate.py
@@ -67,7 +67,7 @@ class EvacuateJsonTest(test_servers.ServersSampleBase):
             'nova.compute.manager.ComputeManager._check_instance_exists',
             fake_check_instance_exists)
 
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  server_req, req_subs)
         if server_resp:
             self._verify_response(server_resp, {}, response,

--- a/nova/tests/functional/api_sample_tests/test_extended_availability_zone.py
+++ b/nova/tests/functional/api_sample_tests/test_extended_availability_zone.py
@@ -42,7 +42,7 @@ class ExtendedAvailabilityZoneJsonTests(test_servers.ServersSampleBase):
 
     def test_show(self):
         uuid = self._post_server()
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['access_ip_v4'] = '1.2.3.4'

--- a/nova/tests/functional/api_sample_tests/test_extended_server_attributes.py
+++ b/nova/tests/functional/api_sample_tests/test_extended_server_attributes.py
@@ -43,7 +43,7 @@ class ExtendedServerAttributesJsonTest(test_servers.ServersSampleBase):
     def test_show(self):
         uuid = self._post_server()
 
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['id'] = uuid
@@ -74,7 +74,7 @@ class ExtendedServerAttributesJsonTestV216(ExtendedServerAttributesJsonTest):
     def test_show(self):
         uuid = self._post_server()
 
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['id'] = uuid

--- a/nova/tests/functional/api_sample_tests/test_extended_status.py
+++ b/nova/tests/functional/api_sample_tests/test_extended_status.py
@@ -42,7 +42,7 @@ class ExtendedStatusSampleJsonTests(test_servers.ServersSampleBase):
 
     def test_show(self):
         uuid = self._post_server()
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['access_ip_v4'] = '1.2.3.4'

--- a/nova/tests/functional/api_sample_tests/test_extended_volumes.py
+++ b/nova/tests/functional/api_sample_tests/test_extended_volumes.py
@@ -47,7 +47,7 @@ class ExtendedVolumesSampleJsonTests(test_servers.ServersSampleBase):
         uuid = self._post_server()
         self.stub_out('nova.db.block_device_mapping_get_all_by_instance_uuids',
                       fakes.stub_bdm_get_all_by_instance_uuids)
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['access_ip_v4'] = '1.2.3.4'

--- a/nova/tests/functional/api_sample_tests/test_flavor_access.py
+++ b/nova/tests/functional/api_sample_tests/test_flavor_access.py
@@ -75,7 +75,7 @@ class FlavorAccessSampleJsonTests(api_sample_base.ApiSampleTestBaseV21):
         self._create_flavor()
         self._add_tenant()
         flavor_id = '10'
-        response = self._do_get('flavors/%s/os-flavor-access' % flavor_id)
+        response = self._do_get('flavors/{0!s}/os-flavor-access'.format(flavor_id))
         subs = {
             'flavor_id': flavor_id,
             'tenant_id': 'fake_tenant',
@@ -84,7 +84,7 @@ class FlavorAccessSampleJsonTests(api_sample_base.ApiSampleTestBaseV21):
 
     def test_flavor_access_show(self):
         flavor_id = '1'
-        response = self._do_get('flavors/%s' % flavor_id)
+        response = self._do_get('flavors/{0!s}'.format(flavor_id))
         subs = {
             'flavor_id': flavor_id
         }

--- a/nova/tests/functional/api_sample_tests/test_flavor_rxtx.py
+++ b/nova/tests/functional/api_sample_tests/test_flavor_rxtx.py
@@ -51,7 +51,7 @@ class FlavorRxtxJsonTest(api_sample_base.ApiSampleTestBaseV21):
 
     def test_flavor_rxtx_get(self):
         flavor_id = '1'
-        response = self._do_get('flavors/%s' % flavor_id)
+        response = self._do_get('flavors/{0!s}'.format(flavor_id))
         subs = {
             'flavor_id': flavor_id,
             'flavor_name': 'm1.tiny'

--- a/nova/tests/functional/api_sample_tests/test_floating_ip_dns.py
+++ b/nova/tests/functional/api_sample_tests/test_floating_ip_dns.py
@@ -42,7 +42,7 @@ class FloatingIpDNSTest(api_sample_base.ApiSampleTestBaseV21):
     def _create_or_update(self):
         subs = {'project': self.project,
                 'scope': self.scope}
-        response = self._do_put('os-floating-ip-dns/%s' % self.domain,
+        response = self._do_put('os-floating-ip-dns/{0!s}'.format(self.domain),
                                 'floating-ip-dns-create-or-update-req', subs)
         subs.update({'domain': self.domain})
         self._verify_response('floating-ip-dns-create-or-update-resp', subs,
@@ -50,8 +50,7 @@ class FloatingIpDNSTest(api_sample_base.ApiSampleTestBaseV21):
 
     def _create_or_update_entry(self):
         subs = {'ip': self.ip, 'dns_type': self.dns_type}
-        response = self._do_put('os-floating-ip-dns/%s/entries/%s'
-                                % (self.domain, self.name),
+        response = self._do_put('os-floating-ip-dns/{0!s}/entries/{1!s}'.format(self.domain, self.name),
                                 'floating-ip-dns-create-or-update-entry-req',
                                 subs)
         subs.update({'name': self.name, 'domain': self.domain})
@@ -72,7 +71,7 @@ class FloatingIpDNSTest(api_sample_base.ApiSampleTestBaseV21):
 
     def test_floating_ip_dns_delete(self):
         self._create_or_update()
-        response = self._do_delete('os-floating-ip-dns/%s' % self.domain)
+        response = self._do_delete('os-floating-ip-dns/{0!s}'.format(self.domain))
         self.assertEqual(202, response.status_code)
 
     def test_floating_ip_dns_create_or_update_entry(self):
@@ -80,8 +79,7 @@ class FloatingIpDNSTest(api_sample_base.ApiSampleTestBaseV21):
 
     def test_floating_ip_dns_entry_get(self):
         self._create_or_update_entry()
-        response = self._do_get('os-floating-ip-dns/%s/entries/%s'
-                                % (self.domain, self.name))
+        response = self._do_get('os-floating-ip-dns/{0!s}/entries/{1!s}'.format(self.domain, self.name))
         subs = {'domain': self.domain,
                 'ip': self.ip,
                 'name': self.name}
@@ -90,14 +88,12 @@ class FloatingIpDNSTest(api_sample_base.ApiSampleTestBaseV21):
 
     def test_floating_ip_dns_entry_delete(self):
         self._create_or_update_entry()
-        response = self._do_delete('os-floating-ip-dns/%s/entries/%s'
-                                   % (self.domain, self.name))
+        response = self._do_delete('os-floating-ip-dns/{0!s}/entries/{1!s}'.format(self.domain, self.name))
         self.assertEqual(202, response.status_code)
 
     def test_floating_ip_dns_entry_list(self):
         self._create_or_update_entry()
-        response = self._do_get('os-floating-ip-dns/%s/entries/%s'
-                                % (self.domain, self.ip))
+        response = self._do_get('os-floating-ip-dns/{0!s}/entries/{1!s}'.format(self.domain, self.ip))
         subs = {'domain': self.domain,
                 'ip': self.ip,
                 'name': self.name}

--- a/nova/tests/functional/api_sample_tests/test_floating_ips.py
+++ b/nova/tests/functional/api_sample_tests/test_floating_ips.py
@@ -102,11 +102,11 @@ class FloatingIpsTest(api_sample_base.ApiSampleTestBaseV21):
         self.test_floating_ips_create()
         # NOTE(sdague): the first floating ip will always have 1 as an id,
         # but it would be better if we could get this from the create
-        response = self._do_get('os-floating-ips/%d' % 1)
+        response = self._do_get('os-floating-ips/{0:d}'.format(1))
         self._verify_response('floating-ips-get-resp', {}, response, 200)
 
     def test_floating_ips_delete(self):
         self.test_floating_ips_create()
-        response = self._do_delete('os-floating-ips/%d' % 1)
+        response = self._do_delete('os-floating-ips/{0:d}'.format(1))
         self.assertEqual(202, response.status_code)
         self.assertEqual("", response.content)

--- a/nova/tests/functional/api_sample_tests/test_fping.py
+++ b/nova/tests/functional/api_sample_tests/test_fping.py
@@ -53,5 +53,5 @@ class FpingSampleJsonTests(test_servers.ServersSampleBase):
 
     def test_get_fping_details(self):
         uuid = self._post_server()
-        response = self._do_get('os-fping/%s' % (uuid))
+        response = self._do_get('os-fping/{0!s}'.format((uuid)))
         self._verify_response('fping-get-details-resp', {}, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_hosts.py
+++ b/nova/tests/functional/api_sample_tests/test_hosts.py
@@ -34,24 +34,24 @@ class HostsSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
         return f
 
     def test_host_startup(self):
-        response = self._do_get('os-hosts/%s/startup' % self.compute.host)
+        response = self._do_get('os-hosts/{0!s}/startup'.format(self.compute.host))
         self._verify_response('host-get-startup', {}, response, 200)
 
     def test_host_reboot(self):
-        response = self._do_get('os-hosts/%s/reboot' % self.compute.host)
+        response = self._do_get('os-hosts/{0!s}/reboot'.format(self.compute.host))
         self._verify_response('host-get-reboot', {}, response, 200)
 
     def test_host_shutdown(self):
-        response = self._do_get('os-hosts/%s/shutdown' % self.compute.host)
+        response = self._do_get('os-hosts/{0!s}/shutdown'.format(self.compute.host))
         self._verify_response('host-get-shutdown', {}, response, 200)
 
     def test_host_maintenance(self):
-        response = self._do_put('os-hosts/%s' % self.compute.host,
+        response = self._do_put('os-hosts/{0!s}'.format(self.compute.host),
                                 'host-put-maintenance-req', {})
         self._verify_response('host-put-maintenance-resp', {}, response, 200)
 
     def test_host_get(self):
-        response = self._do_get('os-hosts/%s' % self.compute.host)
+        response = self._do_get('os-hosts/{0!s}'.format(self.compute.host))
         self._verify_response('host-get-resp', {}, response, 200)
 
     def test_hosts_list(self):

--- a/nova/tests/functional/api_sample_tests/test_hypervisors.py
+++ b/nova/tests/functional/api_sample_tests/test_hypervisors.py
@@ -87,7 +87,7 @@ class HypervisorsSampleJsonTests(api_sample_base.ApiSampleTestBaseV21):
         subs = {
             'hypervisor_id': hypervisor_id
         }
-        response = self._do_get('os-hypervisors/%s' % hypervisor_id)
+        response = self._do_get('os-hypervisors/{0!s}'.format(hypervisor_id))
         self._verify_response('hypervisors-show-resp', subs, response, 200)
 
     def test_hypervisors_statistics(self):
@@ -102,7 +102,7 @@ class HypervisorsSampleJsonTests(api_sample_base.ApiSampleTestBaseV21):
         self.stub_out('nova.compute.api.HostAPI.get_host_uptime',
                       fake_get_host_uptime)
         hypervisor_id = '1'
-        response = self._do_get('os-hypervisors/%s/uptime' % hypervisor_id)
+        response = self._do_get('os-hypervisors/{0!s}/uptime'.format(hypervisor_id))
         subs = {
             'hypervisor_id': hypervisor_id,
         }
@@ -156,6 +156,6 @@ class HypervisorsCellsSampleJsonTests(api_sample_base.ApiSampleTestBaseV21):
             fake_get_host_uptime)
 
         hypervisor_id = fake_hypervisor.id
-        response = self._do_get('os-hypervisors/%s/uptime' % hypervisor_id)
+        response = self._do_get('os-hypervisors/{0!s}/uptime'.format(hypervisor_id))
         subs = {'hypervisor_id': str(hypervisor_id)}
         self._verify_response('hypervisors-uptime-resp', subs, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_images.py
+++ b/nova/tests/functional/api_sample_tests/test_images.py
@@ -37,7 +37,7 @@ class ImagesSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
     def test_image_get(self):
         # Get api sample of one single image details request.
         image_id = fake.get_valid_image_id()
-        response = self._do_get('images/%s' % image_id)
+        response = self._do_get('images/{0!s}'.format(image_id))
         subs = {'image_id': image_id}
         self._verify_response('image-get-resp', subs, response, 200)
 
@@ -49,7 +49,7 @@ class ImagesSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
     def test_image_metadata_get(self):
         # Get api sample of an image metadata request.
         image_id = fake.get_valid_image_id()
-        response = self._do_get('images/%s/metadata' % image_id)
+        response = self._do_get('images/{0!s}/metadata'.format(image_id))
         subs = {'image_id': image_id}
         self._verify_response('image-metadata-get-resp', subs, response, 200)
 
@@ -57,28 +57,28 @@ class ImagesSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
         # Get api sample to update metadata of an image metadata request.
         image_id = fake.get_valid_image_id()
         response = self._do_post(
-                'images/%s/metadata' % image_id,
+                'images/{0!s}/metadata'.format(image_id),
                 'image-metadata-post-req', {})
         self._verify_response('image-metadata-post-resp', {}, response, 200)
 
     def test_image_metadata_put(self):
         # Get api sample of image metadata put request.
         image_id = fake.get_valid_image_id()
-        response = self._do_put('images/%s/metadata' %
-                                (image_id), 'image-metadata-put-req', {})
+        response = self._do_put('images/{0!s}/metadata'.format(
+                                (image_id)), 'image-metadata-put-req', {})
         self._verify_response('image-metadata-put-resp', {}, response, 200)
 
     def test_image_meta_key_get(self):
         # Get api sample of an image metadata key request.
         image_id = fake.get_valid_image_id()
         key = "kernel_id"
-        response = self._do_get('images/%s/metadata/%s' % (image_id, key))
+        response = self._do_get('images/{0!s}/metadata/{1!s}'.format(image_id, key))
         self._verify_response('image-meta-key-get', {}, response, 200)
 
     def test_image_meta_key_put(self):
         # Get api sample of image metadata key put request.
         image_id = fake.get_valid_image_id()
         key = "auto_disk_config"
-        response = self._do_put('images/%s/metadata/%s' % (image_id, key),
+        response = self._do_put('images/{0!s}/metadata/{1!s}'.format(image_id, key),
                                 'image-meta-key-put-req', {})
         self._verify_response('image-meta-key-put-resp', {}, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_instance_actions.py
+++ b/nova/tests/functional/api_sample_tests/test_instance_actions.py
@@ -79,8 +79,7 @@ class ServerActionsSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
         fake_request_id = fake_server_actions.FAKE_REQUEST_ID1
         fake_action = self.actions[fake_uuid][fake_request_id]
 
-        response = self._do_get('servers/%s/os-instance-actions/%s' %
-                                (fake_uuid, fake_request_id))
+        response = self._do_get('servers/{0!s}/os-instance-actions/{1!s}'.format(fake_uuid, fake_request_id))
         subs = {}
         subs['action'] = '(reboot)|(resize)'
         subs['instance_uuid'] = str(fake_uuid)
@@ -93,7 +92,7 @@ class ServerActionsSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
 
     def test_instance_actions_list(self):
         fake_uuid = fake_server_actions.FAKE_UUID
-        response = self._do_get('servers/%s/os-instance-actions' % (fake_uuid))
+        response = self._do_get('servers/{0!s}/os-instance-actions'.format((fake_uuid)))
         subs = {}
         subs['action'] = '(reboot)|(resize)'
         subs['integer_id'] = '[0-9]+'

--- a/nova/tests/functional/api_sample_tests/test_instance_usage_audit_log.py
+++ b/nova/tests/functional/api_sample_tests/test_instance_usage_audit_log.py
@@ -37,8 +37,8 @@ class InstanceUsageAuditLogJsonTest(api_sample_base.ApiSampleTestBaseV21):
         return f
 
     def test_show_instance_usage_audit_log(self):
-        response = self._do_get('os-instance_usage_audit_log/%s' %
-                                urllib.quote('2012-07-05 10:00:00'))
+        response = self._do_get('os-instance_usage_audit_log/{0!s}'.format(
+                                urllib.quote('2012-07-05 10:00:00')))
         self._verify_response('inst-usage-audit-log-show-get-resp',
                               {}, response, 200)
 

--- a/nova/tests/functional/api_sample_tests/test_keypairs.py
+++ b/nova/tests/functional/api_sample_tests/test_keypairs.py
@@ -94,14 +94,14 @@ class KeyPairsSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
     def test_keypairs_get(self):
         # Get api sample of key pairs get request.
         key_name = self.test_keypairs_post()
-        response = self._do_get('os-keypairs/%s' % key_name)
+        response = self._do_get('os-keypairs/{0!s}'.format(key_name))
         subs = {'keypair_name': key_name}
         self._verify_response('keypairs-get-resp', subs, response, 200)
 
     def test_keypairs_delete(self):
         # Get api sample of key pairs delete request.
         key_name = self.test_keypairs_post()
-        response = self._do_delete('os-keypairs/%s' % key_name)
+        response = self._do_delete('os-keypairs/{0!s}'.format(key_name))
         self.assertEqual(self.expected_delete_status_code,
                          response.status_code)
 
@@ -202,7 +202,7 @@ class KeyPairsV210SampleJsonTest(KeyPairsSampleJsonTest):
             'user_id': "fake"
         }
         key_name = self._check_keypairs_post(**subs)
-        response = self._do_delete('os-keypairs/%s?user_id=fake' % key_name)
+        response = self._do_delete('os-keypairs/{0!s}?user_id=fake'.format(key_name))
         self.assertEqual(self.expected_delete_status_code,
                          response.status_code)
 

--- a/nova/tests/functional/api_sample_tests/test_lock_server.py
+++ b/nova/tests/functional/api_sample_tests/test_lock_server.py
@@ -42,13 +42,13 @@ class LockServerSamplesJsonTest(test_servers.ServersSampleBase):
 
     def test_post_lock_server(self):
         # Get api samples to lock server request.
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'lock-server', {})
         self.assertEqual(202, response.status_code)
 
     def test_post_unlock_server(self):
         # Get api samples to unlock server request.
         self.test_post_lock_server()
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'unlock-server', {})
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_migrate_server.py
+++ b/nova/tests/functional/api_sample_tests/test_migrate_server.py
@@ -46,7 +46,7 @@ class MigrateServerSamplesJsonTest(test_servers.ServersSampleBase):
     @mock.patch('nova.conductor.manager.ComputeTaskManager._cold_migrate')
     def test_post_migrate(self, mock_cold_migrate):
         # Get api samples to migrate server request.
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'migrate-server', {})
         self.assertEqual(202, response.status_code)
 
@@ -75,7 +75,7 @@ class MigrateServerSamplesJsonTest(test_servers.ServersSampleBase):
             return {'compute_node': [service]}
         self.stub_out("nova.db.service_get_by_compute_host", fake_get_compute)
 
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'live-migrate-server',
                                  {'hostname': self.compute.host})
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_multinic.py
+++ b/nova/tests/functional/api_sample_tests/test_multinic.py
@@ -47,7 +47,7 @@ class MultinicSampleJsonTest(test_servers.ServersSampleBase):
 
     def _add_fixed_ip(self):
         subs = {"networkId": '1'}
-        response = self._do_post('servers/%s/action' % (self.uuid),
+        response = self._do_post('servers/{0!s}/action'.format((self.uuid)),
                                  'multinic-add-fixed-ip-req', subs)
         self.assertEqual(202, response.status_code)
 
@@ -58,6 +58,6 @@ class MultinicSampleJsonTest(test_servers.ServersSampleBase):
         self._add_fixed_ip()
 
         subs = {"ip": "10.0.0.4"}
-        response = self._do_post('servers/%s/action' % (self.uuid),
+        response = self._do_post('servers/{0!s}/action'.format((self.uuid)),
                                  'multinic-remove-fixed-ip-req', subs)
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_networks.py
+++ b/nova/tests/functional/api_sample_tests/test_networks.py
@@ -54,14 +54,14 @@ class NetworksJsonTests(api_sample_base.ApiSampleTestBaseV21):
 
     def test_network_disassociate(self):
         uuid = test_networks.FAKE_NETWORKS[0]['uuid']
-        response = self._do_post('os-networks/%s/action' % uuid,
+        response = self._do_post('os-networks/{0!s}/action'.format(uuid),
                                  'networks-disassociate-req', {})
         self.assertEqual(202, response.status_code)
         self.assertEqual("", response.content)
 
     def test_network_show(self):
         uuid = test_networks.FAKE_NETWORKS[0]['uuid']
-        response = self._do_get('os-networks/%s' % uuid)
+        response = self._do_get('os-networks/{0!s}'.format(uuid))
         self._verify_response('network-show-resp', {}, response, 200)
 
     def test_network_create(self):

--- a/nova/tests/functional/api_sample_tests/test_pause_server.py
+++ b/nova/tests/functional/api_sample_tests/test_pause_server.py
@@ -42,13 +42,13 @@ class PauseServerSamplesJsonTest(test_servers.ServersSampleBase):
 
     def test_post_pause(self):
         # Get api samples to pause server request.
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'pause-server', {})
         self.assertEqual(202, response.status_code)
 
     def test_post_unpause(self):
         # Get api samples to unpause server request.
         self.test_post_pause()
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'unpause-server', {})
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_pci.py
+++ b/nova/tests/functional/api_sample_tests/test_pci.py
@@ -75,7 +75,7 @@ class ExtendedServerPciSampleJsonTest(test_servers.ServersSampleBase):
 
     def test_show(self):
         uuid = self._post_server()
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {'hostid': '[a-f0-9]+'}
         self._verify_response('server-get-resp', subs, response, 200)
 
@@ -147,7 +147,7 @@ class ExtendedHyervisorPciSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
         mock_obj.return_value = self.fake_compute_node
         mock_svc_get.return_value = self.fake_service
         hypervisor_id = 1
-        response = self._do_get('os-hypervisors/%s' % hypervisor_id)
+        response = self._do_get('os-hypervisors/{0!s}'.format(hypervisor_id))
         subs = {
             'hypervisor_id': hypervisor_id,
         }

--- a/nova/tests/functional/api_sample_tests/test_personality.py
+++ b/nova/tests/functional/api_sample_tests/test_personality.py
@@ -31,7 +31,7 @@ class PersonalitySampleJsonTest(test_servers.ServersSampleBase):
             'access_ip_v6': '80fe::'
         }
         uuid = self._post_server(use_common_server_api_samples=False)
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'server-action-rebuild-req', subs)
         subs['hostid'] = '[a-f0-9]+'
         subs['id'] = uuid

--- a/nova/tests/functional/api_sample_tests/test_preserve_ephemeral_rebuild.py
+++ b/nova/tests/functional/api_sample_tests/test_preserve_ephemeral_rebuild.py
@@ -59,7 +59,7 @@ class PreserveEphemeralOnRebuildJsonTest(test_servers.ServersSampleBase):
                                    **kwargs)
         self.stub_out('nova.compute.api.API.rebuild', fake_rebuild)
 
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'server-action-rebuild-preserve-ephemeral',
                                  subs)
         if resp_tpl:

--- a/nova/tests/functional/api_sample_tests/test_quota_classes.py
+++ b/nova/tests/functional/api_sample_tests/test_quota_classes.py
@@ -37,14 +37,14 @@ class QuotaClassesSampleJsonTests(api_sample_base.ApiSampleTestBaseV21):
 
     def test_show_quota_classes(self):
         # Get api sample to show quota classes.
-        response = self._do_get('os-quota-class-sets/%s' % self.set_id)
+        response = self._do_get('os-quota-class-sets/{0!s}'.format(self.set_id))
         subs = {'set_id': self.set_id}
         self._verify_response('quota-classes-show-get-resp', subs,
                               response, 200)
 
     def test_update_quota_classes(self):
         # Get api sample to update quota classes.
-        response = self._do_put('os-quota-class-sets/%s' % self.set_id,
+        response = self._do_put('os-quota-class-sets/{0!s}'.format(self.set_id),
                                 'quota-classes-update-post-req',
                                 {})
         self._verify_response('quota-classes-update-post-resp',

--- a/nova/tests/functional/api_sample_tests/test_remote_consoles.py
+++ b/nova/tests/functional/api_sample_tests/test_remote_consoles.py
@@ -43,7 +43,7 @@ class ConsolesSampleJsonTests(test_servers.ServersSampleBase):
 
     def test_get_vnc_console(self):
         uuid = self._post_server()
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'get-vnc-console-post-req',
                                 {'action': 'os-getVNCConsole'})
         subs = {"url":
@@ -52,7 +52,7 @@ class ConsolesSampleJsonTests(test_servers.ServersSampleBase):
 
     def test_get_spice_console(self):
         uuid = self._post_server()
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'get-spice-console-post-req',
                                 {'action': 'os-getSPICEConsole'})
         subs = {"url":
@@ -62,7 +62,7 @@ class ConsolesSampleJsonTests(test_servers.ServersSampleBase):
 
     def test_get_rdp_console(self):
         uuid = self._post_server()
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'get-rdp-console-post-req',
                                 {'action': 'os-getRDPConsole'})
         subs = {"url":
@@ -72,7 +72,7 @@ class ConsolesSampleJsonTests(test_servers.ServersSampleBase):
 
     def test_get_serial_console(self):
         uuid = self._post_server()
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'get-serial-console-post-req',
                                 {'action': 'os-getSerialConsole'})
         subs = {"url":
@@ -97,7 +97,7 @@ class ConsolesV26SampleJsonTests(test_servers.ServersSampleBase):
         uuid = self._post_server()
 
         body = {'protocol': 'vnc', 'type': 'novnc'}
-        response = self._do_post('servers/%s/remote-consoles' % uuid,
+        response = self._do_post('servers/{0!s}/remote-consoles'.format(uuid),
                                  'create-vnc-console-req', body)
         subs = {"url": self.http_regex}
         self._verify_response('create-vnc-console-resp', subs, response, 200)
@@ -117,7 +117,7 @@ class ConsolesV28SampleJsonTests(test_servers.ServersSampleBase):
         uuid = self._post_server()
 
         body = {'protocol': 'mks', 'type': 'webmks'}
-        response = self._do_post('servers/%s/remote-consoles' % uuid,
+        response = self._do_post('servers/{0!s}/remote-consoles'.format(uuid),
                                  'create-mks-console-req', body)
         subs = {"url": self.http_regex}
         self._verify_response('create-mks-console-resp', subs, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_rescue.py
+++ b/nova/tests/functional/api_sample_tests/test_rescue.py
@@ -47,12 +47,12 @@ class RescueJsonTest(test_servers.ServersSampleBase):
         req_subs = {
             'password': 'MySecretPass'
         }
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'server-rescue-req', req_subs)
         self._verify_response('server-rescue', req_subs, response, 200)
 
     def _unrescue(self, uuid):
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'server-unrescue-req', {})
         self.assertEqual(202, response.status_code)
 
@@ -62,7 +62,7 @@ class RescueJsonTest(test_servers.ServersSampleBase):
         self._rescue(uuid)
 
         # Do a server get to make sure that the 'RESCUE' state is set
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['id'] = uuid
@@ -78,12 +78,12 @@ class RescueJsonTest(test_servers.ServersSampleBase):
             'password': 'MySecretPass',
             'image_ref': '2341-Abc'
         }
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'server-rescue-req-with-image-ref', req_subs)
         self._verify_response('server-rescue', req_subs, response, 200)
 
         # Do a server get to make sure that the 'RESCUE' state is set
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['id'] = uuid
@@ -99,7 +99,7 @@ class RescueJsonTest(test_servers.ServersSampleBase):
         self._unrescue(uuid)
 
         # Do a server get to make sure that the 'ACTIVE' state is back
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['id'] = uuid

--- a/nova/tests/functional/api_sample_tests/test_security_group_default_rules.py
+++ b/nova/tests/functional/api_sample_tests/test_security_group_default_rules.py
@@ -50,6 +50,6 @@ class SecurityGroupDefaultRulesSampleJsonTest(
     def test_security_group_default_rules_show(self):
         self.test_security_group_default_rules_create()
         rule_id = '1'
-        response = self._do_get('os-security-group-default-rules/%s' % rule_id)
+        response = self._do_get('os-security-group-default-rules/{0!s}'.format(rule_id))
         self._verify_response('security-group-default-rules-show-resp',
                               {}, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_security_groups.py
+++ b/nova/tests/functional/api_sample_tests/test_security_groups.py
@@ -101,7 +101,7 @@ class SecurityGroupsJsonTest(test_servers.ServersSampleBase):
 
     def test_server_get(self):
         uuid = self._post_server(use_common_server_api_samples=False)
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['access_ip_v4'] = '1.2.3.4'
@@ -132,7 +132,7 @@ class SecurityGroupsJsonTest(test_servers.ServersSampleBase):
         subs = {
                 'group_name': 'test'
         }
-        return self._do_post('servers/%s/action' % uuid,
+        return self._do_post('servers/{0!s}/action'.format(uuid),
                              'security-group-add-post-req', subs)
 
     def test_security_group_create(self):
@@ -150,13 +150,13 @@ class SecurityGroupsJsonTest(test_servers.ServersSampleBase):
     def test_security_groups_get(self):
         # Get api sample of security groups get request.
         security_group_id = '11111111-1111-1111-1111-111111111111'
-        response = self._do_get('os-security-groups/%s' % security_group_id)
+        response = self._do_get('os-security-groups/{0!s}'.format(security_group_id))
         self._verify_response('security-groups-get-resp', {}, response, 200)
 
     def test_security_groups_list_server(self):
         # Get api sample of security groups for a specific server.
         uuid = self._post_server(use_common_server_api_samples=False)
-        response = self._do_get('servers/%s/os-security-groups' % uuid)
+        response = self._do_get('servers/{0!s}/os-security-groups'.format(uuid))
         self._verify_response('server-security-groups-list-resp',
                               {}, response, 200)
 
@@ -174,7 +174,7 @@ class SecurityGroupsJsonTest(test_servers.ServersSampleBase):
         subs = {
                 'group_name': 'test'
         }
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'security-group-remove-post-req', subs)
         self.assertEqual(202, response.status_code)
         self.assertEqual('', response.content)

--- a/nova/tests/functional/api_sample_tests/test_server_diagnostics.py
+++ b/nova/tests/functional/api_sample_tests/test_server_diagnostics.py
@@ -35,6 +35,6 @@ class ServerDiagnosticsSamplesJsonTest(test_servers.ServersSampleBase):
 
     def test_server_diagnostics_get(self):
         uuid = self._post_server()
-        response = self._do_get('servers/%s/diagnostics' % uuid)
+        response = self._do_get('servers/{0!s}/diagnostics'.format(uuid))
         self._verify_response('server-diagnostics-get-resp', {},
                               response, 200)

--- a/nova/tests/functional/api_sample_tests/test_server_groups.py
+++ b/nova/tests/functional/api_sample_tests/test_server_groups.py
@@ -68,13 +68,13 @@ class ServerGroupsSampleJsonTest(api_sample_base.ApiSampleTestBaseV21):
         subs = {'name': 'test'}
         uuid = self._post_server_group()
         subs['id'] = uuid
-        response = self._do_get('os-server-groups/%s' % uuid)
+        response = self._do_get('os-server-groups/{0!s}'.format(uuid))
 
         self._verify_response('server-groups-get-resp', subs, response, 200)
 
     def test_server_groups_delete(self):
         uuid = self._post_server_group()
-        response = self._do_delete('os-server-groups/%s' % uuid)
+        response = self._do_delete('os-server-groups/{0!s}'.format(uuid))
         self.assertEqual(204, response.status_code)
 
 

--- a/nova/tests/functional/api_sample_tests/test_server_metadata.py
+++ b/nova/tests/functional/api_sample_tests/test_server_metadata.py
@@ -27,7 +27,7 @@ class ServersMetadataJsonTest(test_servers.ServersSampleBase):
 
     def _create_and_set(self, subs):
         uuid = self._post_server()
-        response = self._do_put('/servers/%s/metadata' % uuid,
+        response = self._do_put('/servers/{0!s}/metadata'.format(uuid),
                                 'server-metadata-all-req',
                                 subs)
         self._verify_response('server-metadata-all-resp', subs, response, 200)
@@ -47,7 +47,7 @@ class ServersMetadataJsonTest(test_servers.ServersSampleBase):
         subs = {'value': 'Foo Value'}
         uuid = self._create_and_set(subs)
         subs['value'] = 'Bar Value'
-        response = self._do_post('servers/%s/metadata' % uuid,
+        response = self._do_post('servers/{0!s}/metadata'.format(uuid),
                                  'server-metadata-all-req',
                                  subs)
         self._verify_response('server-metadata-all-resp', subs, response, 200)
@@ -56,7 +56,7 @@ class ServersMetadataJsonTest(test_servers.ServersSampleBase):
         # Test getting all metadata for a server.
         subs = {'value': 'Foo Value'}
         uuid = self._create_and_set(subs)
-        response = self._do_get('servers/%s/metadata' % uuid)
+        response = self._do_get('servers/{0!s}/metadata'.format(uuid))
         self._verify_response('server-metadata-all-resp', subs, response, 200)
 
     def test_metadata_put(self):
@@ -64,7 +64,7 @@ class ServersMetadataJsonTest(test_servers.ServersSampleBase):
         subs = {'value': 'Foo Value'}
         uuid = self._create_and_set(subs)
         subs['value'] = 'Bar Value'
-        response = self._do_put('servers/%s/metadata/foo' % uuid,
+        response = self._do_put('servers/{0!s}/metadata/foo'.format(uuid),
                                 'server-metadata-req',
                                 subs)
         self._verify_response('server-metadata-resp', subs, response, 200)
@@ -73,13 +73,13 @@ class ServersMetadataJsonTest(test_servers.ServersSampleBase):
         # Test getting an individual metadata item for a server.
         subs = {'value': 'Foo Value'}
         uuid = self._create_and_set(subs)
-        response = self._do_get('servers/%s/metadata/foo' % uuid)
+        response = self._do_get('servers/{0!s}/metadata/foo'.format(uuid))
         self._verify_response('server-metadata-resp', subs, response, 200)
 
     def test_metadata_delete(self):
         # Test deleting an individual metadata item for a server.
         subs = {'value': 'Foo Value'}
         uuid = self._create_and_set(subs)
-        response = self._do_delete('servers/%s/metadata/foo' % uuid)
+        response = self._do_delete('servers/{0!s}/metadata/foo'.format(uuid))
         self.assertEqual(204, response.status_code)
         self.assertEqual('', response.content)

--- a/nova/tests/functional/api_sample_tests/test_server_migrations.py
+++ b/nova/tests/functional/api_sample_tests/test_server_migrations.py
@@ -48,10 +48,9 @@ class ServerMigrationsSampleJsonTest(test_servers.ServersSampleBase):
         migration.id = 1
         migration.status = 'running'
         get_by_id_and_instance.return_value = migration
-        self._do_post('servers/%s/action' % self.uuid, 'live-migrate-server',
+        self._do_post('servers/{0!s}/action'.format(self.uuid), 'live-migrate-server',
                       {'hostname': self.compute.host})
-        response = self._do_post('servers/%s/migrations/%s/action'
-                                 % (self.uuid, '3'), 'force_complete', {})
+        response = self._do_post('servers/{0!s}/migrations/{1!s}/action'.format(self.uuid, '3'), 'force_complete', {})
         self.assertEqual(202, response.status_code)
 
     def test_get_migration(self):
@@ -141,8 +140,7 @@ class ServerMigrationsSamplesJsonTestV2_23(test_servers.ServersSampleBase):
         self.instance.create()
 
     def test_get_migration(self):
-        response = self._do_get('servers/%s/migrations/%s' %
-                                (self.fake_migrations[0]["instance_uuid"],
+        response = self._do_get('servers/{0!s}/migrations/{1!s}'.format(self.fake_migrations[0]["instance_uuid"],
                                  self.mig1.id))
         self.assertEqual(200, response.status_code)
 
@@ -151,8 +149,8 @@ class ServerMigrationsSamplesJsonTestV2_23(test_servers.ServersSampleBase):
                               response, 200)
 
     def test_list_migrations(self):
-        response = self._do_get('servers/%s/migrations' %
-                                self.fake_migrations[0]["instance_uuid"])
+        response = self._do_get('servers/{0!s}/migrations'.format(
+                                self.fake_migrations[0]["instance_uuid"]))
         self.assertEqual(200, response.status_code)
 
         self._verify_response('migrations-index',
@@ -187,17 +185,17 @@ class ServerMigrationsSampleJsonTestV2_24(test_servers.ServersSampleBase):
 
     @mock.patch.object(conductor_manager.ComputeTaskManager, '_live_migrate')
     def test_live_migrate_abort(self, _live_migrate):
-        self._do_post('servers/%s/action' % self.uuid, 'live-migrate-server',
+        self._do_post('servers/{0!s}/action'.format(self.uuid), 'live-migrate-server',
                       {'hostname': self.compute.host})
-        uri = 'servers/%s/migrations/%s' % (self.uuid, self.migration.id)
+        uri = 'servers/{0!s}/migrations/{1!s}'.format(self.uuid, self.migration.id)
         response = self._do_delete(uri)
         self.assertEqual(202, response.status_code)
 
     @mock.patch.object(conductor_manager.ComputeTaskManager, '_live_migrate')
     def test_live_migrate_abort_migration_not_found(self, _live_migrate):
-        self._do_post('servers/%s/action' % self.uuid, 'live-migrate-server',
+        self._do_post('servers/{0!s}/action'.format(self.uuid), 'live-migrate-server',
                       {'hostname': self.compute.host})
-        uri = 'servers/%s/migrations/%s' % (self.uuid, '45')
+        uri = 'servers/{0!s}/migrations/{1!s}'.format(self.uuid, '45')
         response = self._do_delete(uri)
         self.assertEqual(404, response.status_code)
 
@@ -205,8 +203,8 @@ class ServerMigrationsSampleJsonTestV2_24(test_servers.ServersSampleBase):
     def test_live_migrate_abort_migration_not_running(self, _live_migrate):
         self.migration.status = 'completed'
         self.migration.save()
-        self._do_post('servers/%s/action' % self.uuid, 'live-migrate-server',
+        self._do_post('servers/{0!s}/action'.format(self.uuid), 'live-migrate-server',
                       {'hostname': self.compute.host})
-        uri = 'servers/%s/migrations/%s' % (self.uuid, self.migration.id)
+        uri = 'servers/{0!s}/migrations/{1!s}'.format(self.uuid, self.migration.id)
         response = self._do_delete(uri)
         self.assertEqual(400, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_server_password.py
+++ b/nova/tests/functional/api_sample_tests/test_server_password.py
@@ -46,11 +46,11 @@ class ServerPasswordSampleJsonTests(test_servers.ServersSampleBase):
         # Mock password since there is no api to set it
         mock_extract_password.return_value = password
         uuid = self._post_server()
-        response = self._do_get('servers/%s/os-server-password' % uuid)
+        response = self._do_get('servers/{0!s}/os-server-password'.format(uuid))
         subs = {'encrypted_password': password.replace('+', '\\+')}
         self._verify_response('get-password-resp', subs, response, 200)
 
     def test_reset_password(self):
         uuid = self._post_server()
-        response = self._do_delete('servers/%s/os-server-password' % uuid)
+        response = self._do_delete('servers/{0!s}/os-server-password'.format(uuid))
         self.assertEqual(204, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_server_usage.py
+++ b/nova/tests/functional/api_sample_tests/test_server_usage.py
@@ -45,7 +45,7 @@ class ServerUsageSampleJsonTest(test_servers.ServersSampleBase):
         self.uuid = self._post_server()
 
     def test_show(self):
-        response = self._do_get('servers/%s' % self.uuid)
+        response = self._do_get('servers/{0!s}'.format(self.uuid))
         subs = {}
         subs['id'] = self.uuid
         subs['hostid'] = '[a-f0-9]+'

--- a/nova/tests/functional/api_sample_tests/test_servers.py
+++ b/nova/tests/functional/api_sample_tests/test_servers.py
@@ -91,7 +91,7 @@ class ServersSampleJsonTest(ServersSampleBase):
 
     def test_servers_get(self):
         uuid = self.test_servers_post()
-        response = self._do_get('servers/%s' % uuid)
+        response = self._do_get('servers/{0!s}'.format(uuid))
         subs = {}
         subs['hostid'] = '[a-f0-9]+'
         subs['id'] = uuid
@@ -138,7 +138,7 @@ class ServersSampleJson219Test(ServersSampleJsonTest):
 
     def test_servers_put(self):
         uuid = self.test_servers_post()
-        response = self._do_put('servers/%s' % uuid, 'server-put-req', {})
+        response = self._do_put('servers/{0!s}'.format(uuid), 'server-put-req', {})
         subs = {
             'image_id': fake.get_valid_image_id(),
             'hostid': '[a-f0-9]+',
@@ -162,7 +162,7 @@ class ServersUpdateSampleJsonTest(ServersSampleBase):
         subs['hostid'] = '[a-f0-9]+'
         subs['access_ip_v4'] = '1.2.3.4'
         subs['access_ip_v6'] = '80fe::'
-        response = self._do_put('servers/%s' % uuid,
+        response = self._do_put('servers/{0!s}'.format(uuid),
                                 'server-update-req', subs)
         self._verify_response('server-update-resp', subs, response, 200)
 
@@ -198,7 +198,7 @@ class ServersActionsJsonTest(ServersSampleBase):
         subs = subs or {}
         subs.update({'action': action,
                      'glance_host': self._get_glance_host()})
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  req_tpl,
                                  subs)
         if resp_tpl:
@@ -231,7 +231,7 @@ class ServersActionsJsonTest(ServersSampleBase):
             'access_ip_v6': '80fe::',
         }
 
-        resp = self._do_post('servers/%s/action' % uuid,
+        resp = self._do_post('servers/{0!s}/action'.format(uuid),
                              'server-action-rebuild', params)
         subs = params.copy()
         del subs['uuid']
@@ -282,7 +282,7 @@ class ServersActionsJson219Test(ServersSampleBase):
             'access_ip_v6': '80fe::',
         }
 
-        resp = self._do_post('servers/%s/action' % uuid,
+        resp = self._do_post('servers/{0!s}/action'.format(uuid),
                              'server-action-rebuild', params)
         subs = params.copy()
         del subs['uuid']
@@ -306,7 +306,7 @@ class ServerStartStopJsonTest(ServersSampleBase):
         return f
 
     def _test_server_action(self, uuid, action, req_tpl):
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  req_tpl,
                                  {'action': action})
         self.assertEqual(202, response.status_code)
@@ -349,7 +349,7 @@ class ServerTriggerCrashDumpJsonTest(ServersSampleBase):
     def test_trigger_crash_dump(self):
         uuid = self._post_server()
 
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  'server-action-trigger-crash-dump',
                                  {})
         self.assertEqual(response.status_code, 202)

--- a/nova/tests/functional/api_sample_tests/test_servers_ips.py
+++ b/nova/tests/functional/api_sample_tests/test_servers_ips.py
@@ -28,11 +28,11 @@ class ServersIpsJsonTest(test_servers.ServersSampleBase):
     def test_get(self):
         # Test getting a server's IP information.
         uuid = self._post_server()
-        response = self._do_get('servers/%s/ips' % uuid)
+        response = self._do_get('servers/{0!s}/ips'.format(uuid))
         self._verify_response('server-ips-resp', {}, response, 200)
 
     def test_get_by_network(self):
         # Test getting a server's IP information by network id.
         uuid = self._post_server()
-        response = self._do_get('servers/%s/ips/private' % uuid)
+        response = self._do_get('servers/{0!s}/ips/private'.format(uuid))
         self._verify_response('server-ips-network-resp', {}, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_shelve.py
+++ b/nova/tests/functional/api_sample_tests/test_shelve.py
@@ -39,7 +39,7 @@ class ShelveJsonTest(test_servers.ServersSampleBase):
         CONF.set_override('shelved_offload_time', -1)
 
     def _test_server_action(self, uuid, template, action):
-        response = self._do_post('servers/%s/action' % uuid,
+        response = self._do_post('servers/{0!s}/action'.format(uuid),
                                  template, {'action': action})
         self.assertEqual(202, response.status_code)
         self.assertEqual("", response.content)

--- a/nova/tests/functional/api_sample_tests/test_simple_tenant_usage.py
+++ b/nova/tests/functional/api_sample_tests/test_simple_tenant_usage.py
@@ -60,14 +60,14 @@ class SimpleTenantUsageSampleJsonTest(test_servers.ServersSampleBase):
 
     def test_get_tenants_usage(self):
         # Get api sample to get all tenants usage request.
-        response = self._do_get('os-simple-tenant-usage?%s' % (
-                                                urllib.urlencode(self.query)))
+        response = self._do_get('os-simple-tenant-usage?{0!s}'.format((
+                                                urllib.urlencode(self.query))))
         self._verify_response('simple-tenant-usage-get', {}, response, 200)
 
     def test_get_tenant_usage_details(self):
         # Get api sample to get specific tenant usage request.
         tenant_id = astb.PROJECT_ID
-        response = self._do_get('os-simple-tenant-usage/%s?%s' % (tenant_id,
+        response = self._do_get('os-simple-tenant-usage/{0!s}?{1!s}'.format(tenant_id,
                                                 urllib.urlencode(self.query)))
         self._verify_response('simple-tenant-usage-get-specific', {},
                               response, 200)

--- a/nova/tests/functional/api_sample_tests/test_suspend_server.py
+++ b/nova/tests/functional/api_sample_tests/test_suspend_server.py
@@ -41,13 +41,13 @@ class SuspendServerSamplesJsonTest(test_servers.ServersSampleBase):
 
     def test_post_suspend(self):
         # Get api samples to suspend server request.
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'server-suspend', {})
         self.assertEqual(202, response.status_code)
 
     def test_post_resume(self):
         # Get api samples to server resume request.
         self.test_post_suspend()
-        response = self._do_post('servers/%s/action' % self.uuid,
+        response = self._do_post('servers/{0!s}/action'.format(self.uuid),
                                  'server-resume', {})
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_sample_tests/test_tenant_networks.py
+++ b/nova/tests/functional/api_sample_tests/test_tenant_networks.py
@@ -63,7 +63,7 @@ class TenantNetworksJsonTests(api_sample_base.ApiSampleTestBaseV21):
     def test_delete_network(self):
         response = self._do_post('os-tenant-networks', "networks-post-req", {})
         net = jsonutils.loads(response.content)
-        response = self._do_delete('os-tenant-networks/%s' %
-                                                net["network"]["id"])
+        response = self._do_delete('os-tenant-networks/{0!s}'.format(
+                                                net["network"]["id"]))
         self.assertEqual(202, response.status_code)
         self.assertEqual("", response.content)

--- a/nova/tests/functional/api_sample_tests/test_used_limits.py
+++ b/nova/tests/functional/api_sample_tests/test_used_limits.py
@@ -61,5 +61,5 @@ class UsedLimitsSamplesJsonTest(api_sample_base.ApiSampleTestBaseV21):
         # TODO(sdague): if we split the admin tests out the whole
         # class doesn't need admin api enabled.
         tenant_id = 'openstack'
-        response = self._do_get('limits?tenant_id=%s' % tenant_id)
+        response = self._do_get('limits?tenant_id={0!s}'.format(tenant_id))
         self._verify_response(self.template, {}, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_virtual_interfaces.py
+++ b/nova/tests/functional/api_sample_tests/test_virtual_interfaces.py
@@ -45,7 +45,7 @@ class VirtualInterfacesJsonTest(test_servers.ServersSampleBase):
     def test_vifs_list(self):
         uuid = self._post_server()
 
-        response = self._do_get('servers/%s/os-virtual-interfaces' % uuid)
+        response = self._do_get('servers/{0!s}/os-virtual-interfaces'.format(uuid))
 
         subs = {'mac_addr': '(?:[a-f0-9]{2}:){5}[a-f0-9]{2}'}
         self._verify_response(self.template, subs, response, 200)

--- a/nova/tests/functional/api_sample_tests/test_volumes.py
+++ b/nova/tests/functional/api_sample_tests/test_volumes.py
@@ -175,7 +175,7 @@ class VolumesSampleJsonTest(test_servers.ServersSampleBase):
                 'volume_desc': "Volume Description",
         }
         vol_id = self._get_volume_id()
-        response = self._do_get('os-volumes/%s' % vol_id)
+        response = self._do_get('os-volumes/{0!s}'.format(vol_id))
         self._verify_response('os-volumes-get-resp', subs, response, 200)
 
     def test_volumes_index(self):
@@ -202,7 +202,7 @@ class VolumesSampleJsonTest(test_servers.ServersSampleBase):
     def test_volumes_delete(self):
         self._post_volume()
         vol_id = self._get_volume_id()
-        response = self._do_delete('os-volumes/%s' % vol_id)
+        response = self._do_delete('os-volumes/{0!s}'.format(vol_id))
         self.assertEqual(202, response.status_code)
         self.assertEqual('', response.content)
 
@@ -277,8 +277,7 @@ class VolumeAttachmentsSample(test_servers.ServersSampleBase):
             'device': device_name
         }
         server_id = self._post_server()
-        response = self._do_post('servers/%s/os-volume_attachments'
-                                 % server_id,
+        response = self._do_post('servers/{0!s}/os-volume_attachments'.format(server_id),
                                  'attach-volume-to-server-req', subs)
 
         self._verify_response('attach-volume-to-server-resp', subs,
@@ -288,8 +287,7 @@ class VolumeAttachmentsSample(test_servers.ServersSampleBase):
         server_id = self._post_server()
         self._stub_db_bdms_get_all_by_instance(server_id)
 
-        response = self._do_get('servers/%s/os-volume_attachments'
-                                % server_id)
+        response = self._do_get('servers/{0!s}/os-volume_attachments'.format(server_id))
         self._verify_response('list-volume-attachments-resp', {},
                               response, 200)
 
@@ -298,8 +296,7 @@ class VolumeAttachmentsSample(test_servers.ServersSampleBase):
         attach_id = "a26887c6-c47b-4654-abb5-dfadf7d3f803"
         self._stub_db_bdms_get_all_by_instance(server_id)
         self._stub_compute_api_get()
-        response = self._do_get('servers/%s/os-volume_attachments/%s'
-                                % (server_id, attach_id))
+        response = self._do_get('servers/{0!s}/os-volume_attachments/{1!s}'.format(server_id, attach_id))
         self._verify_response('volume-attachment-detail-resp', {},
                               response, 200)
 
@@ -311,8 +308,7 @@ class VolumeAttachmentsSample(test_servers.ServersSampleBase):
         self.stub_out('nova.volume.cinder.API.get', fakes.stub_volume_get)
         self.stub_out('nova.compute.api.API.detach_volume',
                       lambda *a, **k: None)
-        response = self._do_delete('servers/%s/os-volume_attachments/%s'
-                                   % (server_id, attach_id))
+        response = self._do_delete('servers/{0!s}/os-volume_attachments/{1!s}'.format(server_id, attach_id))
         self.assertEqual(202, response.status_code)
         self.assertEqual('', response.content)
 
@@ -328,8 +324,7 @@ class VolumeAttachmentsSample(test_servers.ServersSampleBase):
         self.stub_out('nova.volume.cinder.API.get', fakes.stub_volume_get)
         self.stub_out('nova.compute.api.API.swap_volume',
                       lambda *a, **k: None)
-        response = self._do_put('servers/%s/os-volume_attachments/%s'
-                                % (server_id, attach_id),
+        response = self._do_put('servers/{0!s}/os-volume_attachments/{1!s}'.format(server_id, attach_id),
                                 'update-volume-req',
                                 subs)
         self.assertEqual(202, response.status_code)

--- a/nova/tests/functional/api_samples_test_base.py
+++ b/nova/tests/functional/api_samples_test_base.py
@@ -158,13 +158,11 @@ class ApiSampleTestBase(integrated_helpers._IntegratedTestBase):
             elif result == u'':
                 pass  # TODO(auggy): known issue Bug#1544720
             else:
-                raise NoMatch('%(result_str)s: Expected None, got %(result)s.'
-                        % {'result_str': result_str, 'result': result})
+                raise NoMatch('{result_str!s}: Expected None, got {result!s}.'.format(**{'result_str': result_str, 'result': result}))
         # dictionary
         elif isinstance(expected, dict):
             if not isinstance(result, dict):
-                raise NoMatch('%(result_str)s: %(result)s is not a dict.'
-                        % {'result_str': result_str, 'result': result})
+                raise NoMatch('{result_str!s}: {result!s} is not a dict.'.format(**{'result_str': result_str, 'result': result}))
             ex_keys = sorted(expected.keys())
             res_keys = sorted(result.keys())
             if ex_keys != res_keys:
@@ -191,8 +189,8 @@ class ApiSampleTestBase(integrated_helpers._IntegratedTestBase):
         elif isinstance(expected, list):
             if not isinstance(result, list):
                 raise NoMatch(
-                        '%(result_str)s: %(result)s is not a list.' %
-                        {'result_str': result_str, 'result': result})
+                        '{result_str!s}: {result!s} is not a list.'.format(**
+                        {'result_str': result_str, 'result': result}))
 
             expected = expected[:]
             extra = []
@@ -215,8 +213,8 @@ class ApiSampleTestBase(integrated_helpers._IntegratedTestBase):
                 error.extend([repr(o) for o in expected])
 
             if extra:
-                error.append('Extra list items in %(result_str)s:' %
-                             {'result_str': result_str})
+                error.append('Extra list items in {result_str!s}:'.format(**
+                             {'result_str': result_str}))
                 error.extend([repr(o) for o in extra])
 
             if error:
@@ -225,7 +223,7 @@ class ApiSampleTestBase(integrated_helpers._IntegratedTestBase):
         elif isinstance(expected, six.string_types) and '%' in expected:
             # NOTE(vish): escape stuff for regex
             for char in '[]<>?':
-                expected = expected.replace(char, '\\%s' % char)
+                expected = expected.replace(char, '\\{0!s}'.format(char))
             # NOTE(vish): special handling of subs that are not quoted. We are
             #             expecting an int but we had to pass in a string
             #             so the json would parse properly.
@@ -234,7 +232,7 @@ class ApiSampleTestBase(integrated_helpers._IntegratedTestBase):
                 expected = expected.replace('int:', '')
 
             expected = expected % self.subs
-            expected = '^%s$' % expected
+            expected = '^{0!s}$'.format(expected)
             match = re.match(expected, result)
             if not match:
                 raise NoMatch(
@@ -287,8 +285,7 @@ class ApiSampleTestBase(integrated_helpers._IntegratedTestBase):
 
         else:
             raise ValueError(
-                'Unexpected type %(expected_type)s'
-                % {'expected_type': type(expected)})
+                'Unexpected type {expected_type!s}'.format(**{'expected_type': type(expected)}))
 
         return matched_value
 
@@ -394,7 +391,7 @@ class ApiSampleTestBase(integrated_helpers._IntegratedTestBase):
         return {
             'isotime': isotime_re,
             'strtime': strtime_re,
-            'strtime_or_none': r'None|%s' % strtime_re,
+            'strtime_or_none': r'None|{0!s}'.format(strtime_re),
             'xmltime': xmltime_re,
             'password': '[0-9a-zA-Z]{1,12}',
             'ip': '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}',
@@ -429,7 +426,7 @@ class ApiSampleTestBase(integrated_helpers._IntegratedTestBase):
         # NOTE(sdague): "openstack" is stand in for project_id, it
         # should be more generic in future.
         if self._project_id:
-            return '%s/%s' % (self._get_host(), PROJECT_ID)
+            return '{0!s}/{1!s}'.format(self._get_host(), PROJECT_ID)
         else:
             return self._get_host()
 
@@ -437,10 +434,10 @@ class ApiSampleTestBase(integrated_helpers._IntegratedTestBase):
         # NOTE(sdague): "openstack" is stand in for project_id, it
         # should be more generic in future.
         if self._project_id:
-            return '%s/%s/%s' % (self._get_host(), self.api_major_version,
+            return '{0!s}/{1!s}/{2!s}'.format(self._get_host(), self.api_major_version,
                                  PROJECT_ID)
         else:
-            return '%s/%s' % (self._get_host(), self.api_major_version)
+            return '{0!s}/{1!s}'.format(self._get_host(), self.api_major_version)
 
     def _get_response(self, url, method, body=None, strip_version=False,
                       headers=None):

--- a/nova/tests/functional/db/api/test_migrations.py
+++ b/nova/tests/functional/db/api/test_migrations.py
@@ -124,7 +124,7 @@ class NovaAPIMigrationsWalk(test_migrations.WalkVersionsMixin):
 
     def migrate_up(self, version, with_data=False):
         if with_data:
-            check = getattr(self, '_check_%03d' % version, None)
+            check = getattr(self, '_check_{0:03d}'.format(version), None)
             if version not in self._skippable_migrations():
                 self.assertIsNotNone(check,
                                      ('API DB Migration %i does not have a '
@@ -136,12 +136,11 @@ class NovaAPIMigrationsWalk(test_migrations.WalkVersionsMixin):
 
     def assertColumnExists(self, engine, table_name, column):
         self.assertTrue(db_utils.column_exists(engine, table_name, column),
-                'Column %s.%s does not exist' % (table_name, column))
+                'Column {0!s}.{1!s} does not exist'.format(table_name, column))
 
     def assertIndexExists(self, engine, table_name, index):
         self.assertTrue(db_utils.index_exists(engine, table_name, index),
-                        'Index %s on table %s does not exist' %
-                        (index, table_name))
+                        'Index {0!s} on table {1!s} does not exist'.format(index, table_name))
 
     def assertUniqueConstraintExists(self, engine, table_name, columns):
         inspector = reflection.Inspector.from_engine(engine)

--- a/nova/tests/functional/db/test_archive.py
+++ b/nova/tests/functional/db/test_archive.py
@@ -79,7 +79,7 @@ class TestDatabaseArchive(test_servers.ServersTestBase):
         # key back to the instances table.
         actions = self.api.get_instance_actions(server_id)
         self.assertTrue(len(actions),
-                        'No instance actions for server: %s' % server_id)
+                        'No instance actions for server: {0!s}'.format(server_id))
         self._delete_server(server_id)
         # Verify we have the soft deleted instance in the database.
         admin_context = context.get_admin_context(read_deleted='yes')
@@ -89,7 +89,7 @@ class TestDatabaseArchive(test_servers.ServersTestBase):
         self.assertNotEqual(0, instance.deleted)
         # Verify we have some system_metadata since we'll check that later.
         self.assertTrue(len(instance.system_metadata),
-                        'No system_metadata for instance: %s' % server_id)
+                        'No system_metadata for instance: {0!s}'.format(server_id))
         # Now try and archive the soft deleted records.
         results = db.archive_deleted_rows(max_rows=100)
         # verify system_metadata was dropped

--- a/nova/tests/functional/db/test_request_spec.py
+++ b/nova/tests/functional/db/test_request_spec.py
@@ -52,7 +52,7 @@ class RequestSpecTestCase(test.NoDBTestCase):
         spec = self._create_spec()
 
         old_az = spec.availability_zone
-        spec.availability_zone = '%s-new' % old_az
+        spec.availability_zone = '{0!s}-new'.format(old_az)
         spec.save()
         db_spec = self.spec_obj.get_by_instance_uuid(self.context,
                 spec.instance_uuid)

--- a/nova/tests/functional/integrated_helpers.py
+++ b/nova/tests/functional/integrated_helpers.py
@@ -56,7 +56,7 @@ def generate_new_element(items, prefix, numeric=False):
             candidate = prefix + generate_random_alphanumeric(8)
         if candidate not in items:
             return candidate
-        LOG.debug("Random collision on %s" % candidate)
+        LOG.debug("Random collision on {0!s}".format(candidate))
 
 
 class _IntegratedTestBase(test.TestCase):
@@ -131,13 +131,13 @@ class _IntegratedTestBase(test.TestCase):
 
     def _get_any_image_href(self):
         image = self.api.get_images()[0]
-        LOG.debug("Image: %s" % image)
+        LOG.debug("Image: {0!s}".format(image))
 
         if self._image_ref_parameter in image:
             image_href = image[self._image_ref_parameter]
         else:
             image_href = image['id']
-            image_href = 'http://fake.server/%s' % image_href
+            image_href = 'http://fake.server/{0!s}'.format(image_href)
         return image_href
 
     def _build_minimal_create_server_request(self):
@@ -150,9 +150,8 @@ class _IntegratedTestBase(test.TestCase):
 
         # Set a valid flavorId
         flavor = self.api.get_flavors()[0]
-        LOG.debug("Using flavor: %s" % flavor)
-        server[self._flavor_ref_parameter] = ('http://fake.server/%s'
-                                              % flavor['id'])
+        LOG.debug("Using flavor: {0!s}".format(flavor))
+        server[self._flavor_ref_parameter] = ('http://fake.server/{0!s}'.format(flavor['id']))
 
         # Set a valid server name
         server_name = self.get_unused_server_name()
@@ -193,22 +192,21 @@ class _IntegratedTestBase(test.TestCase):
 
         image_href = self._get_any_image_href()
         image = self.api.get_images()[0]
-        LOG.debug("Image: %s" % image)
+        LOG.debug("Image: {0!s}".format(image))
 
         if self._image_ref_parameter in image:
             image_href = image[self._image_ref_parameter]
         else:
             image_href = image['id']
-            image_href = 'http://fake.server/%s' % image_href
+            image_href = 'http://fake.server/{0!s}'.format(image_href)
 
         # We now have a valid imageId
         server[self._image_ref_parameter] = image_href
 
         # Set a valid flavorId
         flavor = self.api.get_flavor(flavor_id)
-        LOG.debug("Using flavor: %s" % flavor)
-        server[self._flavor_ref_parameter] = ('http://fake.server/%s'
-                                              % flavor['id'])
+        LOG.debug("Using flavor: {0!s}".format(flavor))
+        server[self._flavor_ref_parameter] = ('http://fake.server/{0!s}'.format(flavor['id']))
 
         # Set a valid server name
         server_name = self.get_unused_server_name()

--- a/nova/tests/functional/libvirt/test_numa_servers.py
+++ b/nova/tests/functional/libvirt/test_numa_servers.py
@@ -95,7 +95,7 @@ class NUMAServersTest(ServersTestBase):
         post = {'server': good_server}
 
         created_server = self.api.post_server(post)
-        LOG.debug("created_server: %s" % created_server)
+        LOG.debug("created_server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
         created_server_id = created_server['id']
 

--- a/nova/tests/functional/regressions/test_bug_1548980.py
+++ b/nova/tests/functional/regressions/test_bug_1548980.py
@@ -82,7 +82,7 @@ class TestServerGet(test.TestCase):
             except client.OpenStackApiNotFoundException:
                 break
         else:
-            self.fail('Timed out waiting to delete server: %s' % server['id'])
+            self.fail('Timed out waiting to delete server: {0!s}'.format(server['id']))
         servers = self.admin_api.get_servers(search_opts={'deleted': 1})
         self.assertEqual(1, len(servers))
         self.assertEqual(server['id'], servers[0]['id'])

--- a/nova/tests/functional/test_extensions.py
+++ b/nova/tests/functional/test_extensions.py
@@ -43,5 +43,5 @@ class ExtensionsTest(integrated_helpers._IntegratedTestBase):
         # Simple check that fox-n-socks works.
         response = self.api.api_request('/foxnsocks')
         foxnsocks = response.content
-        LOG.debug("foxnsocks: %s" % foxnsocks)
+        LOG.debug("foxnsocks: {0!s}".format(foxnsocks))
         self.assertEqual('Try to say this Mr. Knox, sir...', foxnsocks)

--- a/nova/tests/functional/test_server_group.py
+++ b/nova/tests/functional/test_server_group.py
@@ -107,8 +107,7 @@ class ServerGroupTestBase(test.TestCase):
                                 expected_status='ACTIVE', flavor=None):
         server = self._build_minimal_create_server_request('some-server')
         if flavor:
-            server[self._flavor_ref_parameter] = ('http://fake.server/%s'
-                                                  % flavor['id'])
+            server[self._flavor_ref_parameter] = ('http://fake.server/{0!s}'.format(flavor['id']))
         post = {'server': server,
                 'os:scheduler_hints': {'group': group['id']}}
         created_server = self.api.post_server(post)
@@ -129,15 +128,14 @@ class ServerGroupTestBase(test.TestCase):
             image_href = image[self._image_ref_parameter]
         else:
             image_href = image['id']
-            image_href = 'http://fake.server/%s' % image_href
+            image_href = 'http://fake.server/{0!s}'.format(image_href)
 
         # We now have a valid imageId
         server[self._image_ref_parameter] = image_href
 
         # Set a valid flavorId
         flavor = self.api.get_flavors()[1]
-        server[self._flavor_ref_parameter] = ('http://fake.server/%s'
-                                              % flavor['id'])
+        server[self._flavor_ref_parameter] = ('http://fake.server/{0!s}'.format(flavor['id']))
         server['name'] = name
         return server
 

--- a/nova/tests/functional/test_servers.py
+++ b/nova/tests/functional/test_servers.py
@@ -64,7 +64,7 @@ class ServersTestBase(integrated_helpers._IntegratedTestBase):
                 LOG.debug("Got 404, proceeding")
                 break
 
-            LOG.debug("Found_server=%s" % found_server)
+            LOG.debug("Found_server={0!s}".format(found_server))
 
             # TODO(justinsb): Mock doesn't yet do accurate state changes
             # if found_server['status'] != 'deleting':
@@ -95,7 +95,7 @@ class ServersTest(ServersTestBase):
         # Simple check that listing servers works.
         servers = self.api.get_servers()
         for server in servers:
-            LOG.debug("server: %s" % server)
+            LOG.debug("server: {0!s}".format(server))
 
     def test_create_server_with_error(self):
         # Create a server which will enter error state.
@@ -162,7 +162,7 @@ class ServersTest(ServersTestBase):
         server['name'] = good_server['name']
 
         created_server = self.api.post_server(post)
-        LOG.debug("created_server: %s" % created_server)
+        LOG.debug("created_server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
         created_server_id = created_server['id']
 
@@ -204,7 +204,7 @@ class ServersTest(ServersTestBase):
         server = self._build_minimal_create_server_request()
 
         created_server = self.api.post_server({'server': server})
-        LOG.debug("created_server: %s" % created_server)
+        LOG.debug("created_server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
         created_server_id = created_server['id']
 
@@ -240,7 +240,7 @@ class ServersTest(ServersTestBase):
         server = self._build_minimal_create_server_request()
 
         created_server = self.api.post_server({'server': server})
-        LOG.debug("created_server: %s" % created_server)
+        LOG.debug("created_server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
         created_server_id = created_server['id']
 
@@ -273,7 +273,7 @@ class ServersTest(ServersTestBase):
         server = self._build_minimal_create_server_request()
 
         created_server = self.api.post_server({'server': server})
-        LOG.debug("created_server: %s" % created_server)
+        LOG.debug("created_server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
         created_server_id = created_server['id']
 
@@ -306,13 +306,13 @@ class ServersTest(ServersTestBase):
 
         metadata = {}
         for i in range(30):
-            metadata['key_%s' % i] = 'value_%s' % i
+            metadata['key_{0!s}'.format(i)] = 'value_{0!s}'.format(i)
 
         server['metadata'] = metadata
 
         post = {'server': server}
         created_server = self.api.post_server(post)
-        LOG.debug("created_server: %s" % created_server)
+        LOG.debug("created_server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
         created_server_id = created_server['id']
 
@@ -349,12 +349,12 @@ class ServersTest(ServersTestBase):
 
         metadata = {}
         for i in range(30):
-            metadata['key_%s' % i] = 'value_%s' % i
+            metadata['key_{0!s}'.format(i)] = 'value_{0!s}'.format(i)
 
         server_post['server']['metadata'] = metadata
 
         created_server = self.api.post_server(server_post)
-        LOG.debug("created_server: %s" % created_server)
+        LOG.debug("created_server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
         created_server_id = created_server['id']
 
@@ -372,7 +372,7 @@ class ServersTest(ServersTestBase):
         post['rebuild'].update(self._get_access_ips_params())
 
         self.api.post_server_action(created_server_id, post)
-        LOG.debug("rebuilt server: %s" % created_server)
+        LOG.debug("rebuilt server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
 
         found_server = self.api.get_server(created_server_id)
@@ -391,7 +391,7 @@ class ServersTest(ServersTestBase):
         }
 
         self.api.post_server_action(created_server_id, post)
-        LOG.debug("rebuilt server: %s" % created_server)
+        LOG.debug("rebuilt server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
 
         found_server = self.api.get_server(created_server_id)
@@ -412,7 +412,7 @@ class ServersTest(ServersTestBase):
         # Create a server
         server = self._build_minimal_create_server_request()
         created_server = self.api.post_server({'server': server})
-        LOG.debug("created_server: %s" % created_server)
+        LOG.debug("created_server: {0!s}".format(created_server))
         server_id = created_server['id']
         self.assertTrue(server_id)
 
@@ -488,7 +488,7 @@ class ServersTest(ServersTestBase):
         post = {'server': server}
 
         created_server = self.api.post_server(post)
-        LOG.debug("created_server: %s" % created_server)
+        LOG.debug("created_server: {0!s}".format(created_server))
         self.assertTrue(created_server['id'])
         created_server_id = created_server['id']
 
@@ -524,7 +524,7 @@ class ServersTestV219(ServersTestBase):
         server = {'server': {'name': new_name}}
         if set_desc:
             server['server']['description'] = desc
-        self.api.api_put('/servers/%s' % server_id, server,
+        self.api.api_put('/servers/{0!s}'.format(server_id), server,
                          headers=self._headers)
 
     def _rebuild_server(self, server_id, set_desc = True, desc = None):
@@ -540,7 +540,7 @@ class ServersTestV219(ServersTestBase):
         post['rebuild'].update(self._get_access_ips_params())
         if set_desc:
             post['rebuild']['description'] = desc
-        self.api.api_post('/servers/%s/action' % server_id, post,
+        self.api.api_post('/servers/{0!s}/action'.format(server_id), post,
                           headers=self._headers)
 
     def _create_server_and_verify(self, set_desc = True, expected_desc = None):
@@ -569,7 +569,7 @@ class ServersTestV219(ServersTestBase):
                                    desc_in_resp = True):
         # Calls GET on the servers and verifies that the description
         # is set as expected in the response, or not set at all.
-        response = self.api.api_get('/servers/%s' % server_id,
+        response = self.api.api_get('/servers/{0!s}'.format(server_id),
                                     headers=self._headers)
         found_server = response.body['server']
         self.assertEqual(server_id, found_server['id'])

--- a/nova/tests/functional/wsgi/test_flavor_manage.py
+++ b/nova/tests/functional/wsgi/test_flavor_manage.py
@@ -28,7 +28,7 @@ from nova.tests.unit import policy_fixture
 
 def rand_flavor(**kwargs):
     flav = {
-        'name': 'name-%s' % helper.generate_random_alphanumeric(10),
+        'name': 'name-{0!s}'.format(helper.generate_random_alphanumeric(10)),
         'id': helper.generate_random_alphanumeric(10),
         'ram': int(helper.generate_random_numeric(2)) + 1,
         'disk': int(helper.generate_random_numeric(3)),
@@ -97,7 +97,7 @@ class FlavorManageFullstack(test.TestCase):
         for k, v in six.iteritems(mapping):
             if k in flav:
                 self.assertEqual(flav[k], flavdb[v],
-                                 "%s != %s" % (flav, flavdb))
+                                 "{0!s} != {1!s}".format(flav, flavdb))
 
     def assertFlavorAPIEqual(self, flav, flavapi):
         # for all keys in the flavor, ensure they are correctly set in
@@ -105,21 +105,21 @@ class FlavorManageFullstack(test.TestCase):
         for k, v in six.iteritems(flav):
             if k in flavapi:
                 self.assertEqual(flav[k], flavapi[k],
-                                 "%s != %s" % (flav, flavapi))
+                                 "{0!s} != {1!s}".format(flav, flavapi))
             else:
-                self.fail("Missing key: %s in flavor: %s" % (k, flavapi))
+                self.fail("Missing key: {0!s} in flavor: {1!s}".format(k, flavapi))
 
     def assertFlavorInList(self, flav, flavlist):
         for item in flavlist['flavors']:
             if flav['id'] == item['id']:
                 self.assertEqual(flav['name'], item['name'])
                 return
-        self.fail("%s not found in %s" % (flav, flavlist))
+        self.fail("{0!s} not found in {1!s}".format(flav, flavlist))
 
     def assertFlavorNotInList(self, flav, flavlist):
         for item in flavlist['flavors']:
             if flav['id'] == item['id']:
-                self.fail("%s found in %s" % (flav, flavlist))
+                self.fail("{0!s} found in {1!s}".format(flav, flavlist))
 
     def test_flavor_manage_func_negative(self):
         """Test flavor manage edge conditions.
@@ -174,7 +174,7 @@ class FlavorManageFullstack(test.TestCase):
         # create a deleted flavor
         new_flav = {'flavor': rand_flavor()}
         self.api.api_post('flavors', new_flav)
-        self.api.api_delete('flavors/%s' % new_flav['flavor']['id'])
+        self.api.api_delete('flavors/{0!s}'.format(new_flav['flavor']['id']))
 
         # deleted flavor should not show up in a list
         resp = self.api.api_get('flavors')
@@ -219,12 +219,12 @@ class FlavorManageFullstack(test.TestCase):
         self.assertFlavorInList(flav1['flavor'], resp.body)
 
         # Delete flavor and ensure it was removed from the database
-        self.api.api_delete('flavors/%s' % flav1['flavor']['id'])
+        self.api.api_delete('flavors/{0!s}'.format(flav1['flavor']['id']))
         self.assertRaises(ex.FlavorNotFound,
                           objects.Flavor.get_by_flavor_id,
                           ctx, flav1['flavor']['id'])
 
-        resp = self.api.api_delete('flavors/%s' % flav1['flavor']['id'],
+        resp = self.api.api_delete('flavors/{0!s}'.format(flav1['flavor']['id']),
                                    check_response_status=False)
         self.assertEqual(404, resp.status)
 
@@ -248,7 +248,7 @@ class FlavorManageFullstack(test.TestCase):
         self.api.api_post('flavors', flav1)
 
         # Ensure user can't delete flavors from our cloud
-        resp = self.user_api.api_delete('flavors/%s' % flav1['flavor']['id'],
+        resp = self.user_api.api_delete('flavors/{0!s}'.format(flav1['flavor']['id']),
                                         check_response_status=False)
         self.assertEqual(403, resp.status)
         # ... and ensure that we didn't actually delete the flavor,

--- a/nova/tests/functional/wsgi/test_secgroup.py
+++ b/nova/tests/functional/wsgi/test_secgroup.py
@@ -62,21 +62,20 @@ class SecgroupsFullstack(testscenarios.WithScenarios, test.TestCase):
         server = {}
 
         image = self.api.get_images()[0]
-        LOG.info("Image: %s" % image)
+        LOG.info("Image: {0!s}".format(image))
 
         if self._image_ref_parameter in image:
             image_href = image[self._image_ref_parameter]
         else:
             image_href = image['id']
-            image_href = 'http://fake.server/%s' % image_href
+            image_href = 'http://fake.server/{0!s}'.format(image_href)
 
         # We now have a valid imageId
         server[self._image_ref_parameter] = image_href
 
         # Set a valid flavorId
         flavor = self.api.get_flavors()[1]
-        server[self._flavor_ref_parameter] = ('http://fake.server/%s'
-                                              % flavor['id'])
+        server[self._flavor_ref_parameter] = ('http://fake.server/{0!s}'.format(flavor['id']))
         server['name'] = name
         return server
 

--- a/nova/tests/unit/api/openstack/common.py
+++ b/nova/tests/unit/api/openstack/common.py
@@ -23,7 +23,7 @@ def webob_factory(url):
     base_url = url
 
     def web_request(url, method=None, body=None):
-        req = webob.Request.blank("%s%s" % (base_url, url))
+        req = webob.Request.blank("{0!s}{1!s}".format(base_url, url))
         if method:
             req.content_type = "application/json"
             req.method = method

--- a/nova/tests/unit/api/openstack/compute/admin_only_action_common.py
+++ b/nova/tests/unit/api/openstack/compute/admin_only_action_common.py
@@ -136,9 +136,8 @@ class CommonMixin(object):
                                controller_function,
                                self.req, instance.uuid,
                                body=body_map)
-        self.assertIn("Cannot \'%(action)s\' instance %(id)s"
-                      % {'action': exception_arg or method,
-                         'id': instance.uuid}, ex.explanation)
+        self.assertIn("Cannot \'{action!s}\' instance {id!s}".format(**{'action': exception_arg or method,
+                         'id': instance.uuid}), ex.explanation)
         # Do these here instead of tearDown because this method is called
         # more than once for the same test case
         self.mox.VerifyAll()

--- a/nova/tests/unit/api/openstack/compute/legacy_v2/test_extensions.py
+++ b/nova/tests/unit/api/openstack/compute/legacy_v2/test_extensions.py
@@ -289,7 +289,7 @@ class ExtensionControllerTest(ExtensionTestCase):
                 'links': []}, fox_ext)
 
         for ext in data['extensions']:
-            url = '/fake/extensions/%s' % ext['alias']
+            url = '/fake/extensions/{0!s}'.format(ext['alias'])
             request = webob.Request.blank(url)
             response = request.get_response(app)
             output = jsonutils.loads(response.body)
@@ -613,7 +613,7 @@ class ExtensionControllerIdFormatTest(test.NoDBTestCase):
                                                     BounceController())
         manager = StubExtensionManager(res_ext)
         app = compute.APIRouter(manager)
-        request = webob.Request.blank("/fake/bounce/%s" % test_id)
+        request = webob.Request.blank("/fake/bounce/{0!s}".format(test_id))
         response = request.get_response(app)
         return response.body
 

--- a/nova/tests/unit/api/openstack/compute/legacy_v2/test_servers.py
+++ b/nova/tests/unit/api/openstack/compute/legacy_v2/test_servers.py
@@ -133,7 +133,7 @@ class Base64ValidationTest(test.TestCase):
     def test_decode_base64_whitespace(self):
         value = b"A random string"
         encoded = base64.b64encode(value).decode("ascii")
-        white = "\n \n%s\t%s\n" % (encoded[:2], encoded[2:])
+        white = "\n \n{0!s}\t{1!s}\n".format(encoded[:2], encoded[2:])
         result = self.controller._decode_base64(white)
         self.assertEqual(value, result)
 
@@ -145,7 +145,7 @@ class Base64ValidationTest(test.TestCase):
     def test_decode_base64_illegal_bytes(self):
         value = b"A random string"
         encoded = base64.b64encode(value).decode("ascii")
-        white = ">\x01%s*%s()" % (encoded[:2], encoded[2:])
+        white = ">\x01{0!s}*{1!s}()".format(encoded[:2], encoded[2:])
         result = self.controller._decode_base64(white)
         self.assertIsNone(result)
 
@@ -250,7 +250,7 @@ class ServersControllerTest(ControllerTest):
         self.assertEqual([(None, None, port, None)], res.as_tuples())
 
     def test_get_server_by_uuid(self):
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         res_dict = self.controller.show(req, FAKE_UUID)
         self.assertEqual(FAKE_UUID, res_dict['server']['id'])
 
@@ -267,7 +267,7 @@ class ServersControllerTest(ControllerTest):
                                           project_id=project_id,
                                           host='fake_host')
 
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         with mock.patch.object(compute_api.API, 'get') as mock_get:
             mock_get.side_effect = return_instance_with_host
             server1 = self.controller.show(req, FAKE_UUID)
@@ -321,11 +321,11 @@ class ServersControllerTest(ControllerTest):
                 "links": [
                     {
                         "rel": "self",
-                        "href": "http://localhost/v2/fake/servers/%s" % uuid,
+                        "href": "http://localhost/v2/fake/servers/{0!s}".format(uuid),
                     },
                     {
                         "rel": "bookmark",
-                        "href": "http://localhost/fake/servers/%s" % uuid,
+                        "href": "http://localhost/fake/servers/{0!s}".format(uuid),
                     },
                 ],
             }
@@ -337,7 +337,7 @@ class ServersControllerTest(ControllerTest):
         flavor_bookmark = "http://localhost/fake/flavors/2"
 
         uuid = FAKE_UUID
-        req = fakes.HTTPRequest.blank('/v2/fake/servers/%s' % uuid)
+        req = fakes.HTTPRequest.blank('/v2/fake/servers/{0!s}'.format(uuid))
         res_dict = self.controller.show(req, uuid)
 
         expected_server = self._get_server_data_dict(uuid,
@@ -359,7 +359,7 @@ class ServersControllerTest(ControllerTest):
                        lambda api, *a, **k: new_return_server(*a, **k))
 
         uuid = FAKE_UUID
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % uuid)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(uuid))
         res_dict = self.controller.show(req, uuid)
         expected_server = self._get_server_data_dict(uuid,
                                                      image_bookmark,
@@ -379,7 +379,7 @@ class ServersControllerTest(ControllerTest):
                        lambda api, *a, **k: new_return_server(*a, **k))
 
         uuid = FAKE_UUID
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % uuid)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(uuid))
         res_dict = self.controller.show(req, uuid)
         expected_server = self._get_server_data_dict(uuid,
                                                      image_bookmark,
@@ -419,7 +419,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get',
                        lambda api, *a, **k: return_server(*a, **k))
 
-        req = fakes.HTTPRequest.blank('/fake/servers/%s/ips' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}/ips'.format(FAKE_UUID))
         res_dict = self.ips_controller.index(req, FAKE_UUID)
 
         expected = {
@@ -444,7 +444,7 @@ class ServersControllerTest(ControllerTest):
             self.assertEqual(label, labels[index])
 
     def test_get_server_addresses_nonexistent_network(self):
-        url = '/fake/servers/%s/ips/network_0' % FAKE_UUID
+        url = '/fake/servers/{0!s}/ips/network_0'.format(FAKE_UUID)
         req = fakes.HTTPRequest.blank(url)
         self.assertRaises(webob.exc.HTTPNotFound, self.ips_controller.show,
                           req, FAKE_UUID, 'network_0')
@@ -456,7 +456,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get', fake_instance_get)
 
         server_id = str(uuid.uuid4())
-        req = fakes.HTTPRequest.blank('/fake/servers/%s/ips' % server_id)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}/ips'.format(server_id))
         self.assertRaises(webob.exc.HTTPNotFound,
                           self.ips_controller.index, req, server_id)
 
@@ -476,7 +476,7 @@ class ServersControllerTest(ControllerTest):
 
         i = 0
         for s in res_dict['servers']:
-            self.assertEqual('server%d' % (i + 1), s.get('name'))
+            self.assertEqual('server{0:d}'.format((i + 1)), s.get('name'))
             i += 1
 
     def test_get_server_list_with_reservation_id_empty(self):
@@ -486,7 +486,7 @@ class ServersControllerTest(ControllerTest):
 
         i = 0
         for s in res_dict['servers']:
-            self.assertEqual('server%d' % (i + 1), s.get('name'))
+            self.assertEqual('server{0:d}'.format((i + 1)), s.get('name'))
             i += 1
 
     def test_get_server_list_with_reservation_id_details(self):
@@ -496,7 +496,7 @@ class ServersControllerTest(ControllerTest):
 
         i = 0
         for s in res_dict['servers']:
-            self.assertEqual('server%d' % (i + 1), s.get('name'))
+            self.assertEqual('server{0:d}'.format((i + 1)), s.get('name'))
             i += 1
 
     def test_get_server_list(self):
@@ -506,17 +506,17 @@ class ServersControllerTest(ControllerTest):
         self.assertEqual(5, len(res_dict['servers']))
         for i, s in enumerate(res_dict['servers']):
             self.assertEqual(fakes.get_fake_uuid(i), s['id'])
-            self.assertEqual('server%d' % (i + 1), s['name'])
+            self.assertEqual('server{0:d}'.format((i + 1)), s['name'])
             self.assertIsNone(s.get('image', None))
 
             expected_links = [
                 {
                     "rel": "self",
-                    "href": "http://localhost/v2/fake/servers/%s" % s['id'],
+                    "href": "http://localhost/v2/fake/servers/{0!s}".format(s['id']),
                 },
                 {
                     "rel": "bookmark",
-                    "href": "http://localhost/fake/servers/%s" % s['id'],
+                    "href": "http://localhost/fake/servers/{0!s}".format(s['id']),
                 },
             ]
 
@@ -612,13 +612,13 @@ class ServersControllerTest(ControllerTest):
                           self.controller.index, req)
 
     def test_get_servers_with_marker(self):
-        url = '/v2/fake/servers?marker=%s' % fakes.get_fake_uuid(2)
+        url = '/v2/fake/servers?marker={0!s}'.format(fakes.get_fake_uuid(2))
         req = fakes.HTTPRequest.blank(url)
         servers = self.controller.index(req)['servers']
         self.assertEqual(["server4", "server5"], [s['name'] for s in servers])
 
     def test_get_servers_with_limit_and_marker(self):
-        url = '/v2/fake/servers?limit=2&marker=%s' % fakes.get_fake_uuid(1)
+        url = '/v2/fake/servers?limit=2&marker={0!s}'.format(fakes.get_fake_uuid(1))
         req = fakes.HTTPRequest.blank(url)
         servers = self.controller.index(req)['servers']
         self.assertEqual(['server3', 'server4'], [s['name'] for s in servers])
@@ -1123,7 +1123,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get_all', fake_get_all)
 
         params = 'changes-since=2011-01-24T17:08:01Z'
-        req = fakes.HTTPRequest.blank('/fake/servers?%s' % params)
+        req = fakes.HTTPRequest.blank('/fake/servers?{0!s}'.format(params))
         servers = self.controller.index(req)['servers']
 
         self.assertEqual(1, len(servers))
@@ -1131,7 +1131,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_get_servers_allows_changes_since_bad_value(self):
         params = 'changes-since=asdf'
-        req = fakes.HTTPRequest.blank('/fake/servers?%s' % params)
+        req = fakes.HTTPRequest.blank('/fake/servers?{0!s}'.format(params))
         self.assertRaises(webob.exc.HTTPBadRequest, self.controller.index, req)
 
     def test_get_servers_admin_filters_as_user(self):
@@ -1159,7 +1159,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get_all', fake_get_all)
 
         query_str = "name=foo&ip=10.*&status=active&unknown_option=meow"
-        req = fakes.HTTPRequest.blank('/fake/servers?%s' % query_str)
+        req = fakes.HTTPRequest.blank('/fake/servers?{0!s}'.format(query_str))
         res = self.controller.index(req)
 
         servers = res['servers']
@@ -1190,7 +1190,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get_all', fake_get_all)
 
         query_str = "name=foo&ip=10.*&status=active&unknown_option=meow"
-        req = fakes.HTTPRequest.blank('/fake/servers?%s' % query_str,
+        req = fakes.HTTPRequest.blank('/fake/servers?{0!s}'.format(query_str),
                                       use_admin_context=True)
         servers = self.controller.index(req)['servers']
 
@@ -1269,7 +1269,7 @@ class ServersControllerTest(ControllerTest):
         for i, s in enumerate(res_dict['servers']):
             self.assertEqual(fakes.get_fake_uuid(i), s['id'])
             self.assertEqual('', s['hostId'])
-            self.assertEqual('server%d' % (i + 1), s['name'])
+            self.assertEqual('server{0:d}'.format((i + 1)), s['name'])
             self.assertEqual(expected_image, s['image'])
             self.assertEqual(expected_flavor, s['flavor'])
             self.assertEqual('BUILD', s['status'])
@@ -1305,7 +1305,7 @@ class ServersControllerTest(ControllerTest):
         for i, s in enumerate(server_list):
             self.assertEqual(fakes.get_fake_uuid(i), s['id'])
             self.assertEqual(host_ids[i % 2], s['hostId'])
-            self.assertEqual('server%d' % (i + 1), s['name'])
+            self.assertEqual('server{0:d}'.format((i + 1)), s['name'])
 
     @mock.patch.object(compute_api.API, 'get_all')
     def test_get_servers_remove_non_search_options(self, get_all_mock):
@@ -1327,9 +1327,9 @@ class ServersControllerUpdateTest(ControllerTest):
         if options:
             self.stubs.Set(compute_api.API, 'get',
                            fakes.fake_compute_get(**options))
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
-        req.content_type = 'application/%s' % content_type
+        req.content_type = 'application/{0!s}'.format(content_type)
         req.body = jsonutils.dump_as_bytes(body)
         return req
 
@@ -1433,7 +1433,7 @@ class ServersControllerUpdateTest(ControllerTest):
         #        self.stub_out('nova.db.instance_get',
         #                return_server_with_attributes(name='server_test'))
 
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
         req.content_type = "application/json"
         req.body = jsonutils.dump_as_bytes(body)
@@ -1486,7 +1486,7 @@ class ServersControllerDeleteTest(ControllerTest):
 
     def _create_delete_request(self, uuid):
         fakes.stub_out_instance_quota(self, 0, 10)
-        req = fakes.HTTPRequest.blank('/v2/fake/servers/%s' % uuid)
+        req = fakes.HTTPRequest.blank('/v2/fake/servers/{0!s}'.format(uuid))
         req.method = 'DELETE'
         return req
 
@@ -1577,7 +1577,7 @@ class ServersControllerDeleteTest(ControllerTest):
 
     def test_delete_server_instance_if_not_launched(self):
         self.flags(reclaim_instance_interval=3600)
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'DELETE'
 
         self.server_delete_called = False
@@ -1600,7 +1600,7 @@ class ServersControllerDeleteTest(ControllerTest):
 
 class ServersControllerRebuildInstanceTest(ControllerTest):
     image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-    image_href = 'http://localhost/v2/fake/images/%s' % image_uuid
+    image_href = 'http://localhost/v2/fake/images/{0!s}'.format(image_uuid)
 
     def setUp(self):
         super(ServersControllerRebuildInstanceTest, self).setUp()
@@ -1765,7 +1765,7 @@ class ServerStatusTest(test.TestCase):
         self.controller = servers.Controller(self.ext_mgr)
 
     def _get_with_state(self, vm_state, task_state=None):
-        request = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        request = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         with mock.patch.object(self.controller.compute_api, 'get') as get:
             get.side_effect = fakes.fake_compute_get(
                 vm_state=vm_state,
@@ -1773,7 +1773,7 @@ class ServerStatusTest(test.TestCase):
             return self.controller.show(request, FAKE_UUID)
 
     def _req_with_policy_fail(self, policy_rule_name):
-        rule = {'compute:%s' % policy_rule_name: 'role:admin'}
+        rule = {'compute:{0!s}'.format(policy_rule_name): 'role:admin'}
         policy.set_rules(oslo_policy.Rules.from_dict(rule))
         return fakes.HTTPRequest.blank('/fake/servers/1234/action')
 
@@ -1868,7 +1868,7 @@ class ServersControllerCreateTest(test.TestCase):
         def instance_create(context, inst):
             inst_type = flavors.get_flavor_by_flavor_id(3)
             image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-            def_image_ref = 'http://localhost/images/%s' % image_uuid
+            def_image_ref = 'http://localhost/images/{0!s}'.format(image_uuid)
             self.instance_cache_num += 1
             instance = fake_instance.fake_db_instance(**{
                 'id': self.instance_cache_num,
@@ -2113,7 +2113,7 @@ class ServersControllerCreateTest(test.TestCase):
                           self._test_create_extra, params, no_image=True)
 
     def test_create_instance_image_ref_is_bookmark(self):
-        image_href = 'http://localhost/fake/images/%s' % self.image_uuid
+        image_href = 'http://localhost/fake/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
         res = self.controller.create(self.req, self.body).obj
@@ -2123,7 +2123,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_image_ref_is_invalid(self):
         image_uuid = 'this_is_not_a_valid_uuid'
-        image_href = 'http://localhost/fake/images/%s' % image_uuid
+        image_href = 'http://localhost/fake/images/{0!s}'.format(image_uuid)
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
         self.assertRaises(webob.exc.HTTPBadRequest, self.controller.create,
@@ -2304,7 +2304,7 @@ class ServersControllerCreateTest(test.TestCase):
     def test_create_instance_numa_topology_wrong(self, numa_constraints_mock):
         numa_constraints_mock.side_effect = (
                 exception.ImageNUMATopologyIncomplete)
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
         self.assertRaises(webob.exc.HTTPBadRequest,
@@ -2836,12 +2836,12 @@ class ServersControllerCreateTest(test.TestCase):
                           self.controller.create, self.req, self.body)
 
     def test_create_location(self):
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
         robj = self.controller.create(self.req, self.body)
         instance = self.instance_cache_by_uuid.values()[0]
-        selfhref = 'http://localhost/v2/fake/servers/%s' % instance['uuid']
+        selfhref = 'http://localhost/v2/fake/servers/{0!s}'.format(instance['uuid'])
         self.assertEqual(selfhref, robj['Location'])
 
     def _do_test_create_instance_above_quota(self, resource, allowed, quota,
@@ -3025,7 +3025,7 @@ class ServersControllerCreateTestWithMock(test.TestCase):
             self._test_create_extra(params)
             self.fail()
         except webob.exc.HTTPBadRequest as ex:
-            self.assertEqual('Invalid fixed IP address (%s)' % address,
+            self.assertEqual('Invalid fixed IP address ({0!s})'.format(address),
                              ex.explanation)
         self.assertFalse(create_mock.called)
 
@@ -3073,8 +3073,8 @@ class ServersViewBuilderTest(test.TestCase):
                     self.request.context,
                     expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
                     **db_inst)
-        self.self_link = "http://localhost/v2/fake/servers/%s" % self.uuid
-        self.bookmark_link = "http://localhost/fake/servers/%s" % self.uuid
+        self.self_link = "http://localhost/v2/fake/servers/{0!s}".format(self.uuid)
+        self.bookmark_link = "http://localhost/fake/servers/{0!s}".format(self.uuid)
         self.expected_detailed_server = {
             "server": {
                 "id": self.uuid,

--- a/nova/tests/unit/api/openstack/compute/test_admin_actions.py
+++ b/nova/tests/unit/api/openstack/compute/test_admin_actions.py
@@ -77,8 +77,8 @@ class AdminActionsPolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." %
-            rule.popitem()[0], exc.format_message())
+            "Policy doesn't allow {0!s} to be performed.".format(
+            rule.popitem()[0]), exc.format_message())
 
     def test_reset_network_policy_failed(self):
         rule = {"os_compute_api:os-admin-actions:reset_network":

--- a/nova/tests/unit/api/openstack/compute/test_admin_password.py
+++ b/nova/tests/unit/api/openstack/compute/test_admin_password.py
@@ -162,5 +162,5 @@ class AdminPasswordPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized, self.controller.change_password,
             self.req, fakes.FAKE_UUID, body=body)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_agents.py
+++ b/nova/tests/unit/api/openstack/compute/test_agents.py
@@ -381,7 +381,7 @@ class AgentsPolicyEnforcementV21(test.NoDBTestCase):
                             'url': 'xxx://xxxx/xxx/xxx',
                             'md5hash': 'add6bb58e139be103324d04d82d8f545'}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_index_policy_failed(self):
@@ -391,7 +391,7 @@ class AgentsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_delete_policy_failed(self):
@@ -401,7 +401,7 @@ class AgentsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.delete, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_update_policy_failed(self):
@@ -414,5 +414,5 @@ class AgentsPolicyEnforcementV21(test.NoDBTestCase):
                            'url': 'xxx://xxxx/xxx/xxx',
                            'md5hash': 'add6bb58e139be103324d04d82d8f545'}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_attach_interfaces.py
+++ b/nova/tests/unit/api/openstack/compute/test_attach_interfaces.py
@@ -492,7 +492,7 @@ class AttachInterfacesPolicyEnforcementv21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % self.rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(self.rule_name),
             exc.format_message())
 
     def test_show_attach_interfaces_policy_failed(self):
@@ -500,7 +500,7 @@ class AttachInterfacesPolicyEnforcementv21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.show, self.req, fakes.FAKE_UUID, FAKE_PORT_ID1)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % self.rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(self.rule_name),
             exc.format_message())
 
     def test_create_attach_interfaces_policy_failed(self):
@@ -508,7 +508,7 @@ class AttachInterfacesPolicyEnforcementv21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.create, self.req, fakes.FAKE_UUID, body={})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % self.rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(self.rule_name),
             exc.format_message())
 
     def test_delete_attach_interfaces_policy_failed(self):
@@ -516,5 +516,5 @@ class AttachInterfacesPolicyEnforcementv21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.delete, self.req, fakes.FAKE_UUID, FAKE_PORT_ID1)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % self.rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(self.rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_availability_zone.py
+++ b/nova/tests/unit/api/openstack/compute/test_availability_zone.py
@@ -205,7 +205,7 @@ class ServersControllerCreateTestV21(test.TestCase):
         def instance_create(context, inst):
             inst_type = flavors.get_flavor_by_flavor_id(3)
             image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-            def_image_ref = 'http://localhost/images/%s' % image_uuid
+            def_image_ref = 'http://localhost/images/{0!s}'.format(image_uuid)
             self.instance_cache_num += 1
             instance = fake_instance.fake_db_instance(**{
                 'id': self.instance_cache_num,

--- a/nova/tests/unit/api/openstack/compute/test_cloudpipe.py
+++ b/nova/tests/unit/api/openstack/compute/test_cloudpipe.py
@@ -176,7 +176,7 @@ class CloudpipePolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_list_policy_failed(self):

--- a/nova/tests/unit/api/openstack/compute/test_config_drive.py
+++ b/nova/tests/unit/api/openstack/compute/test_config_drive.py
@@ -117,7 +117,7 @@ class ServersControllerCreateTestV21(test.TestCase):
         def instance_create(context, inst):
             inst_type = flavors.get_flavor_by_flavor_id(3)
             image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-            def_image_ref = 'http://localhost/images/%s' % image_uuid
+            def_image_ref = 'http://localhost/images/{0!s}'.format(image_uuid)
             self.instance_cache_num += 1
             instance = fake_instance.fake_db_instance(**{
                 'id': self.instance_cache_num,

--- a/nova/tests/unit/api/openstack/compute/test_console_output.py
+++ b/nova/tests/unit/api/openstack/compute/test_console_output.py
@@ -174,5 +174,5 @@ class ConsoleOutpuPolicyEnforcementV21(test.NoDBTestCase):
             self.controller.get_console_output, req, fakes.FAKE_UUID,
             body=body)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_consoles.py
+++ b/nova/tests/unit/api/openstack/compute/test_consoles.py
@@ -79,9 +79,9 @@ def stub_instance(id, user_id='fake', project_id='fake', host=None,
         key_data = ''
 
     # ReservationID isn't sent back, hack it in there.
-    server_name = name or "server%s" % id
+    server_name = name or "server{0!s}".format(id)
     if reservation_id != "":
-        server_name = "reservation_%s" % (reservation_id, )
+        server_name = "reservation_{0!s}".format(reservation_id )
 
     instance = {
         "id": int(id),
@@ -132,7 +132,7 @@ class ConsolesControllerTestV21(test.NoDBTestCase):
         self.stub_out('nova.db.instance_get_by_uuid',
                       self.instance_db.return_server_by_uuid)
         self.uuid = str(stdlib_uuid.uuid4())
-        self.url = '/v2/fake/servers/%s/consoles' % self.uuid
+        self.url = '/v2/fake/servers/{0!s}/consoles'.format(self.uuid)
         self._set_up_controller()
 
     def _set_up_controller(self):

--- a/nova/tests/unit/api/openstack/compute/test_create_backup.py
+++ b/nova/tests/unit/api/openstack/compute/test_create_backup.py
@@ -398,5 +398,5 @@ class CreateBackupPolicyEnforcementv21(test.NoDBTestCase):
             self.controller._create_backup, self.req, fakes.FAKE_UUID,
             body=body)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_deferred_delete.py
+++ b/nova/tests/unit/api/openstack/compute/test_deferred_delete.py
@@ -162,7 +162,7 @@ class DeferredDeletePolicyEnforcementV21(test.NoDBTestCase):
             self.controller._restore, self.req, fakes.FAKE_UUID,
             body={'restore': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_force_delete_policy_failed(self):
@@ -173,5 +173,5 @@ class DeferredDeletePolicyEnforcementV21(test.NoDBTestCase):
             self.controller._force_delete, self.req, fakes.FAKE_UUID,
             body={'forceDelete': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_disk_config.py
+++ b/nova/tests/unit/api/openstack/compute/test_disk_config.py
@@ -164,13 +164,13 @@ class DiskConfigTestCaseV21(test.TestCase):
 
     def test_show_server(self):
         req = fakes.HTTPRequest.blank(
-            '/fake/servers/%s' % MANUAL_INSTANCE_UUID)
+            '/fake/servers/{0!s}'.format(MANUAL_INSTANCE_UUID))
         res = req.get_response(self.app)
         server_dict = jsonutils.loads(res.body)['server']
         self.assertDiskConfig(server_dict, 'MANUAL')
 
         req = fakes.HTTPRequest.blank(
-            '/fake/servers/%s' % AUTO_INSTANCE_UUID)
+            '/fake/servers/{0!s}'.format(AUTO_INSTANCE_UUID))
         res = req.get_response(self.app)
         server_dict = jsonutils.loads(res.body)['server']
         self.assertDiskConfig(server_dict, 'AUTO')
@@ -323,7 +323,7 @@ class DiskConfigTestCaseV21(test.TestCase):
 
     def _test_update_server_disk_config(self, uuid, disk_config):
         req = fakes.HTTPRequest.blank(
-            '/fake/servers/%s' % uuid)
+            '/fake/servers/{0!s}'.format(uuid))
         req.method = 'PUT'
         req.content_type = 'application/json'
         body = {'server': {API_DISK_CONFIG: disk_config}}
@@ -341,7 +341,7 @@ class DiskConfigTestCaseV21(test.TestCase):
     def test_update_server_invalid_disk_config(self):
         # Return BadRequest if user passes an invalid diskConfig value.
         req = fakes.HTTPRequest.blank(
-            '/fake/servers/%s' % MANUAL_INSTANCE_UUID)
+            '/fake/servers/{0!s}'.format(MANUAL_INSTANCE_UUID))
         req.method = 'PUT'
         req.content_type = 'application/json'
         body = {'server': {API_DISK_CONFIG: 'server_test'}}
@@ -356,7 +356,7 @@ class DiskConfigTestCaseV21(test.TestCase):
 
     def _test_rebuild_server_disk_config(self, uuid, disk_config):
         req = fakes.HTTPRequest.blank(
-            '/fake/servers/%s/action' % uuid)
+            '/fake/servers/{0!s}/action'.format(uuid))
         req.method = 'POST'
         req.content_type = 'application/json'
         body = {"rebuild": {
@@ -400,7 +400,7 @@ class DiskConfigTestCaseV21(test.TestCase):
 
     def test_rebuild_server_with_auto_disk_config(self):
         req = fakes.HTTPRequest.blank(
-            '/fake/servers/%s/action' % AUTO_INSTANCE_UUID)
+            '/fake/servers/{0!s}/action'.format(AUTO_INSTANCE_UUID))
         req.method = 'POST'
         req.content_type = 'application/json'
         body = {"rebuild": {
@@ -421,7 +421,7 @@ class DiskConfigTestCaseV21(test.TestCase):
 
     def test_resize_server_with_auto_disk_config(self):
         req = fakes.HTTPRequest.blank(
-            '/fake/servers/%s/action' % AUTO_INSTANCE_UUID)
+            '/fake/servers/{0!s}/action'.format(AUTO_INSTANCE_UUID))
         req.method = 'POST'
         req.content_type = 'application/json'
         body = {"resize": {

--- a/nova/tests/unit/api/openstack/compute/test_evacuate.py
+++ b/nova/tests/unit/api/openstack/compute/test_evacuate.py
@@ -292,7 +292,7 @@ class EvacuatePolicyEnforcementv21(test.NoDBTestCase):
             self.controller._evacuate, req, fakes.FAKE_UUID,
             body=body)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
 

--- a/nova/tests/unit/api/openstack/compute/test_extended_availability_zone.py
+++ b/nova/tests/unit/api/openstack/compute/test_extended_availability_zone.py
@@ -101,7 +101,7 @@ class ExtendedAvailabilityZoneTestV21(test.TestCase):
         return jsonutils.loads(body).get('servers')
 
     def assertAvailabilityZone(self, server, az):
-        self.assertEqual(server.get('%savailability_zone' % self.prefix),
+        self.assertEqual(server.get('{0!s}availability_zone'.format(self.prefix)),
                          az)
 
     def test_show_no_host_az(self):

--- a/nova/tests/unit/api/openstack/compute/test_extended_ips.py
+++ b/nova/tests/unit/api/openstack/compute/test_extended_ips.py
@@ -129,12 +129,12 @@ class ExtendedIpsTestV21(test.TestCase):
         results = []
         for ip in self._get_ips(server):
             results.append({'address': ip.get('addr'),
-                            'type': ip.get('%stype' % self.prefix)})
+                            'type': ip.get('{0!s}type'.format(self.prefix))})
 
         self.assertEqual(ALL_IPS, sorted(results))
 
     def test_show(self):
-        url = '/v2/fake/servers/%s' % UUID3
+        url = '/v2/fake/servers/{0!s}'.format(UUID3)
         res = self._make_request(url)
 
         self.assertEqual(res.status_int, 200)

--- a/nova/tests/unit/api/openstack/compute/test_extended_ips_mac.py
+++ b/nova/tests/unit/api/openstack/compute/test_extended_ips_mac.py
@@ -88,7 +88,7 @@ for cache in NW_CACHE:
                 sanitized['mac_address'] = cache['address']
                 sanitized.pop('type')
                 ALL_IPS.append(sanitized)
-ALL_IPS.sort(key=lambda x: '%s-%s' % (x['address'], x['mac_address']))
+ALL_IPS.sort(key=lambda x: '{0!s}-{1!s}'.format(x['address'], x['mac_address']))
 
 
 def fake_compute_get(*args, **kwargs):
@@ -106,7 +106,7 @@ def fake_compute_get_all(*args, **kwargs):
 
 class ExtendedIpsMacTestV21(test.TestCase):
     content_type = 'application/json'
-    prefix = '%s:' % extended_ips_mac.Extended_ips_mac.alias
+    prefix = '{0!s}:'.format(extended_ips_mac.Extended_ips_mac.alias)
 
     def setUp(self):
         super(ExtendedIpsMacTestV21, self).setUp()
@@ -135,12 +135,12 @@ class ExtendedIpsMacTestV21(test.TestCase):
         results = []
         for ip in self._get_ips(server):
             results.append({'address': ip.get('addr'),
-                            'mac_address': ip.get('%smac_addr' % self.prefix)})
+                            'mac_address': ip.get('{0!s}mac_addr'.format(self.prefix))})
 
         self.assertEqual(ALL_IPS, sorted(results))
 
     def test_show(self):
-        url = '/v2/fake/servers/%s' % UUID3
+        url = '/v2/fake/servers/{0!s}'.format(UUID3)
         res = self._make_request(url)
 
         self.assertEqual(res.status_int, 200)
@@ -157,7 +157,7 @@ class ExtendedIpsMacTestV21(test.TestCase):
 
 class ExtendedIpsMacTestV2(ExtendedIpsMacTestV21):
     content_type = 'application/json'
-    prefix = '%s:' % extended_ips_mac.Extended_ips_mac.alias
+    prefix = '{0!s}:'.format(extended_ips_mac.Extended_ips_mac.alias)
 
     def setUp(self):
         super(ExtendedIpsMacTestV2, self).setUp()

--- a/nova/tests/unit/api/openstack/compute/test_extended_server_attributes.py
+++ b/nova/tests/unit/api/openstack/compute/test_extended_server_attributes.py
@@ -103,14 +103,14 @@ class ExtendedServerAttributesTestV21(test.TestCase):
         return jsonutils.loads(body).get('servers')
 
     def assertServerAttributes(self, server, host, node, instance_name):
-        self.assertEqual(server.get('%shost' % self.prefix), host)
-        self.assertEqual(server.get('%sinstance_name' % self.prefix),
+        self.assertEqual(server.get('{0!s}host'.format(self.prefix)), host)
+        self.assertEqual(server.get('{0!s}instance_name'.format(self.prefix)),
                          instance_name)
-        self.assertEqual(server.get('%shypervisor_hostname' % self.prefix),
+        self.assertEqual(server.get('{0!s}hypervisor_hostname'.format(self.prefix)),
                          node)
 
     def test_show(self):
-        url = self.fake_url + '/servers/%s' % UUID3
+        url = self.fake_url + '/servers/{0!s}'.format(UUID3)
         res = self._make_request(url)
 
         self.assertEqual(res.status_int, 200)
@@ -126,8 +126,8 @@ class ExtendedServerAttributesTestV21(test.TestCase):
         self.assertEqual(res.status_int, 200)
         for i, server in enumerate(self._get_servers(res.body)):
             self.assertServerAttributes(server,
-                                    host='host-%s' % (i + 1),
-                                    node='node-%s' % (i + 1),
+                                    host='host-{0!s}'.format((i + 1)),
+                                    node='node-{0!s}'.format((i + 1)),
                                     instance_name=NAME_FMT % (i + 1))
 
     def test_no_instance_passthrough_404(self):
@@ -167,23 +167,23 @@ class ExtendedServerAttributesTestV23(ExtendedServerAttributesTestV21):
                                user_data):
         super(ExtendedServerAttributesTestV23, self).assertServerAttributes(
             server, host, node, instance_name)
-        self.assertEqual(server.get('%sreservation_id' % self.prefix),
+        self.assertEqual(server.get('{0!s}reservation_id'.format(self.prefix)),
                          reservation_id)
-        self.assertEqual(server.get('%slaunch_index' % self.prefix),
+        self.assertEqual(server.get('{0!s}launch_index'.format(self.prefix)),
                          launch_index)
-        self.assertEqual(server.get('%skernel_id' % self.prefix),
+        self.assertEqual(server.get('{0!s}kernel_id'.format(self.prefix)),
                          kernel_id)
-        self.assertEqual(server.get('%sramdisk_id' % self.prefix),
+        self.assertEqual(server.get('{0!s}ramdisk_id'.format(self.prefix)),
                          ramdisk_id)
-        self.assertEqual(server.get('%shostname' % self.prefix),
+        self.assertEqual(server.get('{0!s}hostname'.format(self.prefix)),
                          hostname)
-        self.assertEqual(server.get('%sroot_device_name' % self.prefix),
+        self.assertEqual(server.get('{0!s}root_device_name'.format(self.prefix)),
                          root_device_name)
-        self.assertEqual(server.get('%suser_data' % self.prefix),
+        self.assertEqual(server.get('{0!s}user_data'.format(self.prefix)),
                          user_data)
 
     def test_show(self):
-        url = self.fake_url + '/servers/%s' % UUID3
+        url = self.fake_url + '/servers/{0!s}'.format(UUID3)
         res = self._make_request(url)
 
         self.assertEqual(res.status_int, 200)
@@ -206,14 +206,14 @@ class ExtendedServerAttributesTestV23(ExtendedServerAttributesTestV21):
         self.assertEqual(res.status_int, 200)
         for i, server in enumerate(self._get_servers(res.body)):
             self.assertServerAttributes(server,
-                                    host='host-%s' % (i + 1),
-                                    node='node-%s' % (i + 1),
+                                    host='host-{0!s}'.format((i + 1)),
+                                    node='node-{0!s}'.format((i + 1)),
                                     instance_name=NAME_FMT % (i + 1),
-                                    reservation_id="r-%s" % (i + 1),
+                                    reservation_id="r-{0!s}".format((i + 1)),
                                     launch_index=i,
                                     kernel_id=UUID4,
                                     ramdisk_id=UUID5,
-                                    hostname="hostname-%s" % (i + 1),
+                                    hostname="hostname-{0!s}".format((i + 1)),
                                     root_device_name="/dev/vda",
                                     user_data="userdata")
 
@@ -228,7 +228,7 @@ class ExtendedServerAttributesTestV216(ExtendedServerAttributesTestV21):
         self.assertEqual(server.get('host_status'), host_status)
 
     def test_show(self):
-        url = self.fake_url + '/servers/%s' % UUID3
+        url = self.fake_url + '/servers/{0!s}'.format(UUID3)
         res = self._make_request(url)
 
         self.assertEqual(res.status_int, 200)
@@ -245,7 +245,7 @@ class ExtendedServerAttributesTestV216(ExtendedServerAttributesTestV21):
         self.assertEqual(res.status_int, 200)
         for i, server in enumerate(self._get_servers(res.body)):
             self.assertServerAttributes(server,
-                                    host='host-%s' % (i + 1),
-                                    node='node-%s' % (i + 1),
+                                    host='host-{0!s}'.format((i + 1)),
+                                    node='node-{0!s}'.format((i + 1)),
                                     instance_name=NAME_FMT % (i + 1),
                                     host_status="DOWN")

--- a/nova/tests/unit/api/openstack/compute/test_extended_status.py
+++ b/nova/tests/unit/api/openstack/compute/test_extended_status.py
@@ -81,13 +81,13 @@ class ExtendedStatusTestV21(test.TestCase):
         return jsonutils.loads(body).get('servers')
 
     def assertServerStates(self, server, vm_state, power_state, task_state):
-        self.assertEqual(server.get('%svm_state' % self.prefix), vm_state)
-        self.assertEqual(int(server.get('%spower_state' % self.prefix)),
+        self.assertEqual(server.get('{0!s}vm_state'.format(self.prefix)), vm_state)
+        self.assertEqual(int(server.get('{0!s}power_state'.format(self.prefix))),
                          power_state)
-        self.assertEqual(server.get('%stask_state' % self.prefix), task_state)
+        self.assertEqual(server.get('{0!s}task_state'.format(self.prefix)), task_state)
 
     def test_show(self):
-        url = self.fake_url + '/servers/%s' % UUID3
+        url = self.fake_url + '/servers/{0!s}'.format(UUID3)
         res = self._make_request(url)
 
         self.assertEqual(res.status_int, 200)
@@ -103,9 +103,9 @@ class ExtendedStatusTestV21(test.TestCase):
         self.assertEqual(res.status_int, 200)
         for i, server in enumerate(self._get_servers(res.body)):
             self.assertServerStates(server,
-                                    vm_state='vm-%s' % (i + 1),
+                                    vm_state='vm-{0!s}'.format((i + 1)),
                                     power_state=(i + 1),
-                                    task_state='task-%s' % (i + 1))
+                                    task_state='task-{0!s}'.format((i + 1)))
 
     def test_no_instance_passthrough_404(self):
 

--- a/nova/tests/unit/api/openstack/compute/test_extended_virtual_interfaces_net.py
+++ b/nova/tests/unit/api/openstack/compute/test_extended_virtual_interfaces_net.py
@@ -63,8 +63,8 @@ def get_vif_by_mac_address(self, context, mac_address):
 
 class ExtendedServerVIFNetTest(test.NoDBTestCase):
     content_type = 'application/json'
-    prefix = "%s:" % extended_virtual_interfaces_net. \
-                        Extended_virtual_interfaces_net.alias
+    prefix = "{0!s}:".format(extended_virtual_interfaces_net. \
+                        Extended_virtual_interfaces_net.alias)
 
     def setUp(self):
         super(ExtendedServerVIFNetTest, self).setUp()
@@ -92,7 +92,7 @@ class ExtendedServerVIFNetTest(test.NoDBTestCase):
 
     def _get_net_id(self, vifs):
         for vif in vifs:
-            yield vif['%snet_id' % self.prefix]
+            yield vif['{0!s}net_id'.format(self.prefix)]
 
     def assertVIFs(self, vifs):
         result = []

--- a/nova/tests/unit/api/openstack/compute/test_extended_volumes.py
+++ b/nova/tests/unit/api/openstack/compute/test_extended_volumes.py
@@ -132,11 +132,11 @@ class ExtendedVolumesTestV21(test.TestCase):
         return jsonutils.loads(body).get('servers')
 
     def test_show(self):
-        res = self._make_request('/%s' % UUID1)
+        res = self._make_request('/{0!s}'.format(UUID1))
 
         self.assertEqual(200, res.status_int)
         server = self._get_server(res.body)
-        actual = server.get('%svolumes_attached' % self.prefix)
+        actual = server.get('{0!s}volumes_attached'.format(self.prefix))
         self.assertEqual(self.exp_volumes_show, actual)
 
     def test_detail(self):
@@ -144,7 +144,7 @@ class ExtendedVolumesTestV21(test.TestCase):
 
         self.assertEqual(200, res.status_int)
         for i, server in enumerate(self._get_servers(res.body)):
-            actual = server.get('%svolumes_attached' % self.prefix)
+            actual = server.get('{0!s}volumes_attached'.format(self.prefix))
             self.assertEqual(self.exp_volumes_detail[i], actual)
 
 

--- a/nova/tests/unit/api/openstack/compute/test_extension_info.py
+++ b/nova/tests/unit/api/openstack/compute/test_extension_info.py
@@ -202,7 +202,7 @@ class ExtensionInfoPolicyEnforcementV21(test.NoDBTestCase):
             getattr(self.controller, action), self.req, *args)
 
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_extension_index_policy_failed(self):

--- a/nova/tests/unit/api/openstack/compute/test_fixed_ips.py
+++ b/nova/tests/unit/api/openstack/compute/test_fixed_ips.py
@@ -76,7 +76,7 @@ fake_fixed_ips = [{'id': 1,
 
 def fake_fixed_ip_get_by_address(context, address, columns_to_join=None):
     if address == 'inv.ali.d.ip':
-        msg = "Invalid fixed IP Address %s in request" % address
+        msg = "Invalid fixed IP Address {0!s} in request".format(address)
         raise exception.FixedIpInvalid(msg)
     for fixed_ip in fake_fixed_ips:
         if fixed_ip['address'] == address and not fixed_ip['deleted']:
@@ -108,7 +108,7 @@ class FakeModel(object):
             raise NotImplementedError()
 
     def __repr__(self):
-        return '<FakeModel: %s>' % self.values
+        return '<FakeModel: {0!s}>'.format(self.values)
 
 
 def fake_network_get_all(context):
@@ -146,7 +146,7 @@ class FixedIpTestV21(test.NoDBTestCase):
         return {}
 
     def test_fixed_ips_get(self):
-        req = fakes.HTTPRequest.blank('%s/192.168.1.1' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/192.168.1.1'.format(self.url))
         req.api_version_request = api_version_request.APIVersionRequest(
                                         self.wsgi_api_version)
         res_dict = self.controller.show(req, '192.168.1.1')
@@ -158,24 +158,24 @@ class FixedIpTestV21(test.NoDBTestCase):
         self.assertEqual(response, res_dict, self.wsgi_api_version)
 
     def test_fixed_ips_get_bad_ip_fail(self):
-        req = fakes.HTTPRequest.blank('%s/10.0.0.1' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/10.0.0.1'.format(self.url))
         self.assertRaises(webob.exc.HTTPNotFound, self.controller.show, req,
                           '10.0.0.1')
 
     def test_fixed_ips_get_invalid_ip_address(self):
-        req = fakes.HTTPRequest.blank('%s/inv.ali.d.ip' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/inv.ali.d.ip'.format(self.url))
         self.assertRaises(webob.exc.HTTPBadRequest, self.controller.show, req,
                           'inv.ali.d.ip')
 
     def test_fixed_ips_get_deleted_ip_fail(self):
-        req = fakes.HTTPRequest.blank('%s/10.0.0.2' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/10.0.0.2'.format(self.url))
         self.assertRaises(webob.exc.HTTPNotFound, self.controller.show, req,
                           '10.0.0.2')
 
     def test_fixed_ip_reserve(self):
         fake_fixed_ips[0]['reserved'] = False
         body = {'reserve': None}
-        req = fakes.HTTPRequest.blank('%s/192.168.1.1/action' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/192.168.1.1/action'.format(self.url))
         action = self._get_reserve_action()
         result = action(req, "192.168.1.1", body=body)
 
@@ -184,7 +184,7 @@ class FixedIpTestV21(test.NoDBTestCase):
 
     def test_fixed_ip_reserve_bad_ip(self):
         body = {'reserve': None}
-        req = fakes.HTTPRequest.blank('%s/10.0.0.1/action' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/10.0.0.1/action'.format(self.url))
         action = self._get_reserve_action()
 
         self.assertRaises(webob.exc.HTTPNotFound, action, req,
@@ -192,7 +192,7 @@ class FixedIpTestV21(test.NoDBTestCase):
 
     def test_fixed_ip_reserve_invalid_ip_address(self):
         body = {'reserve': None}
-        req = fakes.HTTPRequest.blank('%s/inv.ali.d.ip/action' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/inv.ali.d.ip/action'.format(self.url))
         action = self._get_reserve_action()
 
         self.assertRaises(webob.exc.HTTPBadRequest,
@@ -202,14 +202,14 @@ class FixedIpTestV21(test.NoDBTestCase):
         body = {'reserve': None}
         action = self._get_reserve_action()
 
-        req = fakes.HTTPRequest.blank('%s/10.0.0.2/action' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/10.0.0.2/action'.format(self.url))
         self.assertRaises(webob.exc.HTTPNotFound, action, req,
                           '10.0.0.2', body=body)
 
     def test_fixed_ip_unreserve(self):
         fake_fixed_ips[0]['reserved'] = True
         body = {'unreserve': None}
-        req = fakes.HTTPRequest.blank('%s/192.168.1.1/action' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/192.168.1.1/action'.format(self.url))
         action = self._get_unreserve_action()
         result = action(req, "192.168.1.1", body=body)
 
@@ -218,7 +218,7 @@ class FixedIpTestV21(test.NoDBTestCase):
 
     def test_fixed_ip_unreserve_bad_ip(self):
         body = {'unreserve': None}
-        req = fakes.HTTPRequest.blank('%s/10.0.0.1/action' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/10.0.0.1/action'.format(self.url))
         action = self._get_unreserve_action()
 
         self.assertRaises(webob.exc.HTTPNotFound, action, req,
@@ -226,14 +226,14 @@ class FixedIpTestV21(test.NoDBTestCase):
 
     def test_fixed_ip_unreserve_invalid_ip_address(self):
         body = {'unreserve': None}
-        req = fakes.HTTPRequest.blank('%s/inv.ali.d.ip/action' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/inv.ali.d.ip/action'.format(self.url))
         action = self._get_unreserve_action()
         self.assertRaises(webob.exc.HTTPBadRequest,
                           action, req, 'inv.ali.d.ip', body=body)
 
     def test_fixed_ip_unreserve_deleted_ip(self):
         body = {'unreserve': None}
-        req = fakes.HTTPRequest.blank('%s/10.0.0.2/action' % self.url)
+        req = fakes.HTTPRequest.blank('{0!s}/10.0.0.2/action'.format(self.url))
         action = self._get_unreserve_action()
         self.assertRaises(webob.exc.HTTPNotFound, action, req,
                           '10.0.0.2', body=body)
@@ -261,4 +261,4 @@ class FixedIpTestV24(FixedIpTestV21):
         for fixed_ip in fake_fixed_ips:
             if address == fixed_ip['address']:
                 return {'reserved': fixed_ip['reserved']}
-        self.fail('Invalid address: %s' % address)
+        self.fail('Invalid address: {0!s}'.format(address))

--- a/nova/tests/unit/api/openstack/compute/test_flavor_access.py
+++ b/nova/tests/unit/api/openstack/compute/test_flavor_access.py
@@ -460,7 +460,7 @@ class FlavorAccessPolicyEnforcementV21(test.NoDBTestCase):
             self.act_controller._add_tenant_access, self.req, fakes.FAKE_UUID,
             body={'addTenantAccess': {'tenant': fakes.FAKE_UUID}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_remove_tenant_access_policy_failed(self):
@@ -473,7 +473,7 @@ class FlavorAccessPolicyEnforcementV21(test.NoDBTestCase):
             fakes.FAKE_UUID,
             body={'removeTenantAccess': {'tenant': fakes.FAKE_UUID}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_extend_create_policy_failed(self):
@@ -499,5 +499,5 @@ class FlavorAccessPolicyEnforcementV21(test.NoDBTestCase):
             self.access_controller.index, self.req,
             fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_flavor_disabled.py
+++ b/nova/tests/unit/api/openstack/compute/test_flavor_disabled.py
@@ -44,7 +44,7 @@ FAKE_FLAVORS = {
 
 
 def fake_flavor_get_by_flavor_id(flavorid, ctxt=None):
-    return FAKE_FLAVORS['flavor %s' % flavorid]
+    return FAKE_FLAVORS['flavor {0!s}'.format(flavorid)]
 
 
 def fake_get_all_flavors_sorted_list(context=None, inactive=False,
@@ -86,7 +86,7 @@ class FlavorDisabledTestV21(test.NoDBTestCase):
         return jsonutils.loads(body).get('flavors')
 
     def assertFlavorDisabled(self, flavor, disabled):
-        self.assertEqual(str(flavor.get('%sdisabled' % self.prefix)), disabled)
+        self.assertEqual(str(flavor.get('{0!s}disabled'.format(self.prefix))), disabled)
 
     def test_show(self):
         url = self.base_url + '/1'

--- a/nova/tests/unit/api/openstack/compute/test_flavor_manage.py
+++ b/nova/tests/unit/api/openstack/compute/test_flavor_manage.py
@@ -61,7 +61,7 @@ def fake_get_flavor_by_flavor_id(flavorid, ctxt=None, read_deleted='yes'):
     if flavorid == 'failtest':
         raise exception.FlavorNotFound(flavor_id=flavorid)
     elif not str(flavorid) == '1234':
-        raise Exception("This test expects flavorid 1234, not %s" % flavorid)
+        raise Exception("This test expects flavorid 1234, not {0!s}".format(flavorid))
     if read_deleted != 'no':
         raise test.TestingException("Should not be reading deleted")
     return fake_db_flavor(flavorid=flavorid)
@@ -414,7 +414,7 @@ class PrivateFlavorManageTestV21(test.TestCase):
             body["flavor"]["id"])
         expected_flavor_access_body = {
             "tenant_id": 'fake',
-            "flavor_id": "%s" % body["flavor"]["id"]
+            "flavor_id": "{0!s}".format(body["flavor"]["id"])
         }
         self.assertNotIn(expected_flavor_access_body,
                          flavor_access_body["flavor_access"])
@@ -502,7 +502,7 @@ class FlavorManagerPolicyEnforcementV21(test.NoDBTestCase):
                 "rxtx_factor": 1,
             }})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_delete_policy_failed(self):
@@ -514,5 +514,5 @@ class FlavorManagerPolicyEnforcementV21(test.NoDBTestCase):
             self.controller._delete, req,
             fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_flavor_rxtx.py
+++ b/nova/tests/unit/api/openstack/compute/test_flavor_rxtx.py
@@ -46,7 +46,7 @@ FAKE_FLAVORS = {
 
 
 def fake_flavor_get_by_flavor_id(flavorid, ctxt=None):
-    return FAKE_FLAVORS['flavor %s' % flavorid]
+    return FAKE_FLAVORS['flavor {0!s}'.format(flavorid)]
 
 
 def fake_get_all_flavors_sorted_list(context=None, inactive=False,

--- a/nova/tests/unit/api/openstack/compute/test_flavor_swap.py
+++ b/nova/tests/unit/api/openstack/compute/test_flavor_swap.py
@@ -45,7 +45,7 @@ FAKE_FLAVORS = {
 
 # TODO(jogo) dedup these across nova.api.openstack.contrib.test_flavor*
 def fake_flavor_get_by_flavor_id(flavorid, ctxt=None):
-    return FAKE_FLAVORS['flavor %s' % flavorid]
+    return FAKE_FLAVORS['flavor {0!s}'.format(flavorid)]
 
 
 def fake_get_all_flavors_sorted_list(context=None, inactive=False,
@@ -87,7 +87,7 @@ class FlavorSwapTestV21(test.NoDBTestCase):
         return jsonutils.loads(body).get('flavors')
 
     def assertFlavorSwap(self, flavor, swap):
-        self.assertEqual(str(flavor.get('%sswap' % self.prefix)), swap)
+        self.assertEqual(str(flavor.get('{0!s}swap'.format(self.prefix))), swap)
 
     def test_show(self):
         url = self.base_url + '/1'

--- a/nova/tests/unit/api/openstack/compute/test_flavors.py
+++ b/nova/tests/unit/api/openstack/compute/test_flavors.py
@@ -56,7 +56,7 @@ FAKE_FLAVORS = {
 
 
 def fake_flavor_get_by_flavor_id(flavorid, ctxt=None):
-    return FAKE_FLAVORS['flavor %s' % flavorid]
+    return FAKE_FLAVORS['flavor {0!s}'.format(flavorid)]
 
 
 def fake_get_all_flavors_sorted_list(context=None, inactive=False,
@@ -665,7 +665,7 @@ class ParseIsPublicTestV21(test.TestCase):
 
     def assertPublic(self, expected, is_public):
         self.assertIs(expected, self.controller._parse_is_public(is_public),
-                      '%s did not return %s' % (is_public, expected))
+                      '{0!s} did not return {1!s}'.format(is_public, expected))
 
     def test_None(self):
         self.assertPublic(True, None)

--- a/nova/tests/unit/api/openstack/compute/test_floating_ip_dns.py
+++ b/nova/tests/unit/api/openstack/compute/test_floating_ip_dns.py
@@ -410,7 +410,7 @@ class FloatingIPDNSDomainPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_update_floating_ip_dns_policy_failed(self):
@@ -423,7 +423,7 @@ class FloatingIPDNSDomainPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.update, self.req, _quote_domain(domain), body=body)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_delete_floating_ip_dns_policy_failed(self):
@@ -433,7 +433,7 @@ class FloatingIPDNSDomainPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.delete, self.req, _quote_domain(domain))
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
 
@@ -452,7 +452,7 @@ class FloatingIPDNSEntryPolicyEnforcementV21(test.NoDBTestCase):
             self.controller.show, self.req,
                 _quote_domain(domain), test_ipv4_address)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % self.rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(self.rule_name),
             exc.format_message())
 
     def test_update_floating_ip_dns_policy_failed(self):
@@ -464,7 +464,7 @@ class FloatingIPDNSEntryPolicyEnforcementV21(test.NoDBTestCase):
             self.controller.update, self.req, _quote_domain(domain),
                                     name, body=body)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % self.rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(self.rule_name),
             exc.format_message())
 
     def test_delete_floating_ip_dns_policy_failed(self):
@@ -472,5 +472,5 @@ class FloatingIPDNSEntryPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.delete, self.req, _quote_domain(domain), name)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % self.rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(self.rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_floating_ip_pools.py
+++ b/nova/tests/unit/api/openstack/compute/test_floating_ip_pools.py
@@ -75,5 +75,5 @@ class FloatingIPPoolsPolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, self.controller.index, self.req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." %
-            rule_name, exc.format_message())
+            "Policy doesn't allow {0!s} to be performed.".format(
+            rule_name), exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_floating_ips.py
+++ b/nova/tests/unit/api/openstack/compute/test_floating_ips.py
@@ -856,7 +856,7 @@ class FloatingIPPolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
         exc.format_message())
 
     def test_index_policy_failed(self):
@@ -886,7 +886,7 @@ class FloatingIPActionPolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
         exc.format_message())
 
     def test_add_policy_failed(self):

--- a/nova/tests/unit/api/openstack/compute/test_floating_ips_bulk.py
+++ b/nova/tests/unit/api/openstack/compute/test_floating_ips_bulk.py
@@ -214,7 +214,7 @@ class FloatingIPBulkPolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_index_policy_failed(self):

--- a/nova/tests/unit/api/openstack/compute/test_fping.py
+++ b/nova/tests/unit/api/openstack/compute/test_fping.py
@@ -29,7 +29,7 @@ FAKE_UUID = fakes.FAKE_UUID
 
 
 def execute(*cmd, **args):
-    return "".join(["%s is alive" % ip for ip in cmd[1:]])
+    return "".join(["{0!s} is alive".format(ip) for ip in cmd[1:]])
 
 
 class FpingTestV21(test.TestCase):
@@ -76,7 +76,7 @@ class FpingTestV21(test.TestCase):
         res_dict = self.controller.index(req)
         ids = [srv["id"] for srv in res_dict["servers"]]
         req = fakes.HTTPRequest.blank(self._get_url() +
-                                      "/os-fping?include=%s" % ids[0])
+                                      "/os-fping?include={0!s}".format(ids[0]))
         res_dict = self.controller.index(req)
         self.assertEqual(len(res_dict["servers"]), 1)
         self.assertEqual(res_dict["servers"][0]["id"], ids[0])
@@ -86,15 +86,15 @@ class FpingTestV21(test.TestCase):
         res_dict = self.controller.index(req)
         ids = [srv["id"] for srv in res_dict["servers"]]
         req = fakes.HTTPRequest.blank(self._get_url() +
-                                      "/os-fping?exclude=%s" %
-                                      ",".join(ids[1:]))
+                                      "/os-fping?exclude={0!s}".format(
+                                      ",".join(ids[1:])))
         res_dict = self.controller.index(req)
         self.assertEqual(len(res_dict["servers"]), 1)
         self.assertEqual(res_dict["servers"][0]["id"], ids[0])
 
     def test_fping_show(self):
         req = fakes.HTTPRequest.blank(self._get_url() +
-                                      "os-fping/%s" % FAKE_UUID)
+                                      "os-fping/{0!s}".format(FAKE_UUID))
         res_dict = self.controller.show(req, FAKE_UUID)
         self.assertIn("server", res_dict)
         srv = res_dict["server"]
@@ -106,7 +106,7 @@ class FpingTestV21(test.TestCase):
         mock_get_instance.side_effect = exception.InstanceNotFound(
             instance_id='')
         req = fakes.HTTPRequest.blank(self._get_url() +
-                                      "os-fping/%s" % FAKE_UUID)
+                                      "os-fping/{0!s}".format(FAKE_UUID))
         self.assertRaises(webob.exc.HTTPNotFound,
                           self.controller.show, req, FAKE_UUID)
 
@@ -127,8 +127,8 @@ class FpingPolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." %
-            rule.popitem()[0], exc.format_message())
+            "Policy doesn't allow {0!s} to be performed.".format(
+            rule.popitem()[0]), exc.format_message())
 
     def test_list_policy_failed(self):
         rule = {"os_compute_api:os-fping": "project:non_fake"}

--- a/nova/tests/unit/api/openstack/compute/test_hide_server_addresses.py
+++ b/nova/tests/unit/api/openstack/compute/test_hide_server_addresses.py
@@ -83,7 +83,7 @@ class HideServerAddressesTestV21(test.TestCase):
         self.stubs.Set(compute.api.API, 'get',
                        fake_compute_get(instance_id, uuid=uuid,
                                         vm_state=vm_states.BUILDING))
-        res = self._make_request(self.base_url + '/%s' % uuid)
+        res = self._make_request(self.base_url + '/{0!s}'.format(uuid))
         self.assertEqual(res.status_int, 200)
 
         server = self._get_server(res.body)
@@ -96,7 +96,7 @@ class HideServerAddressesTestV21(test.TestCase):
         self.stubs.Set(compute.api.API, 'get',
                        fake_compute_get(instance_id, uuid=uuid,
                                         vm_state=vm_states.ACTIVE))
-        res = self._make_request(self.base_url + '/%s' % uuid)
+        res = self._make_request(self.base_url + '/{0!s}'.format(uuid))
         self.assertEqual(res.status_int, 200)
 
         server = self._get_server(res.body)

--- a/nova/tests/unit/api/openstack/compute/test_hosts.py
+++ b/nova/tests/unit/api/openstack/compute/test_hosts.py
@@ -236,7 +236,7 @@ class HostTestCaseV21(test.TestCase):
         self.req.environ["nova.context"].is_admin = True
         dest = 'dummydest'
         with testtools.ExpectedException(webob.exc.HTTPNotFound,
-                                         ".*%s.*" % dest):
+                                         ".*{0!s}.*".format(dest)):
             self.controller.update(self.req, dest, body={'status': 'enable'})
 
     def test_host_maintenance_bad_host(self):
@@ -244,7 +244,7 @@ class HostTestCaseV21(test.TestCase):
         self.req.environ["nova.context"].is_admin = True
         dest = 'dummydest'
         with testtools.ExpectedException(webob.exc.HTTPNotFound,
-                                         ".*%s.*" % dest):
+                                         ".*{0!s}.*".format(dest)):
             self.controller.update(self.req, dest,
                                    body={'maintenance_mode': 'enable'})
 
@@ -253,7 +253,7 @@ class HostTestCaseV21(test.TestCase):
         self.req.environ["nova.context"].is_admin = True
         dest = 'dummydest'
         with testtools.ExpectedException(webob.exc.HTTPNotFound,
-                                         ".*%s.*" % dest):
+                                         ".*{0!s}.*".format(dest)):
             self.controller.reboot(self.req, dest)
 
     def test_host_status_bad_status(self):
@@ -261,7 +261,7 @@ class HostTestCaseV21(test.TestCase):
         self.req.environ["nova.context"].is_admin = True
         dest = 'service_not_available'
         with testtools.ExpectedException(webob.exc.HTTPBadRequest,
-                                         ".*%s.*" % dest):
+                                         ".*{0!s}.*".format(dest)):
             self.controller.update(self.req, dest, body={'status': 'enable'})
 
     def test_host_maintenance_bad_status(self):
@@ -269,7 +269,7 @@ class HostTestCaseV21(test.TestCase):
         self.req.environ["nova.context"].is_admin = True
         dest = 'service_not_available'
         with testtools.ExpectedException(webob.exc.HTTPBadRequest,
-                                         ".*%s.*" % dest):
+                                         ".*{0!s}.*".format(dest)):
             self.controller.update(self.req, dest,
                                    body={'maintenance_mode': 'enable'})
 
@@ -278,7 +278,7 @@ class HostTestCaseV21(test.TestCase):
         self.req.environ["nova.context"].is_admin = True
         dest = 'service_not_available'
         with testtools.ExpectedException(webob.exc.HTTPBadRequest,
-                                         ".*%s.*" % dest):
+                                         ".*{0!s}.*".format(dest)):
             self.controller.reboot(self.req, dest)
 
     def test_bad_status_value(self):
@@ -311,7 +311,7 @@ class HostTestCaseV21(test.TestCase):
         self.req.environ["nova.context"].is_admin = True
         dest = 'dummydest'
         with testtools.ExpectedException(webob.exc.HTTPNotFound,
-                                         ".*%s.*" % dest):
+                                         ".*{0!s}.*".format(dest)):
             self.controller.show(self.req, dest)
 
     def _create_compute_service(self):
@@ -426,7 +426,7 @@ class HostsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_show_policy_failed(self):
@@ -436,5 +436,5 @@ class HostsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.show, self.req, 1)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_image_metadata.py
+++ b/nova/tests/unit/api/openstack/compute/test_image_metadata.py
@@ -322,8 +322,7 @@ class ImageMetaDataTestV21(test.NoDBTestCase):
         image_id = 131
         # see nova.tests.unit.api.openstack.fakes:_make_image_fixtures
 
-        req = fakes.HTTPRequest.blank('/v2/fake/images/%s/metadata/key1'
-                                      % image_id)
+        req = fakes.HTTPRequest.blank('/v2/fake/images/{0!s}/metadata/key1'.format(image_id))
         req.method = 'PUT'
         body = {"metadata": {"key1": "value1"}}
         req.body = jsonutils.dump_as_bytes(body)
@@ -339,8 +338,7 @@ class ImageMetaDataTestV21(test.NoDBTestCase):
         image_id = 131
         # see nova.tests.unit.api.openstack.fakes:_make_image_fixtures
 
-        req = fakes.HTTPRequest.blank('/v2/fake/images/%s/metadata/key1'
-                                      % image_id)
+        req = fakes.HTTPRequest.blank('/v2/fake/images/{0!s}/metadata/key1'.format(image_id))
         req.method = 'POST'
         body = {"metadata": {"key1": "value1"}}
         req.body = jsonutils.dump_as_bytes(body)

--- a/nova/tests/unit/api/openstack/compute/test_image_size.py
+++ b/nova/tests/unit/api/openstack/compute/test_image_size.py
@@ -98,7 +98,7 @@ class ImageSizeTestV21(test.NoDBTestCase):
         return jsonutils.loads(body).get('images')
 
     def assertImageSize(self, image, size):
-        self.assertEqual(image.get('%s:size' % self.prefix), size)
+        self.assertEqual(image.get('{0!s}:size'.format(self.prefix)), size)
 
     def test_show(self):
         url = '/v2/fake/images/1'

--- a/nova/tests/unit/api/openstack/compute/test_images.py
+++ b/nova/tests/unit/api/openstack/compute/test_images.py
@@ -59,15 +59,15 @@ class ImagesControllerTestV21(test.NoDBTestCase):
         fakes.stub_out_compute_api_backup(self.stubs)
 
         self.controller = self.image_controller_class()
-        self.url_prefix = "http://localhost%s/images" % self.url_base
-        self.bookmark_prefix = "http://localhost%s/images" % self.bookmark_base
+        self.url_prefix = "http://localhost{0!s}/images".format(self.url_base)
+        self.bookmark_prefix = "http://localhost{0!s}/images".format(self.bookmark_base)
         self.uuid = 'fa95aaf5-ab3b-4cd8-88c0-2be7dd051aaf'
         self.server_uuid = "aa640691-d1a7-4a67-9d3c-d35ee6b3cc74"
         self.server_href = (
-            "http://localhost%s/servers/%s" % (self.url_base,
+            "http://localhost{0!s}/servers/{1!s}".format(self.url_base,
                                                self.server_uuid))
         self.server_bookmark = (
-             "http://localhost%s/servers/%s" % (self.bookmark_base,
+             "http://localhost{0!s}/servers/{1!s}".format(self.bookmark_base,
                                                 self.server_uuid))
         self.alternate = "%s/images/%s"
 
@@ -83,12 +83,12 @@ class ImagesControllerTestV21(test.NoDBTestCase):
                       'minRam': 128,
                       "links": [{
                                     "rel": "self",
-                                    "href": "%s/123" % self.url_prefix
+                                    "href": "{0!s}/123".format(self.url_prefix)
                                 },
                                 {
                                     "rel": "bookmark",
                                     "href":
-                                        "%s/123" % self.bookmark_prefix
+                                        "{0!s}/123".format(self.bookmark_prefix)
                                 },
                                 {
                                     "rel": "alternate",
@@ -126,12 +126,12 @@ class ImagesControllerTestV21(test.NoDBTestCase):
                       },
                       "links": [{
                                     "rel": "self",
-                                    "href": "%s/124" % self.url_prefix
+                                    "href": "{0!s}/124".format(self.url_prefix)
                                 },
                                 {
                                     "rel": "bookmark",
                                     "href":
-                                        "%s/124" % self.bookmark_prefix
+                                        "{0!s}/124".format(self.bookmark_prefix)
                                 },
                                 {
                                     "rel": "alternate",
@@ -161,16 +161,16 @@ class ImagesControllerTestV21(test.NoDBTestCase):
 
         expected_image = self.expected_image_124
         expected_image["image"]["links"][0]["href"] = (
-            "https://zoo.com:42%s/images/124" % self.url_base)
+            "https://zoo.com:42{0!s}/images/124".format(self.url_base))
         expected_image["image"]["links"][1]["href"] = (
-            "https://zoo.com:42%s/images/124" % self.bookmark_base)
+            "https://zoo.com:42{0!s}/images/124".format(self.bookmark_base))
         expected_image["image"]["links"][2]["href"] = (
             "http://circus.com:34/images/124")
         expected_image["image"]["server"]["links"][0]["href"] = (
-            "https://zoo.com:42%s/servers/%s" % (self.url_base,
+            "https://zoo.com:42{0!s}/servers/{1!s}".format(self.url_base,
                                                  self.server_uuid))
         expected_image["image"]["server"]["links"][1]["href"] = (
-            "https://zoo.com:42%s/servers/%s" % (self.bookmark_base,
+            "https://zoo.com:42{0!s}/servers/{1!s}".format(self.bookmark_base,
                                                  self.server_uuid))
 
         self.assertThat(actual_image, matchers.DictMatches(expected_image))
@@ -194,50 +194,50 @@ class ImagesControllerTestV21(test.NoDBTestCase):
         image_125['id'] = '125'
         image_125['name'] = 'saving snapshot'
         image_125['progress'] = 50
-        image_125["links"][0]["href"] = "%s/125" % self.url_prefix
-        image_125["links"][1]["href"] = "%s/125" % self.bookmark_prefix
+        image_125["links"][0]["href"] = "{0!s}/125".format(self.url_prefix)
+        image_125["links"][1]["href"] = "{0!s}/125".format(self.bookmark_prefix)
         image_125["links"][2]["href"] = (
-            "%s/images/125" % glance.generate_glance_url())
+            "{0!s}/images/125".format(glance.generate_glance_url()))
 
         image_126 = copy.deepcopy(self.expected_image_124["image"])
         image_126['id'] = '126'
         image_126['name'] = 'active snapshot'
         image_126['status'] = 'ACTIVE'
         image_126['progress'] = 100
-        image_126["links"][0]["href"] = "%s/126" % self.url_prefix
-        image_126["links"][1]["href"] = "%s/126" % self.bookmark_prefix
+        image_126["links"][0]["href"] = "{0!s}/126".format(self.url_prefix)
+        image_126["links"][1]["href"] = "{0!s}/126".format(self.bookmark_prefix)
         image_126["links"][2]["href"] = (
-            "%s/images/126" % glance.generate_glance_url())
+            "{0!s}/images/126".format(glance.generate_glance_url()))
 
         image_127 = copy.deepcopy(self.expected_image_124["image"])
         image_127['id'] = '127'
         image_127['name'] = 'killed snapshot'
         image_127['status'] = 'ERROR'
         image_127['progress'] = 0
-        image_127["links"][0]["href"] = "%s/127" % self.url_prefix
-        image_127["links"][1]["href"] = "%s/127" % self.bookmark_prefix
+        image_127["links"][0]["href"] = "{0!s}/127".format(self.url_prefix)
+        image_127["links"][1]["href"] = "{0!s}/127".format(self.bookmark_prefix)
         image_127["links"][2]["href"] = (
-            "%s/images/127" % glance.generate_glance_url())
+            "{0!s}/images/127".format(glance.generate_glance_url()))
 
         image_128 = copy.deepcopy(self.expected_image_124["image"])
         image_128['id'] = '128'
         image_128['name'] = 'deleted snapshot'
         image_128['status'] = 'DELETED'
         image_128['progress'] = 0
-        image_128["links"][0]["href"] = "%s/128" % self.url_prefix
-        image_128["links"][1]["href"] = "%s/128" % self.bookmark_prefix
+        image_128["links"][0]["href"] = "{0!s}/128".format(self.url_prefix)
+        image_128["links"][1]["href"] = "{0!s}/128".format(self.bookmark_prefix)
         image_128["links"][2]["href"] = (
-            "%s/images/128" % glance.generate_glance_url())
+            "{0!s}/images/128".format(glance.generate_glance_url()))
 
         image_129 = copy.deepcopy(self.expected_image_124["image"])
         image_129['id'] = '129'
         image_129['name'] = 'pending_delete snapshot'
         image_129['status'] = 'DELETED'
         image_129['progress'] = 0
-        image_129["links"][0]["href"] = "%s/129" % self.url_prefix
-        image_129["links"][1]["href"] = "%s/129" % self.bookmark_prefix
+        image_129["links"][0]["href"] = "{0!s}/129".format(self.url_prefix)
+        image_129["links"][1]["href"] = "{0!s}/129".format(self.bookmark_prefix)
         image_129["links"][2]["href"] = (
-            "%s/images/129" % glance.generate_glance_url())
+            "{0!s}/images/129".format(glance.generate_glance_url()))
 
         image_130 = copy.deepcopy(self.expected_image_123["image"])
         image_130['id'] = '130'
@@ -245,10 +245,10 @@ class ImagesControllerTestV21(test.NoDBTestCase):
         image_130['metadata'] = {}
         image_130['minDisk'] = 0
         image_130['minRam'] = 0
-        image_130["links"][0]["href"] = "%s/130" % self.url_prefix
-        image_130["links"][1]["href"] = "%s/130" % self.bookmark_prefix
+        image_130["links"][0]["href"] = "{0!s}/130".format(self.url_prefix)
+        image_130["links"][1]["href"] = "{0!s}/130".format(self.bookmark_prefix)
         image_130["links"][2]["href"] = (
-            "%s/images/130" % glance.generate_glance_url())
+            "{0!s}/images/130".format(glance.generate_glance_url()))
 
         image_131 = copy.deepcopy(self.expected_image_123["image"])
         image_131['id'] = '131'
@@ -256,10 +256,10 @@ class ImagesControllerTestV21(test.NoDBTestCase):
         image_131['metadata'] = {}
         image_131['minDisk'] = 0
         image_131['minRam'] = 0
-        image_131["links"][0]["href"] = "%s/131" % self.url_prefix
-        image_131["links"][1]["href"] = "%s/131" % self.bookmark_prefix
+        image_131["links"][0]["href"] = "{0!s}/131".format(self.url_prefix)
+        image_131["links"][1]["href"] = "{0!s}/131".format(self.bookmark_prefix)
         image_131["links"][2]["href"] = (
-            "%s/images/131" % glance.generate_glance_url())
+            "{0!s}/images/131".format(glance.generate_glance_url()))
 
         expected = [self.expected_image_123["image"],
                     self.expected_image_124["image"],
@@ -353,7 +353,7 @@ class ImagesControllerTestV21(test.NoDBTestCase):
         view = images_view.ViewBuilder()
         request = self.http_request.blank(self.url_base + 'images/1')
         generated_url = view._get_alternate_link(request, 1)
-        actual_url = "%s/images/1" % glance.generate_glance_url()
+        actual_url = "{0!s}/images/1".format(glance.generate_glance_url())
         self.assertEqual(generated_url, actual_url)
 
     def _check_response(self, controller_method, response, expected_code):

--- a/nova/tests/unit/api/openstack/compute/test_instance_actions.py
+++ b/nova/tests/unit/api/openstack/compute/test_instance_actions.py
@@ -77,7 +77,7 @@ class InstanceActionsPolicyTestV21(test.NoDBTestCase):
         self.controller = self.instance_actions.InstanceActionsController()
 
     def _get_http_req(self, action):
-        fake_url = '/123/servers/12/%s' % action
+        fake_url = '/123/servers/12/{0!s}'.format(action)
         return fakes.HTTPRequest.blank(fake_url)
 
     def _set_policy_rules(self):
@@ -93,8 +93,8 @@ class InstanceActionsPolicyTestV21(test.NoDBTestCase):
                                       columns_to_join=None,
                                       use_slave=False):
             return fake_instance.fake_db_instance(
-                **{'name': 'fake', 'project_id': '%s_unequal' %
-                       context.project_id})
+                **{'name': 'fake', 'project_id': '{0!s}_unequal'.format(
+                       context.project_id)})
 
         self.stub_out('nova.db.instance_get_by_uuid',
                       fake_instance_get_by_uuid)
@@ -109,8 +109,8 @@ class InstanceActionsPolicyTestV21(test.NoDBTestCase):
                                       columns_to_join=None,
                                       use_slave=False):
             return fake_instance.fake_db_instance(
-                **{'name': 'fake', 'project_id': '%s_unequal' %
-                       context.project_id})
+                **{'name': 'fake', 'project_id': '{0!s}_unequal'.format(
+                       context.project_id)})
 
         self.stub_out('nova.db.instance_get_by_uuid',
                       fake_instance_get_by_uuid)
@@ -152,7 +152,7 @@ class InstanceActionsTestV21(test.NoDBTestCase):
                       fake_instance_get_by_uuid)
 
     def _get_http_req(self, action, use_admin_context=False):
-        fake_url = '/123/servers/12/%s' % action
+        fake_url = '/123/servers/12/{0!s}'.format(action)
         return fakes.HTTPRequest.blank(fake_url,
                                        use_admin_context=use_admin_context,
                                        version=self.wsgi_api_version)

--- a/nova/tests/unit/api/openstack/compute/test_instance_usage_audit_log.py
+++ b/nova/tests/unit/api/openstack/compute/test_instance_usage_audit_log.py
@@ -95,7 +95,7 @@ def fake_task_log_get_all(context, task_name, begin, end,
         return TEST_LOGS2
     if begin == begin3 and end == end3:
         return TEST_LOGS3
-    raise AssertionError("Invalid date %s to %s" % (begin, end))
+    raise AssertionError("Invalid date {0!s} to {1!s}".format(begin, end))
 
 
 def fake_last_completed_audit_period(unit=None, before=None):
@@ -106,7 +106,7 @@ def fake_last_completed_audit_period(unit=None, before=None):
         for begin, end in audit_periods:
             if before > end:
                 return begin, end
-        raise AssertionError("Invalid before date %s" % (before))
+        raise AssertionError("Invalid before date {0!s}".format((before)))
     return begin1, end1
 
 
@@ -221,7 +221,7 @@ class InstanceUsageAuditPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_show_policy_failed(self):
@@ -231,5 +231,5 @@ class InstanceUsageAuditPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.show, self.req, '2012-07-05 10:00:00')
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_limits.py
+++ b/nova/tests/unit/api/openstack/compute/test_limits.py
@@ -91,7 +91,7 @@ class LimitsControllerTestV21(BaseLimitTestSuite):
         """Helper to set routing arguments."""
         request = webob.Request.blank("/")
         if tenant_id:
-            request = webob.Request.blank("/?tenant_id=%s" % tenant_id)
+            request = webob.Request.blank("/?tenant_id={0!s}".format(tenant_id))
 
         request.accept = accept_header
         request.environ["wsgiorg.routing_args"] = (None, {
@@ -360,8 +360,8 @@ class LimitMiddlewareTest(BaseLimitTestSuite):
         super(LimitMiddlewareTest, self).setUp()
         _limits = '(GET, *, .*, 1, MINUTE)'
         self.app = limits.RateLimitingMiddleware(self._empty_app, _limits,
-                                                 "%s.MockLimiter" %
-                                                 self.__class__.__module__)
+                                                 "{0!s}.MockLimiter".format(
+                                                 self.__class__.__module__))
 
     def test_limit_class(self):
         # Test that middleware selected correct limiter class.
@@ -673,7 +673,7 @@ class WsgiLimiterTest(BaseLimitTestSuite):
         delay and make sure that the WSGI app returns the correct response.
         """
         if username:
-            request = webob.Request.blank("/%s" % username)
+            request = webob.Request.blank("/{0!s}".format(username))
         else:
             request = webob.Request.blank("/")
 
@@ -758,7 +758,7 @@ class FakeHttplibConnection(object):
         req.body = encodeutils.safe_encode(body)
 
         resp = str(req.get_response(self.app))
-        resp = "HTTP/1.0 %s" % resp
+        resp = "HTTP/1.0 {0!s}".format(resp)
         sock = FakeHttplibSocket(resp)
         self.http_response = httplib.HTTPResponse(sock)
         self.http_response.begin()
@@ -915,5 +915,5 @@ class LimitsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, req=req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_lock_server.py
+++ b/nova/tests/unit/api/openstack/compute/test_lock_server.py
@@ -91,7 +91,7 @@ class LockServerPolicyEnforcementV21(test.NoDBTestCase):
                                 fakes.FAKE_UUID,
                                 body={'lock': {}})
         self.assertEqual(
-                      "Policy doesn't allow %s to be performed." % rule_name,
+                      "Policy doesn't allow {0!s} to be performed.".format(rule_name),
                       exc.format_message())
 
     def test_unlock_policy_failed(self):
@@ -103,7 +103,7 @@ class LockServerPolicyEnforcementV21(test.NoDBTestCase):
                                 fakes.FAKE_UUID,
                                 body={'unlock': {}})
         self.assertEqual(
-                      "Policy doesn't allow %s to be performed." % rule_name,
+                      "Policy doesn't allow {0!s} to be performed.".format(rule_name),
                       exc.format_message())
 
     @mock.patch.object(common, 'get_instance')
@@ -122,5 +122,5 @@ class LockServerPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized, self.controller._unlock,
             self.req, fakes.FAKE_UUID, body={'unlock': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_migrate_server.py
+++ b/nova/tests/unit/api/openstack/compute/test_migrate_server.py
@@ -342,7 +342,7 @@ class MigrateServerPolicyEnforcementV21(test.NoDBTestCase):
                                 fakes.FAKE_UUID,
                                 body={'migrate': {}})
         self.assertEqual(
-                      "Policy doesn't allow %s to be performed." % rule_name,
+                      "Policy doesn't allow {0!s} to be performed.".format(rule_name),
                       exc.format_message())
 
     def test_migrate_live_policy_failed(self):
@@ -357,5 +357,5 @@ class MigrateServerPolicyEnforcementV21(test.NoDBTestCase):
                                 fakes.FAKE_UUID,
                                 body=body_args)
         self.assertEqual(
-                      "Policy doesn't allow %s to be performed." % rule_name,
+                      "Policy doesn't allow {0!s} to be performed.".format(rule_name),
                       exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_migrations.py
+++ b/nova/tests/unit/api/openstack/compute/test_migrations.py
@@ -252,7 +252,7 @@ class MigrationsPolicyEnforcement(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
 

--- a/nova/tests/unit/api/openstack/compute/test_multinic.py
+++ b/nova/tests/unit/api/openstack/compute/test_multinic.py
@@ -189,7 +189,7 @@ class MultinicPolicyEnforcementV21(test.NoDBTestCase):
             self.controller._add_fixed_ip, self.req, fakes.FAKE_UUID,
             body={'addFixedIp': {'networkId': fakes.FAKE_UUID}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_remove_fixed_ip_policy_failed(self):
@@ -200,5 +200,5 @@ class MultinicPolicyEnforcementV21(test.NoDBTestCase):
             self.controller._remove_fixed_ip, self.req, fakes.FAKE_UUID,
             body={'removeFixedIp': {'address': "10.0.0.1"}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_multiple_create.py
+++ b/nova/tests/unit/api/openstack/compute/test_multiple_create.py
@@ -65,7 +65,7 @@ class MultiCreateExtensionTestV21(test.TestCase):
         def instance_create(context, inst):
             inst_type = flavors.get_flavor_by_flavor_id(3)
             image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-            def_image_ref = 'http://localhost/images/%s' % image_uuid
+            def_image_ref = 'http://localhost/images/{0!s}'.format(image_uuid)
             self.instance_cache_num += 1
             instance = fake_instance.fake_db_instance(**{
                 'id': self.instance_cache_num,
@@ -532,7 +532,7 @@ class MultiCreateExtensionTestV2(MultiCreateExtensionTestV21):
         def instance_create(context, inst):
             inst_type = flavors.get_flavor_by_flavor_id(3)
             image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-            def_image_ref = 'http://localhost/images/%s' % image_uuid
+            def_image_ref = 'http://localhost/images/{0!s}'.format(image_uuid)
             self.instance_cache_num += 1
             instance = fake_instance.fake_db_instance(**{
                 'id': self.instance_cache_num,

--- a/nova/tests/unit/api/openstack/compute/test_networks.py
+++ b/nova/tests/unit/api/openstack/compute/test_networks.py
@@ -596,7 +596,7 @@ class NetworksAssociateTestV21(test.NoDBTestCase):
 
     def test_network_associate_project_delete_fail(self):
         uuid = FAKE_NETWORKS[0]['uuid']
-        req = fakes.HTTPRequest.blank('/v2/1234/os-networks/%s/action' % uuid)
+        req = fakes.HTTPRequest.blank('/v2/1234/os-networks/{0!s}/action'.format(uuid))
         self.assertRaises(webob.exc.HTTPConflict,
                                     self.controller.delete, req, -1)
 
@@ -708,7 +708,7 @@ class NetworksEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.show, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_index_policy_failed(self):
@@ -718,7 +718,7 @@ class NetworksEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_create_policy_failed(self):
@@ -728,7 +728,7 @@ class NetworksEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.create, self.req, body=NEW_NETWORK)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_delete_policy_failed(self):
@@ -738,7 +738,7 @@ class NetworksEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.delete, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_add_policy_failed(self):
@@ -749,7 +749,7 @@ class NetworksEnforcementV21(test.NoDBTestCase):
             self.controller.add, self.req,
             body={'id': fakes.FAKE_UUID})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_disassociate_policy_failed(self):
@@ -760,7 +760,7 @@ class NetworksEnforcementV21(test.NoDBTestCase):
             self.controller._disassociate_host_and_project,
             self.req, fakes.FAKE_UUID, body={'network': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
 
@@ -780,7 +780,7 @@ class NetworksAssociateEnforcementV21(test.NoDBTestCase):
             self.controller._disassociate_host_only,
             self.req, fakes.FAKE_UUID, body={'disassociate_host': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_disassociate_project_only_policy_failed(self):
@@ -791,7 +791,7 @@ class NetworksAssociateEnforcementV21(test.NoDBTestCase):
             self.controller._disassociate_project_only,
             self.req, fakes.FAKE_UUID, body={'disassociate_project': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_disassociate_host_only_policy_failed(self):
@@ -802,5 +802,5 @@ class NetworksAssociateEnforcementV21(test.NoDBTestCase):
             self.controller._associate_host,
             self.req, fakes.FAKE_UUID, body={'associate_host': 'fake_host'})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_neutron_security_groups.py
+++ b/nova/tests/unit/api/openstack/compute/test_neutron_security_groups.py
@@ -152,30 +152,28 @@ class TestNeutronSecurityGroupsV21(
                     'name': 'test', 'description': 'test-description'}]
         self.stub_out('nova.db.instance_get_by_uuid',
                       test_security_groups.return_server_by_uuid)
-        req = fakes.HTTPRequest.blank('/v2/fake/servers/%s/os-security-groups'
-                                      % test_security_groups.FAKE_UUID1)
+        req = fakes.HTTPRequest.blank('/v2/fake/servers/{0!s}/os-security-groups'.format(test_security_groups.FAKE_UUID1))
         res_dict = self.server_controller.index(
             req, test_security_groups.FAKE_UUID1)['security_groups']
         self.assertEqual(expected, res_dict)
 
     def test_get_security_group_by_id(self):
         sg = self._create_sg_template().get('security_group')
-        req = fakes.HTTPRequest.blank('/v2/fake/os-security-groups/%s'
-                                      % sg['id'])
+        req = fakes.HTTPRequest.blank('/v2/fake/os-security-groups/{0!s}'.format(sg['id']))
         res_dict = self.controller.show(req, sg['id'])
         expected = {'security_group': sg}
         self.assertEqual(res_dict, expected)
 
     def test_delete_security_group_by_id(self):
         sg = self._create_sg_template().get('security_group')
-        req = fakes.HTTPRequest.blank('/v2/fake/os-security-groups/%s' %
-                                      sg['id'])
+        req = fakes.HTTPRequest.blank('/v2/fake/os-security-groups/{0!s}'.format(
+                                      sg['id']))
         self.controller.delete(req, sg['id'])
 
     def test_delete_security_group_by_admin(self):
         sg = self._create_sg_template().get('security_group')
-        req = fakes.HTTPRequest.blank('/v2/fake/os-security-groups/%s' %
-                                      sg['id'], use_admin_context=True)
+        req = fakes.HTTPRequest.blank('/v2/fake/os-security-groups/{0!s}'.format(
+                                      sg['id']), use_admin_context=True)
         self.controller.delete(req, sg['id'])
 
     @mock.patch('nova.compute.utils.refresh_info_cache_for_instance')
@@ -193,8 +191,7 @@ class TestNeutronSecurityGroupsV21(
             neutron.allocate_for_instance(_context, instance,
                                           security_groups=[sg['id']])
 
-        req = fakes.HTTPRequest.blank('/v2/fake/os-security-groups/%s'
-                                      % sg['id'])
+        req = fakes.HTTPRequest.blank('/v2/fake/os-security-groups/{0!s}'.format(sg['id']))
         self.assertRaises(webob.exc.HTTPBadRequest, self.controller.delete,
                           req, sg['id'])
 
@@ -221,8 +218,8 @@ class TestNeutronSecurityGroupsV21(
                       test_security_groups.return_server)
         body = dict(addSecurityGroup=dict(name="test"))
 
-        req = fakes.HTTPRequest.blank('/v2/fake/servers/%s/action' %
-                                      UUID_SERVER)
+        req = fakes.HTTPRequest.blank('/v2/fake/servers/{0!s}/action'.format(
+                                      UUID_SERVER))
         self.manager._addSecurityGroup(req, UUID_SERVER, body)
 
     def test_associate_duplicate_names(self):
@@ -239,8 +236,8 @@ class TestNeutronSecurityGroupsV21(
                       test_security_groups.return_server)
         body = dict(addSecurityGroup=dict(name="sg1"))
 
-        req = fakes.HTTPRequest.blank('/v2/fake/servers/%s/action' %
-                                      UUID_SERVER)
+        req = fakes.HTTPRequest.blank('/v2/fake/servers/{0!s}/action'.format(
+                                      UUID_SERVER))
         self.assertRaises(webob.exc.HTTPConflict,
                           self.manager._addSecurityGroup,
                           req, UUID_SERVER, body)
@@ -257,8 +254,8 @@ class TestNeutronSecurityGroupsV21(
                       test_security_groups.return_server)
         body = dict(addSecurityGroup=dict(name="test"))
 
-        req = fakes.HTTPRequest.blank('/v2/fake/servers/%s/action' %
-                                      UUID_SERVER)
+        req = fakes.HTTPRequest.blank('/v2/fake/servers/{0!s}/action'.format(
+                                      UUID_SERVER))
         self.manager._addSecurityGroup(req, UUID_SERVER, body)
 
     def test_associate_port_security_enabled_false(self):
@@ -272,8 +269,8 @@ class TestNeutronSecurityGroupsV21(
                       test_security_groups.return_server)
         body = dict(addSecurityGroup=dict(name="test"))
 
-        req = fakes.HTTPRequest.blank('/v2/fake/servers/%s/action' %
-                                      UUID_SERVER)
+        req = fakes.HTTPRequest.blank('/v2/fake/servers/{0!s}/action'.format(
+                                      UUID_SERVER))
         self.assertRaises(webob.exc.HTTPBadRequest,
                           self.manager._addSecurityGroup,
                           req, UUID_SERVER, body)
@@ -283,8 +280,8 @@ class TestNeutronSecurityGroupsV21(
                       test_security_groups.return_server)
         body = dict(removeSecurityGroup=dict(name='non-existing'))
 
-        req = fakes.HTTPRequest.blank('/v2/fake/servers/%s/action' %
-                                      UUID_SERVER)
+        req = fakes.HTTPRequest.blank('/v2/fake/servers/{0!s}/action'.format(
+                                      UUID_SERVER))
         self.assertRaises(webob.exc.HTTPNotFound,
                           self.manager._removeSecurityGroup,
                           req, UUID_SERVER, body)
@@ -312,8 +309,8 @@ class TestNeutronSecurityGroupsV21(
                       test_security_groups.return_server)
         body = dict(removeSecurityGroup=dict(name="test"))
 
-        req = fakes.HTTPRequest.blank('/v2/fake/servers/%s/action' %
-                                      UUID_SERVER)
+        req = fakes.HTTPRequest.blank('/v2/fake/servers/{0!s}/action'.format(
+                                      UUID_SERVER))
         self.manager._removeSecurityGroup(req, UUID_SERVER, body)
 
     def test_get_raises_no_unique_match_error(self):
@@ -469,8 +466,7 @@ class _TestNeutronSecurityGroupRulesBase(object):
         req = fakes.HTTPRequest.blank('/v2/fake/os-security-group-rules')
         res_dict = self.controller.create(req, {'security_group_rule': rule})
         security_group_rule = res_dict['security_group_rule']
-        req = fakes.HTTPRequest.blank('/v2/fake/os-security-group-rules/%s'
-                                      % security_group_rule['id'])
+        req = fakes.HTTPRequest.blank('/v2/fake/os-security-group-rules/{0!s}'.format(security_group_rule['id']))
         self.controller.delete(req, security_group_rule['id'])
 
     def test_create_rule_quota_limit(self):
@@ -552,7 +548,7 @@ class TestNeutronSecurityGroupsOutputTest(TestNeutronSecurityGroupsTestCase):
         self.assertEqual(res.status_int, 202)
         server = self._get_server(res.body)
         for i, group in enumerate(self._get_groups(server)):
-            name = 'fake-2-%s' % i
+            name = 'fake-2-{0!s}'.format(i)
             self.assertEqual(group.get('name'), name)
 
     def test_create_server_get_default_security_group(self):
@@ -588,7 +584,7 @@ class TestNeutronSecurityGroupsOutputTest(TestNeutronSecurityGroupsTestCase):
         self.assertEqual(res.status_int, 202)
         server = self._get_server(res.body)
         for i, group in enumerate(self._get_groups(server)):
-            name = 'fake-2-%s' % i
+            name = 'fake-2-{0!s}'.format(i)
             self.assertEqual(group.get('name'), name)
 
         # Test that show (GET) returns the same information as create (POST)
@@ -598,7 +594,7 @@ class TestNeutronSecurityGroupsOutputTest(TestNeutronSecurityGroupsTestCase):
         server = self._get_server(res.body)
 
         for i, group in enumerate(self._get_groups(server)):
-            name = 'fake-2-%s' % i
+            name = 'fake-2-{0!s}'.format(i)
             self.assertEqual(group.get('name'), name)
 
     def test_detail(self):
@@ -608,7 +604,7 @@ class TestNeutronSecurityGroupsOutputTest(TestNeutronSecurityGroupsTestCase):
         self.assertEqual(res.status_int, 200)
         for i, server in enumerate(self._get_servers(res.body)):
             for j, group in enumerate(self._get_groups(server)):
-                name = 'fake-%s-%s' % (i, j)
+                name = 'fake-{0!s}-{1!s}'.format(i, j)
                 self.assertEqual(group.get('name'), name)
 
     def test_no_instance_passthrough_404(self):
@@ -687,7 +683,7 @@ class MockClient(object):
         try:
             net = self._fake_networks[s.get('network_id')]
         except KeyError:
-            msg = 'Network %s not found' % s.get('network_id')
+            msg = 'Network {0!s} not found'.format(s.get('network_id'))
             raise n_exc.NeutronClientException(message=msg, status_code=404)
         ret = {'name': s.get('name'), 'network_id': s.get('network_id'),
                'tenant_id': 'fake_tenant', 'cidr': s.get('cidr'),
@@ -748,7 +744,7 @@ class MockClient(object):
         try:
             sg = self._fake_security_groups[security_group]
         except KeyError:
-            msg = 'Security Group %s not found' % security_group
+            msg = 'Security Group {0!s} not found'.format(security_group)
             raise n_exc.NeutronClientException(message=msg, status_code=404)
         for security_group_rule in self._fake_security_group_rules.values():
             if security_group_rule['security_group_id'] == sg['id']:
@@ -761,7 +757,7 @@ class MockClient(object):
             return {'security_group_rule':
                     self._fake_security_group_rules[security_group_rule]}
         except KeyError:
-            msg = 'Security Group rule %s not found' % security_group_rule
+            msg = 'Security Group rule {0!s} not found'.format(security_group_rule)
             raise n_exc.NeutronClientException(message=msg, status_code=404)
 
     def show_network(self, network, **_params):
@@ -769,7 +765,7 @@ class MockClient(object):
             return {'network':
                     self._fake_networks[network]}
         except KeyError:
-            msg = 'Network %s not found' % network
+            msg = 'Network {0!s} not found'.format(network)
             raise n_exc.NeutronClientException(message=msg, status_code=404)
 
     def show_port(self, port, **_params):
@@ -777,7 +773,7 @@ class MockClient(object):
             return {'port':
                     self._fake_ports[port]}
         except KeyError:
-            msg = 'Port %s not found' % port
+            msg = 'Port {0!s} not found'.format(port)
             raise n_exc.NeutronClientException(message=msg, status_code=404)
 
     def show_subnet(self, subnet, **_params):
@@ -785,7 +781,7 @@ class MockClient(object):
             return {'subnet':
                     self._fake_subnets[subnet]}
         except KeyError:
-            msg = 'Port %s not found' % subnet
+            msg = 'Port {0!s} not found'.format(subnet)
             raise n_exc.NeutronClientException(message=msg, status_code=404)
 
     def list_security_groups(self, **_params):
@@ -843,8 +839,7 @@ class MockClient(object):
         for port in ports.get('ports'):
             for sg_port in port['security_groups']:
                 if sg_port == security_group:
-                    msg = ('Unable to delete Security group %s in use'
-                           % security_group)
+                    msg = ('Unable to delete Security group {0!s} in use'.format(security_group))
                     raise n_exc.NeutronClientException(message=msg,
                                                        status_code=409)
         del self._fake_security_groups[security_group]

--- a/nova/tests/unit/api/openstack/compute/test_pause_server.py
+++ b/nova/tests/unit/api/openstack/compute/test_pause_server.py
@@ -90,7 +90,7 @@ class PauseServerPolicyEnforcementV21(test.NoDBTestCase):
             self.controller._pause, req, fakes.FAKE_UUID,
             body={'pause': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_unpause_policy_failed(self):
@@ -102,5 +102,5 @@ class PauseServerPolicyEnforcementV21(test.NoDBTestCase):
             self.controller._unpause, req, fakes.FAKE_UUID,
             body={'unpause': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_pci.py
+++ b/nova/tests/unit/api/openstack/compute/test_pci.py
@@ -239,14 +239,14 @@ class PciControllerPolicyEnforcementV21(test.NoDBTestCase):
         self.req = fakes.HTTPRequest.blank('')
 
     def _test_policy_failed(self, action, *args):
-        rule_name = "os_compute_api:os-pci:%s" % action
+        rule_name = "os_compute_api:os-pci:{0!s}".format(action)
         rule = {rule_name: "project:non_fake"}
         self.policy.set_rules(rule)
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, getattr(self.controller, action),
             self.req, *args)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_index_policy_failed(self):

--- a/nova/tests/unit/api/openstack/compute/test_quota_classes.py
+++ b/nova/tests/unit/api/openstack/compute/test_quota_classes.py
@@ -177,7 +177,7 @@ class QuotaClassesPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.show, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_update_policy_failed(self):
@@ -188,5 +188,5 @@ class QuotaClassesPolicyEnforcementV21(test.NoDBTestCase):
             self.controller.update, self.req, fakes.FAKE_UUID,
             body={'quota_class_set': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_quotas.py
+++ b/nova/tests/unit/api/openstack/compute/test_quotas.py
@@ -710,7 +710,7 @@ class QuotaSetsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.delete, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_defaults_policy_failed(self):
@@ -720,7 +720,7 @@ class QuotaSetsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.defaults, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_show_policy_failed(self):
@@ -730,7 +730,7 @@ class QuotaSetsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.show, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_detail_policy_failed(self):
@@ -740,7 +740,7 @@ class QuotaSetsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.detail, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_update_policy_failed(self):
@@ -751,5 +751,5 @@ class QuotaSetsPolicyEnforcementV21(test.NoDBTestCase):
             self.controller.update, self.req, fakes.FAKE_UUID,
             body={'quota_set': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_remote_consoles.py
+++ b/nova/tests/unit/api/openstack/compute/test_remote_consoles.py
@@ -635,7 +635,7 @@ class TestRemoteConsolePolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_remote_vnc_console_policy_failed(self):

--- a/nova/tests/unit/api/openstack/compute/test_rescue.py
+++ b/nova/tests/unit/api/openstack/compute/test_rescue.py
@@ -219,7 +219,7 @@ class RescuePolicyEnforcementV21(test.NoDBTestCase):
             self.controller._rescue, self.req, fakes.FAKE_UUID,
             body=body)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_unrescue_policy_failed(self):
@@ -231,5 +231,5 @@ class RescuePolicyEnforcementV21(test.NoDBTestCase):
             self.controller._unrescue, self.req, fakes.FAKE_UUID,
             body=body)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_scheduler_hints.py
+++ b/nova/tests/unit/api/openstack/compute/test_scheduler_hints.py
@@ -186,7 +186,7 @@ class ServersControllerCreateTestV21(test.TestCase):
         def instance_create(context, inst):
             inst_type = flavors.get_flavor_by_flavor_id(3)
             image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-            def_image_ref = 'http://localhost/images/%s' % image_uuid
+            def_image_ref = 'http://localhost/images/{0!s}'.format(image_uuid)
             self.instance_cache_num += 1
             instance = fake_instance.fake_db_instance(**{
                 'id': self.instance_cache_num,

--- a/nova/tests/unit/api/openstack/compute/test_security_group_default_rules.py
+++ b/nova/tests/unit/api/openstack/compute/test_security_group_default_rules.py
@@ -354,8 +354,8 @@ class SecurityGroupDefaultRulesPolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." %
-            rule_name, exc.format_message())
+            "Policy doesn't allow {0!s} to be performed.".format(
+            rule_name), exc.format_message())
 
     def test_create_policy_failed(self):
         self._common_policy_check(self.controller.create, self.req, {})

--- a/nova/tests/unit/api/openstack/compute/test_security_groups.py
+++ b/nova/tests/unit/api/openstack/compute/test_security_groups.py
@@ -309,7 +309,7 @@ class TestSecurityGroupsV21(test.TestCase):
 
     def test_create_security_group_quota_limit(self):
         for num in range(1, CONF.quota_security_groups):
-            name = 'test%s' % num
+            name = 'test{0!s}'.format(num)
             sg = security_group_request_template(name=name)
             res_dict = self.controller.create(self.req, {'security_group': sg})
             self.assertEqual(res_dict['security_group']['name'], name)
@@ -412,7 +412,7 @@ class TestSecurityGroupsV21(test.TestCase):
         res_dict = self.controller.index(req)
         self.assertEqual(res_dict, tenant_specific)
 
-        req = fakes.HTTPRequest.blank('%s?all_tenants=1' % path,
+        req = fakes.HTTPRequest.blank('{0!s}?all_tenants=1'.format(path),
                                       use_admin_context=True)
         res_dict = self.controller.index(req)
         self.assertEqual(res_dict, all)
@@ -1364,7 +1364,7 @@ class SecurityGroupsOutputTestV21(test.TestCase):
         self.assertEqual(res.status_int, 202)
         server = self._get_server(res.body)
         for i, group in enumerate(self._get_groups(server)):
-            name = 'fake-2-%s' % i
+            name = 'fake-2-{0!s}'.format(i)
             self.assertEqual(group.get('name'), name)
 
     def test_show(self):
@@ -1374,7 +1374,7 @@ class SecurityGroupsOutputTestV21(test.TestCase):
         self.assertEqual(res.status_int, 200)
         server = self._get_server(res.body)
         for i, group in enumerate(self._get_groups(server)):
-            name = 'fake-2-%s' % i
+            name = 'fake-2-{0!s}'.format(i)
             self.assertEqual(group.get('name'), name)
 
     def test_detail(self):
@@ -1384,7 +1384,7 @@ class SecurityGroupsOutputTestV21(test.TestCase):
         self.assertEqual(res.status_int, 200)
         for i, server in enumerate(self._get_servers(res.body)):
             for j, group in enumerate(self._get_groups(server)):
-                name = 'fake-%s-%s' % (i, j)
+                name = 'fake-{0!s}-{1!s}'.format(i, j)
                 self.assertEqual(group.get('name'), name)
 
     def test_no_instance_passthrough_404(self):
@@ -1468,7 +1468,7 @@ class PolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % self.rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(self.rule_name),
             exc.format_message())
 
 

--- a/nova/tests/unit/api/openstack/compute/test_server_actions.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_actions.py
@@ -309,7 +309,7 @@ class ServerActionsControllerTestV21(test.TestCase):
         return_server = fakes.fake_instance_get(image_ref='2',
                 vm_state=vm_states.ACTIVE, host='fake_host')
         self.stub_out('nova.db.instance_get_by_uuid', return_server)
-        self_href = 'http://localhost/v2/servers/%s' % FAKE_UUID
+        self_href = 'http://localhost/v2/servers/{0!s}'.format(FAKE_UUID)
 
         body = {
             "rebuild": {
@@ -374,7 +374,7 @@ class ServerActionsControllerTestV21(test.TestCase):
         return_server = fakes.fake_instance_get(image_ref='2',
                 vm_state=vm_states.ACTIVE, host='fake_host')
         self.stub_out('nova.db.instance_get_by_uuid', return_server)
-        self_href = 'http://localhost/v2/servers/%s' % FAKE_UUID
+        self_href = 'http://localhost/v2/servers/{0!s}'.format(FAKE_UUID)
 
         body = {
             "rebuild": {
@@ -935,7 +935,7 @@ class ServerActionsControllerTestV21(test.TestCase):
     def _do_test_create_volume_backed_image(self, extra_properties):
 
         def _fake_id(x):
-            return '%s-%s-%s-%s' % (x * 8, x * 4, x * 4, x * 12)
+            return '{0!s}-{1!s}-{2!s}-{3!s}'.format(x * 8, x * 4, x * 4, x * 12)
 
         body = dict(createImage=dict(name='snapshot_of_volume_backed'))
 
@@ -1033,7 +1033,7 @@ class ServerActionsControllerTestV21(test.TestCase):
             self, extra_metadata=None):
 
         def _fake_id(x):
-            return '%s-%s-%s-%s' % (x * 8, x * 4, x * 4, x * 12)
+            return '{0!s}-{1!s}-{2!s}-{3!s}'.format(x * 8, x * 4, x * 4, x * 12)
 
         body = dict(createImage=dict(name='snapshot_of_volume_backed'))
         if extra_metadata:
@@ -1141,7 +1141,7 @@ class ServerActionsControllerTestV21(test.TestCase):
             },
         }
         for num in range(CONF.quota_metadata_items + 1):
-            body['createImage']['metadata']['foo%i' % num] = "bar"
+            body['createImage']['metadata']['foo{0:d}'.format(num)] = "bar"
 
         self.assertRaises(webob.exc.HTTPForbidden,
                           self.controller._action_create_image,
@@ -1334,7 +1334,7 @@ class ServerActionsControllerTestV2(ServerActionsControllerTestV21):
                               self.controller._action_create_image,
                               self.req, FAKE_UUID, body=body)
             self.assertEqual(
-                "Policy doesn't allow %s to be performed." % rule_name,
+                "Policy doesn't allow {0!s} to be performed.".format(rule_name),
                 exc.format_message())
 
     def test_create_vol_backed_img_snapshotting_policy_blocks_role(self):
@@ -1358,5 +1358,5 @@ class ServerActionsControllerTestV2(ServerActionsControllerTestV21):
                               self.controller._action_create_image,
                               self.req, FAKE_UUID, body=body)
             self.assertEqual(
-                "Policy doesn't allow %s to be performed." % rule_name,
+                "Policy doesn't allow {0!s} to be performed.".format(rule_name),
                 exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_server_diagnostics.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_diagnostics.py
@@ -46,7 +46,7 @@ class ServerDiagnosticsTestV21(test.NoDBTestCase):
 
     def _get_request(self):
         return fakes.HTTPRequest.blank(
-                   '/fake/servers/%s/diagnostics' % UUID)
+                   '/fake/servers/{0!s}/diagnostics'.format(UUID))
 
     def setUp(self):
         super(ServerDiagnosticsTestV21, self).setUp()
@@ -115,5 +115,5 @@ class ServerDiagnosticsEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_server_metadata.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_metadata.py
@@ -54,7 +54,7 @@ def fake_instance_save(inst, **kwargs):
 
 def return_server_metadata(context, server_id):
     if not isinstance(server_id, six.string_types) or not len(server_id) == 36:
-        msg = 'id %s must be a uuid in return server metadata' % server_id
+        msg = 'id {0!s} must be a uuid in return server metadata'.format(server_id)
         raise Exception(msg)
     return stub_server_metadata()
 
@@ -79,7 +79,7 @@ def stub_server_metadata():
 def stub_max_server_metadata():
     metadata = {"metadata": {}}
     for num in range(CONF.quota_metadata_items):
-        metadata['metadata']['key%i' % num] = "blah"
+        metadata['metadata']['key{0:d}'.format(num)] = "blah"
     return metadata
 
 
@@ -135,7 +135,7 @@ class ServerMetaDataTestV21(test.TestCase):
     def _set_up_resources(self):
         self.controller = server_metadata_v21.ServerMetadataController()
         self.uuid = str(uuid.uuid4())
-        self.url = '/fake/servers/%s/metadata' % self.uuid
+        self.url = '/fake/servers/{0!s}/metadata'.format(self.uuid)
 
     def _get_request(self, param_url=''):
         return fakes.HTTPRequestV21.blank(self.url + param_url)
@@ -586,7 +586,7 @@ class ServerMetaDataTestV21(test.TestCase):
                       return_create_instance_metadata)
         data = {"metadata": {}}
         for num in range(CONF.quota_metadata_items + 1):
-            data['metadata']['key%i' % num] = "blah"
+            data['metadata']['key{0:d}'.format(num)] = "blah"
         req = self._get_request()
         req.method = 'POST'
         req.body = jsonutils.dump_as_bytes(data)
@@ -625,7 +625,7 @@ class ServerMetaDataTestV21(test.TestCase):
                       return_create_instance_metadata)
         data = {"metadata": {}}
         for num in range(CONF.quota_metadata_items + 1):
-            data['metadata']['key%i' % num] = "blah"
+            data['metadata']['key{0:d}'.format(num)] = "blah"
         req = self._get_request()
         req.method = 'PUT'
         req.body = jsonutils.dump_as_bytes(data)
@@ -641,7 +641,7 @@ class ServerMetaDataTestV21(test.TestCase):
                       return_create_instance_metadata)
         data = {"metadata": {}}
         for num in range(CONF.quota_metadata_items + 1):
-            data['metadata']['key%i' % num] = "blah"
+            data['metadata']['key{0:d}'.format(num)] = "blah"
         req = self._get_request()
         req.method = 'PUT'
         req.body = jsonutils.dump_as_bytes(data)
@@ -676,7 +676,7 @@ class ServerMetaDataTestV2(ServerMetaDataTestV21):
     def _set_up_resources(self):
         self.controller = server_metadata_v2.Controller()
         self.uuid = str(uuid.uuid4())
-        self.url = '/v1.1/fake/servers/%s/metadata' % self.uuid
+        self.url = '/v1.1/fake/servers/{0!s}/metadata'.format(self.uuid)
 
     def _get_request(self, param_url=''):
         return fakes.HTTPRequest.blank(self.url + param_url)
@@ -701,7 +701,7 @@ class BadStateServerMetaDataTestV21(test.TestCase):
     def _set_up_resources(self):
         self.controller = server_metadata_v21.ServerMetadataController()
         self.uuid = str(uuid.uuid4())
-        self.url = '/fake/servers/%s/metadata' % self.uuid
+        self.url = '/fake/servers/{0!s}/metadata'.format(self.uuid)
 
     def _get_request(self, param_url=''):
         return fakes.HTTPRequestV21.blank(self.url + param_url)
@@ -766,7 +766,7 @@ class BadStateServerMetaDataTestV2(BadStateServerMetaDataTestV21):
     def _set_up_resources(self):
         self.controller = server_metadata_v2.Controller()
         self.uuid = str(uuid.uuid4())
-        self.url = '/v1.1/fake/servers/%s/metadata' % self.uuid
+        self.url = '/v1.1/fake/servers/{0!s}/metadata'.format(self.uuid)
 
     def _get_request(self, param_url=''):
         return fakes.HTTPRequest.blank(self.url + param_url)
@@ -787,7 +787,7 @@ class ServerMetaPolicyEnforcementV21(test.NoDBTestCase):
             self.controller.create, self.req, fakes.FAKE_UUID,
             body={'metadata': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_index_policy_failed(self):
@@ -797,7 +797,7 @@ class ServerMetaPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_update_policy_failed(self):
@@ -808,7 +808,7 @@ class ServerMetaPolicyEnforcementV21(test.NoDBTestCase):
             self.controller.update, self.req, fakes.FAKE_UUID, fakes.FAKE_UUID,
             body={'meta': {'fake_meta': 'fake_meta'}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_update_all_policy_failed(self):
@@ -819,7 +819,7 @@ class ServerMetaPolicyEnforcementV21(test.NoDBTestCase):
             self.controller.update_all, self.req, fakes.FAKE_UUID,
             body={'metadata': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_delete_policy_failed(self):
@@ -829,7 +829,7 @@ class ServerMetaPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.delete, self.req, fakes.FAKE_UUID, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_show_policy_failed(self):
@@ -839,5 +839,5 @@ class ServerMetaPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.show, self.req, fakes.FAKE_UUID, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_server_migrations.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_migrations.py
@@ -339,7 +339,7 @@ class ServerMigrationsPolicyEnforcementV21(test.NoDBTestCase):
                                 fakes.FAKE_UUID, fakes.FAKE_UUID,
                                 body=body_args)
         self.assertEqual(
-                      "Policy doesn't allow %s to be performed." % rule_name,
+                      "Policy doesn't allow {0!s} to be performed.".format(rule_name),
                       exc.format_message())
 
 
@@ -357,8 +357,8 @@ class ServerMigrationsPolicyEnforcementV223(
         exc = self.assertRaises(exception.PolicyNotAuthorized,
                                 self.controller.index, self.req,
                                 fakes.FAKE_UUID)
-        self.assertEqual("Policy doesn't allow %s to be performed." %
-                         rule_name, exc.format_message())
+        self.assertEqual("Policy doesn't allow {0!s} to be performed.".format(
+                         rule_name), exc.format_message())
 
     def test_migration_show_failed(self):
         rule_name = "os_compute_api:servers:migrations:show"
@@ -366,8 +366,8 @@ class ServerMigrationsPolicyEnforcementV223(
         exc = self.assertRaises(exception.PolicyNotAuthorized,
                                 self.controller.show, self.req,
                                 fakes.FAKE_UUID, 1)
-        self.assertEqual("Policy doesn't allow %s to be performed." %
-                         rule_name, exc.format_message())
+        self.assertEqual("Policy doesn't allow {0!s} to be performed.".format(
+                         rule_name), exc.format_message())
 
 
 class ServerMigrationsPolicyEnforcementV224(

--- a/nova/tests/unit/api/openstack/compute/test_server_password.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_password.py
@@ -95,7 +95,7 @@ class ServerPasswordPolicyEnforcementV21(test.NoDBTestCase):
             method, self.req, fakes.FAKE_UUID)
 
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_get_password_policy_failed(self):

--- a/nova/tests/unit/api/openstack/compute/test_server_reset_state.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_reset_state.py
@@ -81,7 +81,7 @@ class ResetStateTestsV21(test.NoDBTestCase):
                              instance.obj_what_changed())
             for k, v in expected.items():
                 self.assertEqual(v, getattr(instance, k),
-                                 "Instance.%s doesn't match" % k)
+                                 "Instance.{0!s} doesn't match".format(k))
             instance.obj_reset_changes()
 
         self.compute_api.get(self.context, instance.uuid, expected_attrs=None,

--- a/nova/tests/unit/api/openstack/compute/test_server_usage.py
+++ b/nova/tests/unit/api/openstack/compute/test_server_usage.py
@@ -89,16 +89,16 @@ class ServerUsageTestV21(test.TestCase):
 
     def assertServerUsage(self, server, launched_at, terminated_at):
         resp_launched_at = timeutils.parse_isotime(
-            server.get('%slaunched_at' % self.prefix))
+            server.get('{0!s}launched_at'.format(self.prefix)))
         self.assertEqual(timeutils.normalize_time(resp_launched_at),
                          launched_at)
         resp_terminated_at = timeutils.parse_isotime(
-            server.get('%sterminated_at' % self.prefix))
+            server.get('{0!s}terminated_at'.format(self.prefix)))
         self.assertEqual(timeutils.normalize_time(resp_terminated_at),
                          terminated_at)
 
     def test_show(self):
-        url = self._prefix + ('/servers/%s' % UUID3)
+        url = self._prefix + ('/servers/{0!s}'.format(UUID3))
         res = self._make_request(url)
 
         self.assertEqual(res.status_int, 200)

--- a/nova/tests/unit/api/openstack/compute/test_serversV21.py
+++ b/nova/tests/unit/api/openstack/compute/test_serversV21.py
@@ -172,7 +172,7 @@ class Base64ValidationTest(test.TestCase):
     def test_decode_base64_whitespace(self):
         value = "A random string"
         encoded = base64.b64encode(value)
-        white = "\n \n%s\t%s\n" % (encoded[:2], encoded[2:])
+        white = "\n \n{0!s}\t{1!s}\n".format(encoded[:2], encoded[2:])
         result = self.controller._decode_base64(white)
         self.assertEqual(result, value)
 
@@ -184,7 +184,7 @@ class Base64ValidationTest(test.TestCase):
     def test_decode_base64_illegal_bytes(self):
         value = "A random string"
         encoded = base64.b64encode(value)
-        white = ">\x01%s*%s()" % (encoded[:2], encoded[2:])
+        white = ">\x01{0!s}*{1!s}()".format(encoded[:2], encoded[2:])
         result = self.controller._decode_base64(white)
         self.assertIsNone(result)
 
@@ -301,7 +301,7 @@ class ServersControllerTest(ControllerTest):
         self.assertEqual([(None, None, port, None)], res.as_tuples())
 
     def test_get_server_by_uuid(self):
-        req = self.req('/fake/servers/%s' % FAKE_UUID)
+        req = self.req('/fake/servers/{0!s}'.format(FAKE_UUID))
         res_dict = self.controller.show(req, FAKE_UUID)
         self.assertEqual(res_dict['server']['id'], FAKE_UUID)
 
@@ -317,7 +317,7 @@ class ServersControllerTest(ControllerTest):
 
         self.stubs.Set(compute_api.API, 'get', fake_get)
 
-        req = self.req('/fake/servers/%s' % FAKE_UUID)
+        req = self.req('/fake/servers/{0!s}'.format(FAKE_UUID))
         self.controller.show(req, FAKE_UUID)
 
     def test_unique_host_id(self):
@@ -333,7 +333,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get',
                        return_instance_with_host)
 
-        req = self.req('/fake/servers/%s' % FAKE_UUID)
+        req = self.req('/fake/servers/{0!s}'.format(FAKE_UUID))
         with mock.patch.object(compute_api.API, 'get') as mock_get:
             mock_get.side_effect = return_instance_with_host
             server1 = self.controller.show(req, FAKE_UUID)
@@ -389,11 +389,11 @@ class ServersControllerTest(ControllerTest):
                 "links": [
                     {
                         "rel": "self",
-                        "href": "http://localhost/v2/fake/servers/%s" % uuid,
+                        "href": "http://localhost/v2/fake/servers/{0!s}".format(uuid),
                     },
                     {
                         "rel": "bookmark",
-                        "href": "http://localhost/fake/servers/%s" % uuid,
+                        "href": "http://localhost/fake/servers/{0!s}".format(uuid),
                     },
                 ],
             }
@@ -405,7 +405,7 @@ class ServersControllerTest(ControllerTest):
         flavor_bookmark = "http://localhost/fake/flavors/2"
 
         uuid = FAKE_UUID
-        req = self.req('/v2/fake/servers/%s' % uuid)
+        req = self.req('/v2/fake/servers/{0!s}'.format(uuid))
         res_dict = self.controller.show(req, uuid)
 
         expected_server = self._get_server_data_dict(uuid,
@@ -427,7 +427,7 @@ class ServersControllerTest(ControllerTest):
                        lambda api, *a, **k: new_return_server(*a, **k))
 
         uuid = FAKE_UUID
-        req = self.req('/fake/servers/%s' % uuid)
+        req = self.req('/fake/servers/{0!s}'.format(uuid))
         res_dict = self.controller.show(req, uuid)
         expected_server = self._get_server_data_dict(uuid,
                                                      image_bookmark,
@@ -447,7 +447,7 @@ class ServersControllerTest(ControllerTest):
                        lambda api, *a, **k: new_return_server(*a, **k))
 
         uuid = FAKE_UUID
-        req = self.req('/fake/servers/%s' % uuid)
+        req = self.req('/fake/servers/{0!s}'.format(uuid))
         res_dict = self.controller.show(req, uuid)
         expected_server = self._get_server_data_dict(uuid,
                                                      image_bookmark,
@@ -488,7 +488,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get',
                        lambda api, *a, **k: return_server(*a, **k))
 
-        req = self.req('/fake/servers/%s/ips' % FAKE_UUID)
+        req = self.req('/fake/servers/{0!s}/ips'.format(FAKE_UUID))
         res_dict = self.ips_controller.index(req, FAKE_UUID)
 
         expected = {
@@ -513,7 +513,7 @@ class ServersControllerTest(ControllerTest):
             self.assertEqual(label, labels[index])
 
     def test_get_server_addresses_nonexistent_network(self):
-        url = '/v2/fake/servers/%s/ips/network_0' % FAKE_UUID
+        url = '/v2/fake/servers/{0!s}/ips/network_0'.format(FAKE_UUID)
         req = self.req(url)
         self.assertRaises(webob.exc.HTTPNotFound, self.ips_controller.show,
                           req, FAKE_UUID, 'network_0')
@@ -525,7 +525,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get', fake_instance_get)
 
         server_id = str(uuid.uuid4())
-        req = self.req('/fake/servers/%s/ips' % server_id)
+        req = self.req('/fake/servers/{0!s}/ips'.format(server_id))
         self.assertRaises(webob.exc.HTTPNotFound,
                           self.ips_controller.index, req, server_id)
 
@@ -545,7 +545,7 @@ class ServersControllerTest(ControllerTest):
 
         i = 0
         for s in res_dict['servers']:
-            self.assertEqual(s.get('name'), 'server%d' % (i + 1))
+            self.assertEqual(s.get('name'), 'server{0:d}'.format((i + 1)))
             i += 1
 
     def test_get_server_list_with_reservation_id_empty(self):
@@ -555,7 +555,7 @@ class ServersControllerTest(ControllerTest):
 
         i = 0
         for s in res_dict['servers']:
-            self.assertEqual(s.get('name'), 'server%d' % (i + 1))
+            self.assertEqual(s.get('name'), 'server{0:d}'.format((i + 1)))
             i += 1
 
     def test_get_server_list_with_reservation_id_details(self):
@@ -565,7 +565,7 @@ class ServersControllerTest(ControllerTest):
 
         i = 0
         for s in res_dict['servers']:
-            self.assertEqual(s.get('name'), 'server%d' % (i + 1))
+            self.assertEqual(s.get('name'), 'server{0:d}'.format((i + 1)))
             i += 1
 
     def test_get_server_list(self):
@@ -575,17 +575,17 @@ class ServersControllerTest(ControllerTest):
         self.assertEqual(len(res_dict['servers']), 5)
         for i, s in enumerate(res_dict['servers']):
             self.assertEqual(s['id'], fakes.get_fake_uuid(i))
-            self.assertEqual(s['name'], 'server%d' % (i + 1))
+            self.assertEqual(s['name'], 'server{0:d}'.format((i + 1)))
             self.assertIsNone(s.get('image', None))
 
             expected_links = [
                 {
                     "rel": "self",
-                    "href": "http://localhost/v2/fake/servers/%s" % s['id'],
+                    "href": "http://localhost/v2/fake/servers/{0!s}".format(s['id']),
                 },
                 {
                     "rel": "bookmark",
-                    "href": "http://localhost/fake/servers/%s" % s['id'],
+                    "href": "http://localhost/fake/servers/{0!s}".format(s['id']),
                 },
             ]
 
@@ -677,14 +677,14 @@ class ServersControllerTest(ControllerTest):
                           self.controller.index, req)
 
     def test_get_servers_with_marker(self):
-        url = '/v2/fake/servers?marker=%s' % fakes.get_fake_uuid(2)
+        url = '/v2/fake/servers?marker={0!s}'.format(fakes.get_fake_uuid(2))
         req = self.req(url)
         servers = self.controller.index(req)['servers']
         self.assertEqual([s['name'] for s in servers], ["server4", "server5"])
 
     def test_get_servers_with_limit_and_marker(self):
-        url = ('/v2/fake/servers?limit=2&marker=%s' %
-               fakes.get_fake_uuid(1))
+        url = ('/v2/fake/servers?limit=2&marker={0!s}'.format(
+               fakes.get_fake_uuid(1)))
         req = self.req(url)
         servers = self.controller.index(req)['servers']
         self.assertEqual([s['name'] for s in servers], ['server3', 'server4'])
@@ -1090,7 +1090,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get_all', fake_get_all)
 
         params = 'changes-since=2011-01-24T17:08:01Z'
-        req = self.req('/fake/servers?%s' % params)
+        req = self.req('/fake/servers?{0!s}'.format(params))
         servers = self.controller.index(req)['servers']
 
         self.assertEqual(len(servers), 1)
@@ -1098,7 +1098,7 @@ class ServersControllerTest(ControllerTest):
 
     def test_get_servers_allows_changes_since_bad_value(self):
         params = 'changes-since=asdf'
-        req = self.req('/fake/servers?%s' % params)
+        req = self.req('/fake/servers?{0!s}'.format(params))
         self.assertRaises(webob.exc.HTTPBadRequest, self.controller.index, req)
 
     def test_get_servers_admin_filters_as_user(self):
@@ -1125,7 +1125,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get_all', fake_get_all)
 
         query_str = "name=foo&ip=10.*&status=active&unknown_option=meow"
-        req = fakes.HTTPRequest.blank('/fake/servers?%s' % query_str)
+        req = fakes.HTTPRequest.blank('/fake/servers?{0!s}'.format(query_str))
         res = self.controller.index(req)
 
         servers = res['servers']
@@ -1155,7 +1155,7 @@ class ServersControllerTest(ControllerTest):
         self.stubs.Set(compute_api.API, 'get_all', fake_get_all)
 
         query_str = "name=foo&ip=10.*&status=active&unknown_option=meow"
-        req = self.req('/fake/servers?%s' % query_str,
+        req = self.req('/fake/servers?{0!s}'.format(query_str),
                                       use_admin_context=True)
         servers = self.controller.index(req)['servers']
 
@@ -1257,7 +1257,7 @@ class ServersControllerTest(ControllerTest):
         for i, s in enumerate(res_dict['servers']):
             self.assertEqual(s['id'], fakes.get_fake_uuid(i))
             self.assertEqual(s['hostId'], '')
-            self.assertEqual(s['name'], 'server%d' % (i + 1))
+            self.assertEqual(s['name'], 'server{0:d}'.format((i + 1)))
             self.assertEqual(s['image'], expected_image)
             self.assertEqual(s['flavor'], expected_flavor)
             self.assertEqual(s['status'], 'BUILD')
@@ -1293,7 +1293,7 @@ class ServersControllerTest(ControllerTest):
         for i, s in enumerate(server_list):
             self.assertEqual(s['id'], fakes.get_fake_uuid(i))
             self.assertEqual(s['hostId'], host_ids[i % 2])
-            self.assertEqual(s['name'], 'server%d' % (i + 1))
+            self.assertEqual(s['name'], 'server{0:d}'.format((i + 1)))
 
     def test_get_servers_joins_pci_devices(self):
 
@@ -1332,7 +1332,7 @@ class ServersControllerTestV29(ServersControllerTest):
                                                       locked_by=locked_by,
                                                       uuid=uuid)
 
-        req = self.req('/fake/servers/%s' % uuid)
+        req = self.req('/fake/servers/{0!s}'.format(uuid))
         res_dict = self.controller.show(req, uuid)
 
         expected_server = self._get_server_data_dict(uuid,
@@ -1427,7 +1427,7 @@ class ServersControllerTestV219(ServersControllerTest):
                                               display_description=description,
                                               uuid=uuid)
 
-        req = self.req('/fake/servers/%s' % uuid)
+        req = self.req('/fake/servers/{0!s}'.format(uuid))
         res_dict = self.controller.show(req, uuid)
 
         expected_server = self._get_server_data_dict(uuid,
@@ -1478,7 +1478,7 @@ class ServersControllerDeleteTest(ControllerTest):
 
     def _create_delete_request(self, uuid):
         fakes.stub_out_instance_quota(self, 0, 10)
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s' % uuid)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}'.format(uuid))
         req.method = 'DELETE'
         return req
 
@@ -1526,7 +1526,7 @@ class ServersControllerDeleteTest(ControllerTest):
 
     def test_delete_server_instance_if_not_launched(self):
         self.flags(reclaim_instance_interval=3600)
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'DELETE'
 
         self.server_delete_called = False
@@ -1550,7 +1550,7 @@ class ServersControllerDeleteTest(ControllerTest):
 class ServersControllerRebuildInstanceTest(ControllerTest):
 
     image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-    image_href = 'http://localhost/v2/fake/images/%s' % image_uuid
+    image_href = 'http://localhost/v2/fake/images/{0!s}'.format(image_uuid)
 
     def setUp(self):
         super(ServersControllerRebuildInstanceTest, self).setUp()
@@ -1762,7 +1762,7 @@ class ServersControllerRebuildInstanceTest(ControllerTest):
         compute_api.API.start(mox.IgnoreArg(), mox.IgnoreArg())
         self.mox.ReplayAll()
 
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(start="")
         self.controller._start_server(req, FAKE_UUID, body)
 
@@ -1771,7 +1771,7 @@ class ServersControllerRebuildInstanceTest(ControllerTest):
             "os_compute_api:servers:start": "project_id:non_fake"
         }
         policy.set_rules(oslo_policy.Rules.from_dict(rules))
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(start="")
         exc = self.assertRaises(exception.PolicyNotAuthorized,
                                 self.controller._start_server,
@@ -1780,7 +1780,7 @@ class ServersControllerRebuildInstanceTest(ControllerTest):
 
     def test_start_not_ready(self):
         self.stubs.Set(compute_api.API, 'start', fake_start_stop_not_ready)
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(start="")
         self.assertRaises(webob.exc.HTTPConflict,
             self.controller._start_server, req, FAKE_UUID, body)
@@ -1788,14 +1788,14 @@ class ServersControllerRebuildInstanceTest(ControllerTest):
     def test_start_locked_server(self):
         self.stubs.Set(compute_api.API, 'start',
                        fakes.fake_actions_to_locked_server)
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(start="")
         self.assertRaises(webob.exc.HTTPConflict,
             self.controller._start_server, req, FAKE_UUID, body)
 
     def test_start_invalid(self):
         self.stubs.Set(compute_api.API, 'start', fake_start_stop_invalid_state)
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(start="")
         self.assertRaises(webob.exc.HTTPConflict,
             self.controller._start_server, req, FAKE_UUID, body)
@@ -1805,7 +1805,7 @@ class ServersControllerRebuildInstanceTest(ControllerTest):
         compute_api.API.stop(mox.IgnoreArg(), mox.IgnoreArg())
         self.mox.ReplayAll()
 
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(stop="")
         self.controller._stop_server(req, FAKE_UUID, body)
 
@@ -1814,7 +1814,7 @@ class ServersControllerRebuildInstanceTest(ControllerTest):
             "os_compute_api:servers:stop": "project_id:non_fake"
         }
         policy.set_rules(oslo_policy.Rules.from_dict(rules))
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(stop='')
         exc = self.assertRaises(exception.PolicyNotAuthorized,
                                 self.controller._stop_server,
@@ -1823,7 +1823,7 @@ class ServersControllerRebuildInstanceTest(ControllerTest):
 
     def test_stop_not_ready(self):
         self.stubs.Set(compute_api.API, 'stop', fake_start_stop_not_ready)
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(stop="")
         self.assertRaises(webob.exc.HTTPConflict,
             self.controller._stop_server, req, FAKE_UUID, body)
@@ -1831,14 +1831,14 @@ class ServersControllerRebuildInstanceTest(ControllerTest):
     def test_stop_locked_server(self):
         self.stubs.Set(compute_api.API, 'stop',
                        fakes.fake_actions_to_locked_server)
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(stop="")
         self.assertRaises(webob.exc.HTTPConflict,
             self.controller._stop_server, req, FAKE_UUID, body)
 
     def test_stop_invalid_state(self):
         self.stubs.Set(compute_api.API, 'stop', fake_start_stop_invalid_state)
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s/action' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}/action'.format(FAKE_UUID))
         body = dict(start="")
         self.assertRaises(webob.exc.HTTPConflict,
             self.controller._stop_server, req, FAKE_UUID, body)
@@ -1916,7 +1916,7 @@ class ServersControllerUpdateTest(ControllerTest):
             fake_get = fakes.fake_compute_get(**options)
             self.stubs.Set(compute_api.API, 'get',
                            lambda api, *a, **k: fake_get(*a, **k))
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
         req.content_type = 'application/json'
         req.body = jsonutils.dump_as_bytes(body)
@@ -1949,7 +1949,7 @@ class ServersControllerUpdateTest(ControllerTest):
     def test_update_server_name_all_blank_spaces(self):
         self.stub_out('nova.db.instance_get',
                 fakes.fake_instance_get(name='server_test'))
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
         req.content_type = 'application/json'
         body = {'server': {'name': ' ' * 64}}
@@ -1960,7 +1960,7 @@ class ServersControllerUpdateTest(ControllerTest):
     def test_update_server_name_with_spaces_in_the_middle(self):
         self.stub_out('nova.db.instance_get',
                 fakes.fake_instance_get(name='server_test'))
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
         req.content_type = 'application/json'
         body = {'server': {'name': 'abc   def'}}
@@ -1970,7 +1970,7 @@ class ServersControllerUpdateTest(ControllerTest):
     def test_update_server_name_with_leading_trailing_spaces(self):
         self.stub_out('nova.db.instance_get',
                 fakes.fake_instance_get(name='server_test'))
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
         req.content_type = 'application/json'
         body = {'server': {'name': '  abc   def  '}}
@@ -1981,7 +1981,7 @@ class ServersControllerUpdateTest(ControllerTest):
     def test_update_server_name_with_leading_trailing_spaces_compat_mode(self):
         self.stub_out('nova.db.instance_get',
                 fakes.fake_instance_get(name='server_test'))
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
         req.content_type = 'application/json'
         body = {'server': {'name': '  abc   def  '}}
@@ -1993,7 +1993,7 @@ class ServersControllerUpdateTest(ControllerTest):
         inst_dict = dict(name='server_test', admin_password='bacon')
         body = dict(server=inst_dict)
 
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
         req.content_type = "application/json"
         req.body = jsonutils.dump_as_bytes(body)
@@ -2004,7 +2004,7 @@ class ServersControllerUpdateTest(ControllerTest):
         inst_dict = dict(host_id='123')
         body = dict(server=inst_dict)
 
-        req = fakes.HTTPRequest.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequest.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
         req.content_type = "application/json"
         req.body = jsonutils.dump_as_bytes(body)
@@ -2058,7 +2058,7 @@ class ServersControllerTriggerCrashDumpTest(ControllerTest):
                                  'ServersController._get_instance',
                                  fake_get))
 
-        self.req = fakes.HTTPRequest.blank('/servers/%s/action' % FAKE_UUID)
+        self.req = fakes.HTTPRequest.blank('/servers/{0!s}/action'.format(FAKE_UUID))
         self.req.api_version_request =\
             api_version_request.APIVersionRequest('2.17')
         self.body = dict(trigger_crash_dump=None)
@@ -2201,7 +2201,7 @@ class ServerStatusTest(test.TestCase):
                 fakes.fake_instance_get(vm_state=vm_state,
                                         task_state=task_state))
 
-        request = fakes.HTTPRequestV21.blank('/fake/servers/%s' % FAKE_UUID)
+        request = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         return self.controller.show(request, FAKE_UUID)
 
     def test_active(self):
@@ -2310,7 +2310,7 @@ class ServersControllerCreateTest(test.TestCase):
         def instance_create(context, inst):
             inst_type = flavors.get_flavor_by_flavor_id(3)
             image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-            def_image_ref = 'http://localhost/fake/images/%s' % image_uuid
+            def_image_ref = 'http://localhost/fake/images/{0!s}'.format(image_uuid)
             self.instance_cache_num += 1
             instance = fake_instance.fake_db_instance(**{
                 'id': self.instance_cache_num,
@@ -2508,7 +2508,7 @@ class ServersControllerCreateTest(test.TestCase):
             self.controller.create(self.req, body=self.body)
 
     def test_create_instance_image_ref_is_bookmark(self):
-        image_href = 'http://localhost/fake/images/%s' % self.image_uuid
+        image_href = 'http://localhost/fake/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
         res = self.controller.create(self.req, body=self.body).obj
@@ -2518,7 +2518,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_image_ref_is_invalid(self):
         image_uuid = 'this_is_not_a_valid_uuid'
-        image_href = 'http://localhost/fake/images/%s' % image_uuid
+        image_href = 'http://localhost/fake/images/{0!s}'.format(image_uuid)
         flavor_ref = 'http://localhost/fake/flavors/3'
         self.body['server']['imageRef'] = image_href
         self.body['server']['flavorRef'] = flavor_ref
@@ -2686,7 +2686,7 @@ class ServersControllerCreateTest(test.TestCase):
 
         # proper local hrefs must start with 'http://localhost/v2/'
         self.flags(enable_instance_password=False)
-        image_href = 'http://localhost/v2/fake/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/fake/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
         res = self.controller.create(self.req, body=self.body).obj
@@ -2697,7 +2697,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_name_too_long(self):
         # proper local hrefs must start with 'http://localhost/v2/'
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['name'] = 'X' * 256
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2706,7 +2706,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_name_with_spaces_in_the_middle(self):
         # proper local hrefs must start with 'http://localhost/v2/'
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['name'] = 'abc    def'
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2714,7 +2714,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_name_with_leading_trailing_spaces(self):
         # proper local hrefs must start with 'http://localhost/v2/'
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['name'] = '   abc    def   '
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2724,7 +2724,7 @@ class ServersControllerCreateTest(test.TestCase):
     def test_create_instance_name_with_leading_trailing_spaces_in_compat_mode(
             self):
         # proper local hrefs must start with 'http://localhost/v2/'
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['name'] = '   abc    def   '
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2734,7 +2734,7 @@ class ServersControllerCreateTest(test.TestCase):
     def test_create_instance_name_all_blank_spaces(self):
         # proper local hrefs must start with 'http://localhost/v2/'
         image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-        image_href = 'http://localhost/v2/images/%s' % image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(image_uuid)
         flavor_ref = 'http://localhost/fake/flavors/3'
         body = {
             'server': {
@@ -2757,7 +2757,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_az_with_leading_trailing_spaces(self):
         # proper local hrefs must start with 'http://localhost/v2/'
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.body['server']['availability_zone'] = '  zone1  '
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2767,7 +2767,7 @@ class ServersControllerCreateTest(test.TestCase):
     def test_create_az_with_leading_trailing_spaces_in_compat_mode(
             self):
         # proper local hrefs must start with 'http://localhost/v2/'
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['name'] = '   abc    def   '
         self.body['server']['imageRef'] = image_href
         self.body['server']['availability_zones'] = '  zone1  '
@@ -2779,7 +2779,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance(self):
         # proper local hrefs must start with 'http://localhost/v2/'
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
         res = self.controller.create(self.req, body=self.body).obj
@@ -2797,7 +2797,7 @@ class ServersControllerCreateTest(test.TestCase):
                        fake_keypair_server_create)
         # proper local hrefs must start with 'http://localhost/v2/'
         image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-        image_href = 'http://localhost/v2/images/%s' % image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(image_uuid)
         flavor_ref = 'http://localhost/123/flavors/3'
         body = {
             'server': {
@@ -2821,7 +2821,7 @@ class ServersControllerCreateTest(test.TestCase):
     def test_create_instance_pass_disabled(self):
         self.flags(enable_instance_password=False)
         # proper local hrefs must start with 'http://localhost/v2/'
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
         res = self.controller.create(self.req, body=self.body).obj
@@ -2839,7 +2839,7 @@ class ServersControllerCreateTest(test.TestCase):
                                                    'cpuset': None,
                                                    'memsize': 0,
                                                    'memtotal': 0})
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.req.body = jsonutils.dump_as_bytes(self.body)
         self.assertRaises(webob.exc.HTTPBadRequest,
@@ -2857,7 +2857,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_too_much_metadata(self):
         self.flags(quota_metadata_items=1)
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.body['server']['metadata']['vote'] = 'fiddletown'
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2866,7 +2866,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_metadata_key_too_long(self):
         self.flags(quota_metadata_items=1)
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.body['server']['metadata'] = {('a' * 260): '12345'}
 
@@ -2876,7 +2876,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_metadata_value_too_long(self):
         self.flags(quota_metadata_items=1)
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.body['server']['metadata'] = {'key1': ('a' * 260)}
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2885,7 +2885,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_metadata_key_blank(self):
         self.flags(quota_metadata_items=1)
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.body['server']['metadata'] = {'': 'abcd'}
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2894,7 +2894,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_metadata_not_dict(self):
         self.flags(quota_metadata_items=1)
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.body['server']['metadata'] = 'string'
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2903,7 +2903,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_metadata_key_not_string(self):
         self.flags(quota_metadata_items=1)
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.body['server']['metadata'] = {1: 'test'}
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -2912,7 +2912,7 @@ class ServersControllerCreateTest(test.TestCase):
 
     def test_create_instance_metadata_value_not_string(self):
         self.flags(quota_metadata_items=1)
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         self.body['server']['metadata'] = {'test': ['a', 'list']}
         self.req.body = jsonutils.dump_as_bytes(self.body)
@@ -3018,7 +3018,7 @@ class ServersControllerCreateTest(test.TestCase):
         self.controller.create(self.req, body=self.body)
 
     def test_create_location(self):
-        selfhref = 'http://localhost/v2/fake/servers/%s' % FAKE_UUID
+        selfhref = 'http://localhost/v2/fake/servers/{0!s}'.format(FAKE_UUID)
         self.req.body = jsonutils.dump_as_bytes(self.body)
         robj = self.controller.create(self.req, body=self.body)
 
@@ -3321,7 +3321,7 @@ class ServersControllerCreateTest(test.TestCase):
 class ServersControllerCreateTestV219(ServersControllerCreateTest):
     def _create_instance_req(self, set_desc, desc=None):
         # proper local hrefs must start with 'http://localhost/v2/'
-        image_href = 'http://localhost/v2/images/%s' % self.image_uuid
+        image_href = 'http://localhost/v2/images/{0!s}'.format(self.image_uuid)
         self.body['server']['imageRef'] = image_href
         if set_desc:
             self.body['server']['description'] = desc
@@ -3471,8 +3471,8 @@ class ServersViewBuilderTest(test.TestCase):
                     self.request.context,
                     expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
                     **db_inst)
-        self.self_link = "http://localhost/v2/fake/servers/%s" % self.uuid
-        self.bookmark_link = "http://localhost/fake/servers/%s" % self.uuid
+        self.self_link = "http://localhost/v2/fake/servers/{0!s}".format(self.uuid)
+        self.bookmark_link = "http://localhost/fake/servers/{0!s}".format(self.uuid)
 
     def _generate_nw_cache_info(self):
         fixed_ipv4 = ('192.168.1.100', '192.168.2.100', '192.168.3.100')
@@ -4009,7 +4009,7 @@ class ServersInvalidRequestTestCase(test.TestCase):
         self._invalid_server_create(body=body)
 
     def _unprocessable_server_update(self, body):
-        req = fakes.HTTPRequestV21.blank('/fake/servers/%s' % FAKE_UUID)
+        req = fakes.HTTPRequestV21.blank('/fake/servers/{0!s}'.format(FAKE_UUID))
         req.method = 'PUT'
 
         self.assertRaises(webob.exc.HTTPBadRequest,
@@ -4061,15 +4061,15 @@ class TestServersExtensionPoint(test.NoDBTestCase):
         self.stubs.Set(disk_config, 'DiskConfig', FakeExt)
 
     def _test_load_extension_point(self, name):
-        setattr(FakeExt, 'server_%s' % name,
+        setattr(FakeExt, 'server_{0!s}'.format(name),
                 FakeExt.fake_extension_point)
         ext_info = extension_info.LoadedExtensionInfo()
         controller = servers.ServersController(extension_info=ext_info)
         self.assertEqual(
             'os-disk-config',
             list(getattr(controller,
-                         '%s_extension_manager' % name))[0].obj.alias)
-        delattr(FakeExt, 'server_%s' % name)
+                         '{0!s}_extension_manager'.format(name)))[0].obj.alias)
+        delattr(FakeExt, 'server_{0!s}'.format(name))
 
     def test_load_update_extension_point(self):
         self._test_load_extension_point('update')
@@ -4092,14 +4092,14 @@ class TestServersExtensionSchema(test.NoDBTestCase):
         self.stubs.Set(disk_config, 'DiskConfig', FakeExt)
 
     def _test_load_extension_schema(self, name):
-        setattr(FakeExt, 'get_server_%s_schema' % name,
+        setattr(FakeExt, 'get_server_{0!s}_schema'.format(name),
                 FakeExt.fake_schema_extension_point)
         ext_info = extension_info.LoadedExtensionInfo()
         controller = servers.ServersController(extension_info=ext_info)
-        self.assertTrue(hasattr(controller, '%s_schema_manager' % name))
+        self.assertTrue(hasattr(controller, '{0!s}_schema_manager'.format(name)))
 
-        delattr(FakeExt, 'get_server_%s_schema' % name)
-        return getattr(controller, 'schema_server_%s' % name)
+        delattr(FakeExt, 'get_server_{0!s}_schema'.format(name))
+        return getattr(controller, 'schema_server_{0!s}'.format(name))
 
     def test_load_create_extension_point(self):
         # The expected is the schema combination of base and keypairs
@@ -4159,7 +4159,7 @@ class IPsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_show_policy_failed(self):
@@ -4169,7 +4169,7 @@ class IPsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.show, self.req, fakes.FAKE_UUID, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
 
@@ -4188,7 +4188,7 @@ class ServersPolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
             exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     @mock.patch.object(servers.ServersController, '_get_instance')

--- a/nova/tests/unit/api/openstack/compute/test_services.py
+++ b/nova/tests/unit/api/openstack/compute/test_services.py
@@ -997,7 +997,7 @@ class ServicesPolicyEnforcementV21(test.NoDBTestCase):
             body={'host': 'host1',
                   'binary': 'nova-compute'})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_delete_policy_failed(self):
@@ -1007,7 +1007,7 @@ class ServicesPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.delete, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_index_policy_failed(self):
@@ -1017,5 +1017,5 @@ class ServicesPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_shelve.py
+++ b/nova/tests/unit/api/openstack/compute/test_shelve.py
@@ -30,7 +30,7 @@ from nova.tests.unit import fake_instance
 def fake_instance_get_by_uuid(context, instance_id,
                               columns_to_join=None, use_slave=False):
     return fake_instance.fake_db_instance(
-        **{'name': 'fake', 'project_id': '%s_unequal' % context.project_id})
+        **{'name': 'fake', 'project_id': '{0!s}_unequal'.format(context.project_id)})
 
 
 class ShelvePolicyTestV21(test.NoDBTestCase):
@@ -44,7 +44,7 @@ class ShelvePolicyTestV21(test.NoDBTestCase):
         self.req = fakes.HTTPRequest.blank('')
 
     def test_shelve_restricted_by_role(self):
-        rules = {'compute_extension:%sshelve' % self.prefix: 'role:admin'}
+        rules = {'compute_extension:{0!s}shelve'.format(self.prefix): 'role:admin'}
         policy.set_rules(oslo_policy.Rules.from_dict(rules))
 
         self.assertRaises(exception.Forbidden, self.controller._shelve,
@@ -59,7 +59,7 @@ class ShelvePolicyTestV21(test.NoDBTestCase):
                           self.req, str(uuid.uuid4()), {})
 
     def test_unshelve_restricted_by_role(self):
-        rules = {'compute_extension:%sunshelve' % self.prefix: 'role:admin'}
+        rules = {'compute_extension:{0!s}unshelve'.format(self.prefix): 'role:admin'}
         policy.set_rules(oslo_policy.Rules.from_dict(rules))
 
         self.assertRaises(exception.Forbidden, self.controller._unshelve,
@@ -74,7 +74,7 @@ class ShelvePolicyTestV21(test.NoDBTestCase):
                           self.req, str(uuid.uuid4()), {})
 
     def test_shelve_offload_restricted_by_role(self):
-        rules = {'compute_extension:%s%s' % (self.prefix, self.offload):
+        rules = {'compute_extension:{0!s}{1!s}'.format(self.prefix, self.offload):
                      'role:admin'}
         policy.set_rules(oslo_policy.Rules.from_dict(rules))
 
@@ -100,7 +100,7 @@ class ShelvePolicyTestV2(ShelvePolicyTestV21):
     # These 3 cases are covered in ShelvePolicyEnforcementV21
     def test_shelve_allowed(self):
         rules = {'compute:get': '',
-                 'compute_extension:%sshelve' % self.prefix: ''}
+                 'compute_extension:{0!s}shelve'.format(self.prefix): ''}
         policy.set_rules(oslo_policy.Rules.from_dict(rules))
         self.stub_out('nova.db.instance_get_by_uuid',
                       fake_instance_get_by_uuid)
@@ -109,7 +109,7 @@ class ShelvePolicyTestV2(ShelvePolicyTestV21):
 
     def test_unshelve_allowed(self):
         rules = {'compute:get': '',
-                 'compute_extension:%sunshelve' % self.prefix: ''}
+                 'compute_extension:{0!s}unshelve'.format(self.prefix): ''}
         policy.set_rules(oslo_policy.Rules.from_dict(rules))
 
         self.stub_out('nova.db.instance_get_by_uuid',
@@ -119,7 +119,7 @@ class ShelvePolicyTestV2(ShelvePolicyTestV21):
 
     def test_shelve_offload_allowed(self):
         rules = {'compute:get': '',
-                 'compute_extension:%s%s' % (self.prefix, self.offload): ''}
+                 'compute_extension:{0!s}{1!s}'.format(self.prefix, self.offload): ''}
         policy.set_rules(oslo_policy.Rules.from_dict(rules))
 
         self.stub_out('nova.db.instance_get_by_uuid',
@@ -145,7 +145,7 @@ class ShelvePolicyEnforcementV21(test.NoDBTestCase):
             self.controller._shelve, self.req, fakes.FAKE_UUID,
             body={'shelve': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_shelve_offload_policy_failed(self):
@@ -156,7 +156,7 @@ class ShelvePolicyEnforcementV21(test.NoDBTestCase):
             self.controller._shelve_offload, self.req, fakes.FAKE_UUID,
             body={'shelve_offload': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_unshelve_policy_failed(self):
@@ -167,5 +167,5 @@ class ShelvePolicyEnforcementV21(test.NoDBTestCase):
             self.controller._unshelve, self.req, fakes.FAKE_UUID,
             body={'unshelve': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_suspend_server.py
+++ b/nova/tests/unit/api/openstack/compute/test_suspend_server.py
@@ -74,7 +74,7 @@ class SuspendServerPolicyEnforcementV21(test.NoDBTestCase):
             self.controller._suspend, self.req, fakes.FAKE_UUID,
             body={'suspend': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_resume_policy_failed(self):
@@ -85,5 +85,5 @@ class SuspendServerPolicyEnforcementV21(test.NoDBTestCase):
             self.controller._resume, self.req, fakes.FAKE_UUID,
             body={'resume': {}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_tenant_networks.py
+++ b/nova/tests/unit/api/openstack/compute/test_tenant_networks.py
@@ -288,7 +288,7 @@ class TenantNetworksEnforcementV21(test.NoDBTestCase):
             self.req, body={'network': {'label': 'test',
                                         'cidr': '10.0.0.0/32'}})
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_index_policy_failed(self):
@@ -299,7 +299,7 @@ class TenantNetworksEnforcementV21(test.NoDBTestCase):
             self.controller.index,
             self.req)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_delete_policy_failed(self):
@@ -310,7 +310,7 @@ class TenantNetworksEnforcementV21(test.NoDBTestCase):
             self.controller.delete,
             self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_show_policy_failed(self):
@@ -321,5 +321,5 @@ class TenantNetworksEnforcementV21(test.NoDBTestCase):
             self.controller.show,
             self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_used_limits.py
+++ b/nova/tests/unit/api/openstack/compute/test_used_limits.py
@@ -125,7 +125,7 @@ class UsedLimitsTestCaseV21(test.NoDBTestCase):
                 self.include_server_group_quotas)
         self.authorize(self.fake_context, target=target)
         self.mox.StubOutWithMock(quota.QUOTAS, 'get_project_quotas')
-        quota.QUOTAS.get_project_quotas(self.fake_context, '%s' % tenant_id,
+        quota.QUOTAS.get_project_quotas(self.fake_context, '{0!s}'.format(tenant_id),
                                         usages=True).AndReturn({})
         self.mox.ReplayAll()
         res = wsgi.ResponseObject(obj)
@@ -150,7 +150,7 @@ class UsedLimitsTestCaseV21(test.NoDBTestCase):
                 self.include_server_group_quotas)
         self.mox.StubOutWithMock(extensions, 'extension_authorizer')
         self.mox.StubOutWithMock(quota.QUOTAS, 'get_project_quotas')
-        quota.QUOTAS.get_project_quotas(self.fake_context, '%s' % project_id,
+        quota.QUOTAS.get_project_quotas(self.fake_context, '{0!s}'.format(project_id),
                                         usages=True).AndReturn({})
         self.mox.ReplayAll()
         res = wsgi.ResponseObject(obj)

--- a/nova/tests/unit/api/openstack/compute/test_user_data.py
+++ b/nova/tests/unit/api/openstack/compute/test_user_data.py
@@ -68,7 +68,7 @@ class ServersControllerCreateTest(test.TestCase):
         def instance_create(context, inst):
             inst_type = flavors.get_flavor_by_flavor_id(3)
             image_uuid = '76fa36fc-c930-4bf3-8c8a-ea2a2420deb6'
-            def_image_ref = 'http://localhost/images/%s' % image_uuid
+            def_image_ref = 'http://localhost/images/{0!s}'.format(image_uuid)
             self.instance_cache_num += 1
             instance = fake_instance.fake_db_instance(**{
                 'id': self.instance_cache_num,

--- a/nova/tests/unit/api/openstack/compute/test_versions.py
+++ b/nova/tests/unit/api/openstack/compute/test_versions.py
@@ -428,7 +428,7 @@ class VersionsViewBuilderTests(test.NoDBTestCase):
     def test_generate_href_with_path(self):
         path = "random/path"
         base_url = "http://example.org/app/"
-        expected = "http://example.org/app/v2/%s" % path
+        expected = "http://example.org/app/v2/{0!s}".format(path)
         builder = views.versions.ViewBuilder(base_url)
         actual = builder.generate_href("v2", path)
         self.assertEqual(actual, expected)

--- a/nova/tests/unit/api/openstack/compute/test_virtual_interfaces.py
+++ b/nova/tests/unit/api/openstack/compute/test_virtual_interfaces.py
@@ -150,5 +150,5 @@ class ServerVirtualInterfaceEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.index, self.req, fakes.FAKE_UUID)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())

--- a/nova/tests/unit/api/openstack/compute/test_volumes.py
+++ b/nova/tests/unit/api/openstack/compute/test_volumes.py
@@ -910,8 +910,8 @@ class AssistedSnapshotDeleteTestCaseV21(test.NoDBTestCase):
             'delete_info': jsonutils.dumps({'volume_id': '1'}),
         }
         req = fakes.HTTPRequest.blank(
-                '/v2/fake/os-assisted-volume-snapshots?%s' %
-                urllib.parse.urlencode(params))
+                '/v2/fake/os-assisted-volume-snapshots?{0!s}'.format(
+                urllib.parse.urlencode(params)))
         req.method = 'DELETE'
         result = self.controller.delete(req, '5')
         self._check_status(204, result, self.controller.delete)
@@ -950,7 +950,7 @@ class TestAssistedVolumeSnapshotsPolicyEnforcementV21(test.NoDBTestCase):
             exception.PolicyNotAuthorized,
             self.controller.create, self.req, body=body)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_delete_assisted_volumes_snapshots_policy_failed(self):
@@ -961,7 +961,7 @@ class TestAssistedVolumeSnapshotsPolicyEnforcementV21(test.NoDBTestCase):
             self.controller.delete, self.req, '5')
 
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
 
@@ -977,7 +977,7 @@ class TestVolumeAttachPolicyEnforcementV21(test.NoDBTestCase):
         exc = self.assertRaises(
              exception.PolicyNotAuthorized, func, *arg, **kwarg)
         self.assertEqual(
-            "Policy doesn't allow %s to be performed." % rule_name,
+            "Policy doesn't allow {0!s} to be performed.".format(rule_name),
             exc.format_message())
 
     def test_index_volume_attach_policy_failed(self):

--- a/nova/tests/unit/api/openstack/fakes.py
+++ b/nova/tests/unit/api/openstack/fakes.py
@@ -303,15 +303,15 @@ class FakeAuthDatabase(object):
     def auth_token_create(context, token):
         fake_token = FakeToken(created_at=timeutils.utcnow(), **token)
         FakeAuthDatabase.data[fake_token.token_hash] = fake_token
-        FakeAuthDatabase.data['id_%i' % fake_token.id] = fake_token
+        FakeAuthDatabase.data['id_{0:d}'.format(fake_token.id)] = fake_token
         return fake_token
 
     @staticmethod
     def auth_token_destroy(context, token_id):
-        token = FakeAuthDatabase.data.get('id_%i' % token_id)
+        token = FakeAuthDatabase.data.get('id_{0:d}'.format(token_id))
         if token and token.token_hash in FakeAuthDatabase.data:
             del FakeAuthDatabase.data[token.token_hash]
-            del FakeAuthDatabase.data['id_%i' % token_id]
+            del FakeAuthDatabase.data['id_{0:d}'.format(token_id)]
 
 
 def create_info_cache(nw_cache):
@@ -474,9 +474,9 @@ def stub_instance(id=1, user_id=None, project_id=None, host=None,
                             "deleted_at": None, "deleted": False}]
 
     # ReservationID isn't sent back, hack it in there.
-    server_name = name or "server%s" % id
+    server_name = name or "server{0!s}".format(id)
     if reservation_id != "":
-        server_name = "reservation_%s" % (reservation_id, )
+        server_name = "reservation_{0!s}".format(reservation_id )
 
     info_cache = create_info_cache(nw_cache)
 
@@ -532,7 +532,7 @@ def stub_instance(id=1, user_id=None, project_id=None, host=None,
         "uuid": uuid,
         "progress": progress,
         "auto_disk_config": auto_disk_config,
-        "name": "instance-%s" % id,
+        "name": "instance-{0!s}".format(id),
         "shutdown_terminate": True,
         "disable_terminate": False,
         "security_groups": security_groups,
@@ -699,7 +699,7 @@ def stub_bdm_get_all_by_instance_uuids(context, instance_uuids,
                 'id': i,
                 'source_type': 'volume',
                 'destination_type': 'volume',
-                'volume_id': 'volume_id%d' % (i),
+                'volume_id': 'volume_id{0:d}'.format((i)),
                 'instance_uuid': instance_uuid,
             }))
             i += 1

--- a/nova/tests/unit/api/openstack/test_common.py
+++ b/nova/tests/unit/api/openstack/test_common.py
@@ -261,7 +261,7 @@ class PaginationParamsTest(test.NoDBTestCase):
     def test_valid_limit_and_marker(self):
         # Test valid limit and marker parameters.
         marker = '263abb28-1de6-412f-b00b-f0ee0c4333c2'
-        req = webob.Request.blank('/?limit=20&marker=%s' % marker)
+        req = webob.Request.blank('/?limit=20&marker={0!s}'.format(marker))
         self.assertEqual(common.get_pagination_params(req),
                          {'marker': marker, 'limit': 20})
 
@@ -617,7 +617,7 @@ class ViewBuilderLinkTest(test.NoDBTestCase):
 
     def setUp(self):
         super(ViewBuilderLinkTest, self).setUp()
-        self.request = self.req("/%s" % self.project_id)
+        self.request = self.req("/{0!s}".format(self.project_id))
         self.vb = common.ViewBuilder()
 
     def req(self, url, use_admin_context=False):
@@ -634,7 +634,7 @@ class ViewBuilderLinkTest(test.NoDBTestCase):
         next_link = self.vb._get_next_link(self.request, identifier,
                                            collection)
         expected = "/".join((self.request.url,
-                             "%s?marker=%s" % (collection, identifier)))
+                             "{0!s}?marker={1!s}".format(collection, identifier)))
         self.assertEqual(expected, next_link)
 
     def test_get_href_link(self):

--- a/nova/tests/unit/api/openstack/test_legacy_v2_compatible_wrapper.py
+++ b/nova/tests/unit/api/openstack/test_legacy_v2_compatible_wrapper.py
@@ -73,7 +73,7 @@ class TestLegacyV2CompatibleWrapper(test.NoDBTestCase):
         def fake_app(req, *args, **kwargs):
             resp = webob.Response()
             resp.status_int = 204
-            resp.headers['Vary'] = '%s, %s, %s' % (
+            resp.headers['Vary'] = '{0!s}, {1!s}, {2!s}'.format(
                 wsgi.API_VERSION_REQUEST_HEADER, 'FAKE_HEADER1',
                 'FAKE_HEADER2')
             return resp

--- a/nova/tests/unit/api/openstack/test_wsgi.py
+++ b/nova/tests/unit/api/openstack/test_wsgi.py
@@ -59,7 +59,7 @@ class RequestTest(test.NoDBTestCase):
         request = wsgi.Request.blank('/foo')
         instances = []
         for x in range(3):
-            instances.append({'uuid': 'uuid%s' % x})
+            instances.append({'uuid': 'uuid{0!s}'.format(x)})
         # Store 2
         request.cache_db_instances(instances[:2])
         # Store 1
@@ -80,7 +80,7 @@ class RequestTest(test.NoDBTestCase):
         request = wsgi.Request.blank('/foo')
         compute_nodes = []
         for x in range(3):
-            compute_nodes.append({'id': 'id%s' % x})
+            compute_nodes.append({'id': 'id{0!s}'.format(x)})
         # Store 2
         request.cache_db_compute_nodes(compute_nodes[:2])
         # Store 1

--- a/nova/tests/unit/cells/fakes.py
+++ b/nova/tests/unit/cells/fakes.py
@@ -122,13 +122,13 @@ class CellStubInfo(object):
 
 
 def _build_cell_transport_url(cur_db_id):
-    username = 'username%s' % cur_db_id
-    password = 'password%s' % cur_db_id
-    hostname = 'rpc_host%s' % cur_db_id
+    username = 'username{0!s}'.format(cur_db_id)
+    password = 'password{0!s}'.format(cur_db_id)
+    hostname = 'rpc_host{0!s}'.format(cur_db_id)
     port = 3090 + cur_db_id
-    virtual_host = 'rpc_vhost%s' % cur_db_id
+    virtual_host = 'rpc_vhost{0!s}'.format(cur_db_id)
 
-    return 'rabbit://%s:%s@%s:%s/%s' % (username, password, hostname, port,
+    return 'rabbit://{0!s}:{1!s}@{2!s}:{3!s}/{4!s}'.format(username, password, hostname, port,
                                         virtual_host)
 
 

--- a/nova/tests/unit/cells/test_cells_manager.py
+++ b/nova/tests/unit/cells/test_cells_manager.py
@@ -281,7 +281,7 @@ class CellsManagerClassTestCase(test.NoDBTestCase):
         # 3 cells... so 3 responses.  Each response is a list of services.
         # Manager should turn these into a single list of responses.
         for i in range(3):
-            cell_name = 'path!to!cell%i' % i
+            cell_name = 'path!to!cell{0:d}'.format(i)
             services = []
             for service in FAKE_SERVICES:
                 fake_service = objects.Service(**service)
@@ -390,7 +390,7 @@ class CellsManagerClassTestCase(test.NoDBTestCase):
                                  'proxy_rpc_to_manager')
         fake_response = self._get_fake_response()
         cell_and_host = cells_utils.cell_with_item('fake-cell', 'fake-host')
-        topic = "%s.%s" % (CONF.compute_topic, cell_and_host)
+        topic = "{0!s}.{1!s}".format(CONF.compute_topic, cell_and_host)
         self.msg_runner.proxy_rpc_to_manager(self.ctxt, 'fake-cell',
                 'fake-host', topic, 'fake-rpc-msg',
                 True, -1).AndReturn(fake_response)
@@ -407,7 +407,7 @@ class CellsManagerClassTestCase(test.NoDBTestCase):
         # entries. Manager should turn these into a single list of
         # task log entries.
         for i in range(num):
-            cell_name = 'path!to!cell%i' % i
+            cell_name = 'path!to!cell{0:d}'.format(i)
             task_logs = []
             for task_log in FAKE_TASK_LOGS:
                 task_logs.append(copy.deepcopy(task_log))
@@ -470,7 +470,7 @@ class CellsManagerClassTestCase(test.NoDBTestCase):
         # 3 cells... so 3 responses.  Each response is a list of computes.
         # Manager should turn these into a single list of responses.
         for i in range(3):
-            cell_name = 'path!to!cell%i' % i
+            cell_name = 'path!to!cell{0:d}'.format(i)
             compute_nodes = []
             for compute_node in FAKE_COMPUTE_NODES:
                 fake_compute = objects.ComputeNode(**compute_node)
@@ -670,7 +670,7 @@ class CellsManagerClassTestCase(test.NoDBTestCase):
 
     def test_get_migrations_for_a_given_cell(self):
         filters = {'status': 'confirmed', 'cell_name': 'ChildCell1'}
-        target_cell = '%s%s%s' % (CONF.cells.name, '!', filters['cell_name'])
+        target_cell = '{0!s}{1!s}{2!s}'.format(CONF.cells.name, '!', filters['cell_name'])
         migrations = [{'id': 123}]
         fake_responses = [self._get_fake_response(migrations)]
         self.mox.StubOutWithMock(self.msg_runner,

--- a/nova/tests/unit/cells/test_cells_messaging.py
+++ b/nova/tests/unit/cells/test_cells_messaging.py
@@ -539,7 +539,7 @@ class CellsMessageClassesTestCase(test.NoDBTestCase):
         direction = 'down'
 
         def our_fake_method(message, **kwargs):
-            return 'response-%s' % message.routing_path
+            return 'response-{0!s}'.format(message.routing_path)
 
         fakes.stub_bcast_methods(self, 'our_fake_method', our_fake_method)
 
@@ -553,7 +553,7 @@ class CellsMessageClassesTestCase(test.NoDBTestCase):
         self.assertEqual(8, len(responses))
         for response in responses:
             self.assertFalse(response.failure)
-            self.assertEqual('response-%s' % response.cell_name,
+            self.assertEqual('response-{0!s}'.format(response.cell_name),
                     response.value_or_raise())
 
     def test_broadcast_routing_with_response_max_hops(self):
@@ -563,7 +563,7 @@ class CellsMessageClassesTestCase(test.NoDBTestCase):
         direction = 'down'
 
         def our_fake_method(message, **kwargs):
-            return 'response-%s' % message.routing_path
+            return 'response-{0!s}'.format(message.routing_path)
 
         fakes.stub_bcast_methods(self, 'our_fake_method', our_fake_method)
 
@@ -579,7 +579,7 @@ class CellsMessageClassesTestCase(test.NoDBTestCase):
         self.assertEqual(5, len(responses))
         for response in responses:
             self.assertFalse(response.failure)
-            self.assertEqual('response-%s' % response.cell_name,
+            self.assertEqual('response-{0!s}'.format(response.cell_name),
                     response.value_or_raise())
 
     def test_broadcast_routing_with_all_erroring(self):
@@ -613,7 +613,7 @@ class CellsMessageClassesTestCase(test.NoDBTestCase):
             raise test.TestingException('fake failure')
 
         def our_fake_method(message, **kwargs):
-            return 'response-%s' % message.routing_path
+            return 'response-{0!s}'.format(message.routing_path)
 
         fakes.stub_bcast_methods(self, 'our_fake_method', our_fake_method)
         fakes.stub_bcast_method(self, 'child-cell2', 'our_fake_method',
@@ -636,7 +636,7 @@ class CellsMessageClassesTestCase(test.NoDBTestCase):
 
         for response in success_responses:
             self.assertFalse(response.failure)
-            self.assertEqual('response-%s' % response.cell_name,
+            self.assertEqual('response-{0!s}'.format(response.cell_name),
                     response.value_or_raise())
 
         for response in failure_responses:
@@ -1251,7 +1251,7 @@ class CellsTargetedMethodsTestCase(test.NoDBTestCase):
                                'set_admin_password': 'set_admin_password',
                               }
         tgt_method = method_translations.get(method,
-                                             '%s_instance' % method)
+                                             '{0!s}_instance'.format(method))
         result = getattr(meth_cls, tgt_method)(
                 message, 'fake-instance', *args, **kwargs)
         if expect_result:

--- a/nova/tests/unit/cells/test_cells_rpcapi.py
+++ b/nova/tests/unit/cells/test_cells_rpcapi.py
@@ -72,8 +72,8 @@ class CellsAPITestCase(test.NoDBTestCase):
         if version is not None:
             self.assertIn('version', call_info)
             self.assertIsInstance(call_info['version'], six.string_types,
-                                  msg="Message version %s is not a string" %
-                                  call_info['version'])
+                                  msg="Message version {0!s} is not a string".format(
+                                  call_info['version']))
             self.assertEqual(version, call_info['version'])
         else:
             self.assertNotIn('version', call_info)

--- a/nova/tests/unit/cells/test_cells_scheduler.py
+++ b/nova/tests/unit/cells/test_cells_scheduler.py
@@ -137,7 +137,7 @@ class CellsSchedulerTestCase(test.TestCase):
             sys_meta = utils.instance_sys_meta(instance)
             self.assertEqual('cat', sys_meta['meow'])
             self.assertEqual('meow', instance['hostname'])
-            self.assertEqual('moo-%d' % (count + 1),
+            self.assertEqual('moo-{0:d}'.format((count + 1)),
                              instance['display_name'])
             self.assertEqual('fake_image_ref', instance['image_ref'])
 

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -4635,7 +4635,7 @@ class ComputeTestCase(BaseTestCase):
 
         orig_connection_data = {
             'target_discovered': True,
-            'target_iqn': 'iqn.2010-10.org.openstack:%s.1' % uuids.volume_id,
+            'target_iqn': 'iqn.2010-10.org.openstack:{0!s}.1'.format(uuids.volume_id),
             'target_portal': '127.0.0.0.1:3260',
             'volume_id': uuids.volume_id,
         }
@@ -4728,7 +4728,7 @@ class ComputeTestCase(BaseTestCase):
 
         # new initialize connection
         new_connection_data = dict(orig_connection_data)
-        new_iqn = 'iqn.2010-10.org.openstack:%s.2' % uuids.volume_id,
+        new_iqn = 'iqn.2010-10.org.openstack:{0!s}.2'.format(uuids.volume_id),
         new_connection_data['target_iqn'] = new_iqn
 
         def fake_init_conn_with_data(self, context, volume, session):
@@ -6257,7 +6257,7 @@ class ComputeTestCase(BaseTestCase):
         instance_map = {}
         instances = []
         for x in range(8):
-            inst_uuid = getattr(uuids, 'db_instance_%i' % x)
+            inst_uuid = getattr(uuids, 'db_instance_{0:d}'.format(x))
             instance_map[inst_uuid] = fake_instance.fake_db_instance(
                 uuid=inst_uuid, host=CONF.host, created_at=None)
             # These won't be in our instance since they're not requested
@@ -7766,7 +7766,7 @@ class ComputeAPITestCase(BaseTestCase):
                 '_populate_instance_for_create',
                 _fake_populate)
 
-        cases = [(None, 'server-%s' % fake_uuids[0]),
+        cases = [(None, 'server-{0!s}'.format(fake_uuids[0])),
                  ('Hello, Server!', 'hello-server'),
                  ('<}\x1fh\x10e\x08l\x02l\x05o\x12!{>', 'hello'),
                  ('hello_server', 'hello-server')]
@@ -9108,10 +9108,10 @@ class ComputeAPITestCase(BaseTestCase):
                 flavors.get_default_flavor(),
                 image_href=uuids.image_href_id,
                 min_count=2, max_count=2, display_name='x')
-        self.assertEqual(refs[0]['display_name'], 'x-%s' % refs[0]['uuid'])
-        self.assertEqual(refs[0]['hostname'], 'x-%s' % refs[0]['uuid'])
-        self.assertEqual(refs[1]['display_name'], 'x-%s' % refs[1]['uuid'])
-        self.assertEqual(refs[1]['hostname'], 'x-%s' % refs[1]['uuid'])
+        self.assertEqual(refs[0]['display_name'], 'x-{0!s}'.format(refs[0]['uuid']))
+        self.assertEqual(refs[0]['hostname'], 'x-{0!s}'.format(refs[0]['uuid']))
+        self.assertEqual(refs[1]['display_name'], 'x-{0!s}'.format(refs[1]['uuid']))
+        self.assertEqual(refs[1]['hostname'], 'x-{0!s}'.format(refs[1]['uuid']))
 
     def test_multi_instance_display_name_default(self):
         self._multi_instance_display_name_default()
@@ -9146,16 +9146,15 @@ class ComputeAPITestCase(BaseTestCase):
         # Test the instance_name template.
         self.flags(instance_name_template='instance-%d')
         i_ref = self._create_fake_instance_obj()
-        self.assertEqual(i_ref['name'], 'instance-%d' % i_ref['id'])
+        self.assertEqual(i_ref['name'], 'instance-{0:d}'.format(i_ref['id']))
 
         self.flags(instance_name_template='instance-%(uuid)s')
         i_ref = self._create_fake_instance_obj()
-        self.assertEqual(i_ref['name'], 'instance-%s' % i_ref['uuid'])
+        self.assertEqual(i_ref['name'], 'instance-{0!s}'.format(i_ref['uuid']))
 
         self.flags(instance_name_template='%(id)d-%(uuid)s')
         i_ref = self._create_fake_instance_obj()
-        self.assertEqual(i_ref['name'], '%d-%s' %
-                (i_ref['id'], i_ref['uuid']))
+        self.assertEqual(i_ref['name'], '{0:d}-{1!s}'.format(i_ref['id'], i_ref['uuid']))
 
         # not allowed.. default is uuid
         self.flags(instance_name_template='%(name)s')

--- a/nova/tests/unit/compute/test_compute_api.py
+++ b/nova/tests/unit/compute/test_compute_api.py
@@ -912,7 +912,7 @@ class _ComputeAPIUnitTestMixIn(object):
     def _test_downed_host_part(self, inst, updates, delete_time, delete_type):
         compute_utils.notify_about_instance_usage(
             self.compute_api.notifier, self.context, inst,
-            '%s.start' % delete_type)
+            '{0!s}.start'.format(delete_type))
         self.context.elevated().AndReturn(self.context)
         self.compute_api.network_api.deallocate_for_instance(
             self.context, inst)
@@ -931,7 +931,7 @@ class _ComputeAPIUnitTestMixIn(object):
                             constraint=None).AndReturn(fake_inst)
         compute_utils.notify_about_instance_usage(
             self.compute_api.notifier,
-            self.context, inst, '%s.end' % delete_type,
+            self.context, inst, '{0!s}.end'.format(delete_type),
             system_metadata=inst.system_metadata)
 
     def _test_delete(self, delete_type, **attrs):
@@ -2282,7 +2282,7 @@ class _ComputeAPIUnitTestMixIn(object):
             return {'id': volume_id, 'display_description': ''}
 
         def fake_volume_create_snapshot(context, volume_id, name, description):
-            return {'id': '%s-snapshot' % volume_id}
+            return {'id': '{0!s}-snapshot'.format(volume_id)}
 
         def fake_quiesce_instance(context, instance):
             if quiesce_fails:
@@ -3465,7 +3465,7 @@ class _ComputeAPIUnitTestMixIn(object):
         params = dict(display_name=u'\u865a\u62df\u673a\u662f\u4e2d\u6587')
         instance = self._create_instance_obj(params=params)
         self.compute_api._populate_instance_names(instance, 1)
-        self.assertEqual('Server-%s' % instance.uuid, instance.hostname)
+        self.assertEqual('Server-{0!s}'.format(instance.uuid), instance.hostname)
 
     def test_populate_instance_names_host_name_multi(self):
         params = dict(display_name="vm")
@@ -3481,7 +3481,7 @@ class _ComputeAPIUnitTestMixIn(object):
         with mock.patch.object(instance, 'save'):
             self.compute_api._apply_instance_name_template(self.context,
                                                            instance, 1)
-            self.assertEqual('Server-%s' % instance.uuid, instance.hostname)
+            self.assertEqual('Server-{0!s}'.format(instance.uuid), instance.hostname)
 
     def test_host_statuses(self):
         instances = [

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -178,7 +178,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         self, get_db_nodes, get_avail_nodes, get_rt):
         db_nodes = []
 
-        db_nodes = [self._make_compute_node('node%s' % i, i)
+        db_nodes = [self._make_compute_node('node{0!s}'.format(i), i)
                     for i in range(1, 5)]
         avail_nodes = set(['node2', 'node3', 'node4', 'node5'])
         avail_nodes_l = list(avail_nodes)
@@ -213,7 +213,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     @mock.patch.object(manager.ComputeManager, '_get_compute_nodes_in_db')
     def test_update_available_resource(self, get_db_nodes, get_avail_nodes,
                                        get_rt):
-        db_nodes = [self._make_compute_node('node%s' % i, i)
+        db_nodes = [self._make_compute_node('node{0!s}'.format(i), i)
                     for i in range(1, 5)]
         avail_nodes = set(['node2', 'node3', 'node4', 'node5'])
         avail_nodes_l = list(avail_nodes)
@@ -1346,7 +1346,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         all_instances = []
         driver_instances = []
         for x in range(10):
-            instance = fake_instance.fake_db_instance(name='inst-%i' % x,
+            instance = fake_instance.fake_db_instance(name='inst-{0:d}'.format(x),
                                                       id=x)
             if x % 2:
                 driver_instances.append(instance)
@@ -1940,7 +1940,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
     def test_instance_events_lock_name(self):
         inst_obj = objects.Instance(uuid=uuids.instance)
         result = self.compute.instance_events._lock_name(inst_obj)
-        self.assertEqual(result, "%s-events" % uuids.instance)
+        self.assertEqual(result, "{0!s}-events".format(uuids.instance))
 
     def test_prepare_for_instance_event_again(self):
         inst_obj = objects.Instance(uuid=uuids.instance)

--- a/nova/tests/unit/compute/test_compute_utils.py
+++ b/nova/tests/unit/compute/test_compute_utils.py
@@ -444,10 +444,10 @@ class UsageInfoTestCase(test.TestCase):
                      'bandwidth', 'audit_period_beginning',
                      'audit_period_ending', 'image_meta'):
             self.assertIn(attr, payload,
-                          "Key %s not in payload" % attr)
+                          "Key {0!s} not in payload".format(attr))
         self.assertEqual(payload['image_meta'],
                 {'md_key1': 'val1', 'md_key2': 'val2'})
-        image_ref_url = "%s/images/1" % glance.generate_glance_url()
+        image_ref_url = "{0!s}/images/1".format(glance.generate_glance_url())
         self.assertEqual(payload['image_ref_url'], image_ref_url)
         self.compute.terminate_instance(self.context, instance, [], [])
 
@@ -479,10 +479,10 @@ class UsageInfoTestCase(test.TestCase):
                      'state', 'state_description',
                      'bandwidth', 'audit_period_beginning',
                      'audit_period_ending', 'image_meta'):
-            self.assertIn(attr, payload, "Key %s not in payload" % attr)
+            self.assertIn(attr, payload, "Key {0!s} not in payload".format(attr))
         self.assertEqual(payload['image_meta'],
                 {'md_key1': 'val1', 'md_key2': 'val2'})
-        image_ref_url = "%s/images/1" % glance.generate_glance_url()
+        image_ref_url = "{0!s}/images/1".format(glance.generate_glance_url())
         self.assertEqual(payload['image_ref_url'], image_ref_url)
 
     def test_notify_usage_exists_instance_not_found(self):
@@ -507,9 +507,9 @@ class UsageInfoTestCase(test.TestCase):
                      'state', 'state_description',
                      'bandwidth', 'audit_period_beginning',
                      'audit_period_ending', 'image_meta'):
-            self.assertIn(attr, payload, "Key %s not in payload" % attr)
+            self.assertIn(attr, payload, "Key {0!s} not in payload".format(attr))
         self.assertEqual(payload['image_meta'], {})
-        image_ref_url = "%s/images/1" % glance.generate_glance_url()
+        image_ref_url = "{0!s}/images/1".format(glance.generate_glance_url())
         self.assertEqual(payload['image_ref_url'], image_ref_url)
 
     def test_notify_about_instance_usage(self):
@@ -540,11 +540,11 @@ class UsageInfoTestCase(test.TestCase):
         self.assertEqual(str(payload['instance_flavor_id']), str(flavor_id))
         for attr in ('display_name', 'created_at', 'launched_at',
                      'state', 'state_description', 'image_meta'):
-            self.assertIn(attr, payload, "Key %s not in payload" % attr)
+            self.assertIn(attr, payload, "Key {0!s} not in payload".format(attr))
         self.assertEqual(payload['image_meta'],
                 {'md_key1': 'val1', 'md_key2': 'val2'})
         self.assertEqual(payload['image_name'], 'fake_name')
-        image_ref_url = "%s/images/1" % glance.generate_glance_url()
+        image_ref_url = "{0!s}/images/1".format(glance.generate_glance_url())
         self.assertEqual(payload['image_ref_url'], image_ref_url)
         self.compute.terminate_instance(self.context, instance, [], [])
 

--- a/nova/tests/unit/compute/test_keypairs.py
+++ b/nova/tests/unit/compute/test_keypairs.py
@@ -86,16 +86,16 @@ class KeypairAPITestCase(test_compute.BaseTestCase):
 
         n1 = fake_notifier.NOTIFICATIONS[0]
         self.assertEqual('INFO', n1.priority)
-        self.assertEqual('keypair.%s.start' % action, n1.event_type)
-        self.assertEqual('api.%s' % CONF.host, n1.publisher_id)
+        self.assertEqual('keypair.{0!s}.start'.format(action), n1.event_type)
+        self.assertEqual('api.{0!s}'.format(CONF.host), n1.publisher_id)
         self.assertEqual('fake', n1.payload['user_id'])
         self.assertEqual('fake', n1.payload['tenant_id'])
         self.assertEqual(key_name, n1.payload['key_name'])
 
         n2 = fake_notifier.NOTIFICATIONS[1]
         self.assertEqual('INFO', n2.priority)
-        self.assertEqual('keypair.%s.end' % action, n2.event_type)
-        self.assertEqual('api.%s' % CONF.host, n2.publisher_id)
+        self.assertEqual('keypair.{0!s}.end'.format(action), n2.event_type)
+        self.assertEqual('api.{0!s}'.format(CONF.host), n2.publisher_id)
         self.assertEqual('fake', n2.payload['user_id'])
         self.assertEqual('fake', n2.payload['tenant_id'])
         self.assertEqual(key_name, n2.payload['key_name'])
@@ -121,7 +121,7 @@ class CreateImportSharedTestMixIn(object):
         self.assertEqual(expected_message, six.text_type(exc))
 
     def assertInvalidKeypair(self, expected_message, name):
-        msg = 'Keypair data is invalid: %s' % expected_message
+        msg = 'Keypair data is invalid: {0!s}'.format(expected_message)
         self.assertKeypairRaises(exception.InvalidKeypair, msg, name)
 
     def test_name_too_short(self):
@@ -144,8 +144,8 @@ class CreateImportSharedTestMixIn(object):
 
         self.stub_out("nova.db.key_pair_create", db_key_pair_create_duplicate)
 
-        msg = ("Key pair '%(key_name)s' already exists." %
-               {'key_name': self.existing_key_name})
+        msg = ("Key pair '{key_name!s}' already exists.".format(**
+               {'key_name': self.existing_key_name}))
         self.assertKeypairRaises(exception.KeyPairExists, msg,
                                  self.existing_key_name)
 

--- a/nova/tests/unit/compute/test_resource_tracker.py
+++ b/nova/tests/unit/compute/test_resource_tracker.py
@@ -685,7 +685,7 @@ class BaseTrackerTestCase(BaseTestCase):
 
         if field not in tracker.compute_node:
             raise test.TestingException(
-                "'%(field)s' not in compute node." % {'field': field})
+                "'{field!s}' not in compute node.".format(**{'field': field}))
         x = getattr(tracker.compute_node, field)
 
         if field == 'numa_topology':

--- a/nova/tests/unit/compute/test_resources.py
+++ b/nova/tests/unit/compute/test_resources.py
@@ -72,8 +72,8 @@ class FakeResource(base.Resource):
         if requested <= free:
             return
         else:
-            return ('Free %(free)d < requested %(requested)d ' %
-                    {'free': free, 'requested': requested})
+            return ('Free {free:d} < requested {requested:d} '.format(**
+                    {'free': free, 'requested': requested}))
 
     def add_instance(self, usage):
         requested = self._get_requested(usage)
@@ -89,7 +89,7 @@ class FakeResource(base.Resource):
         pass
 
     def report_free(self):
-        return "Free %s" % (self.total_res - self.used_res)
+        return "Free {0!s}".format((self.total_res - self.used_res))
 
 
 class ResourceA(FakeResource):

--- a/nova/tests/unit/compute/test_stats.py
+++ b/nova/tests/unit/compute/test_stats.py
@@ -167,8 +167,8 @@ class StatsTestCase(test.NoDBTestCase):
         self.assertEqual(1, self.stats.num_instances)
         self.assertEqual(1, self.stats.num_instances_for_project(1234))
         self.assertEqual(1, self.stats["num_os_type_Linux"])
-        self.assertEqual(0, self.stats["num_vm_%s" % vm_states.BUILDING])
-        self.assertEqual(1, self.stats["num_vm_%s" % vm_states.PAUSED])
+        self.assertEqual(0, self.stats["num_vm_{0!s}".format(vm_states.BUILDING)])
+        self.assertEqual(1, self.stats["num_vm_{0!s}".format(vm_states.PAUSED)])
 
     def test_update_stats_for_instance_task_change(self):
         instance = self._create_instance()
@@ -180,7 +180,7 @@ class StatsTestCase(test.NoDBTestCase):
         self.assertEqual(1, self.stats.num_instances_for_project("1234"))
         self.assertEqual(1, self.stats["num_os_type_Linux"])
         self.assertEqual(0, self.stats["num_task_None"])
-        self.assertEqual(1, self.stats["num_task_%s" % task_states.REBUILDING])
+        self.assertEqual(1, self.stats["num_task_{0!s}".format(task_states.REBUILDING)])
 
     def test_update_stats_for_instance_deleted(self):
         instance = self._create_instance()

--- a/nova/tests/unit/compute/test_tracker.py
+++ b/nova/tests/unit/compute/test_tracker.py
@@ -1517,7 +1517,7 @@ class TestMoveClaim(BaseTestCase):
         for k, e in expected.items():
             a = actual[k]
             if e != a:
-                print("%s: %s != %s" % (k, e, a))
+                print("{0!s}: {1!s} != {2!s}".format(k, e, a))
                 fail = True
         if fail:
             self.fail()

--- a/nova/tests/unit/console/test_serial.py
+++ b/nova/tests/unit/console/test_serial.py
@@ -83,7 +83,7 @@ class SerialTestCase(test.NoDBTestCase):
     def test_acquire_port(self):
         start, stop = 15, 20
         self.flags(
-            port_range='%d:%d' % (start, stop),
+            port_range='{0:d}:{1:d}'.format(start, stop),
             group='serial_console')
 
         for port in six.moves.range(start, stop):
@@ -115,7 +115,7 @@ class SerialTestCase(test.NoDBTestCase):
     def test_acquire_port_not_ble_to_bind_at_any_port(self, fake_verify_port):
         start, stop = 15, 20
         self.flags(
-            port_range='%d:%d' % (start, stop),
+            port_range='{0:d}:{1:d}'.format(start, stop),
             group='serial_console')
 
         fake_verify_port.side_effect = (

--- a/nova/tests/unit/db/fakes.py
+++ b/nova/tests/unit/db/fakes.py
@@ -39,7 +39,7 @@ class FakeModel(object):
             raise NotImplementedError()
 
     def __repr__(self):
-        return '<FakeModel: %s>' % self.values
+        return '<FakeModel: {0!s}>'.format(self.values)
 
     def get(self, name):
         return self.values[name]
@@ -337,7 +337,7 @@ def stub_out_db_network_api(test):
              fake_network_set_host,
              fake_network_update,
              fake_project_get_networks]
-    funcs = {'nova.db.%s' % fn.__name__.replace('fake_', ''): fn
+    funcs = {'nova.db.{0!s}'.format(fn.__name__.replace('fake_', '')): fn
              for fn in funcs}
 
     stub_out(test, funcs)

--- a/nova/tests/unit/db/test_db_api.py
+++ b/nova/tests/unit/db/test_db_api.py
@@ -104,7 +104,7 @@ def _quota_reserve(context, project_id, user_id):
     resources = {}
     deltas = {}
     for i in range(3):
-        resource = 'resource%d' % i
+        resource = 'resource{0:d}'.format(i)
         if i == 2:
             # test for project level resources
             resource = 'fixed_ips'
@@ -119,9 +119,9 @@ def _quota_reserve(context, project_id, user_id):
             user_quotas[resource] = db.quota_create(context, project_id,
                                                     resource, i + 1,
                                                     user_id=user_id).hard_limit
-        sync_name = '_sync_%s' % resource
+        sync_name = '_sync_{0!s}'.format(resource)
         resources[resource] = quota.ReservableResource(
-            resource, sync_name, 'quota_res_%d' % i)
+            resource, sync_name, 'quota_res_{0:d}'.format(i))
         deltas[resource] = i
         setattr(sqlalchemy_api, sync_name, get_sync(resource, i))
         sqlalchemy_api.QUOTA_SYNC_FUNCTIONS[sync_name] = getattr(
@@ -153,7 +153,7 @@ class DbTestCase(test.TestCase):
     def fake_metadata(self, content):
         meta = {}
         for i in range(0, 10):
-            meta["foo%i" % i] = "this is %s item %i" % (content, i)
+            meta["foo{0:d}".format(i)] = "this is {0!s} item {1:d}".format(content, i)
         return meta
 
     def create_metadata_for_instance(self, instance_uuid):
@@ -823,7 +823,7 @@ class AggregateDBApiTestCase(test.TestCase):
         counter = 3
         for c in range(counter):
             _create_aggregate(context=ctxt,
-                              values={'name': 'fake_aggregate_%d' % c},
+                              values={'name': 'fake_aggregate_{0:d}'.format(c)},
                               metadata=None)
         results = db.aggregate_get_all(ctxt)
         self.assertEqual(len(results), counter)
@@ -834,7 +834,7 @@ class AggregateDBApiTestCase(test.TestCase):
         remove_counter = 2
         aggregates = []
         for c in range(1, add_counter):
-            values = {'name': 'fake_aggregate_%d' % c}
+            values = {'name': 'fake_aggregate_{0:d}'.format(c)}
             aggregates.append(_create_aggregate(context=ctxt,
                                                 values=values, metadata=None))
         for c in range(1, remove_counter):
@@ -1539,8 +1539,8 @@ class ModelsObjectComparatorMixin(object):
 
         self.assertEqual(len(obj1),
                          len(obj2),
-                         "Keys mismatch: %s" %
-                          str(set(obj1.keys()) ^ set(obj2.keys())))
+                         "Keys mismatch: {0!s}".format(
+                          str(set(obj1.keys()) ^ set(obj2.keys()))))
         for key, value in obj1.items():
             self.assertEqual(value, obj2[key])
 
@@ -4865,7 +4865,7 @@ class FixedIPTestCase(BaseInstanceTypeTestCase):
             timeutils.set_time_override(now)
             address = self.create_fixed_ip(
                 updated_at=now,
-                address='10.1.0.%d' % i,
+                address='10.1.0.{0:d}'.format(i),
                 network_id=network['id'])
         db.fixed_ip_associate_pool(self.ctxt, network['id'], instance_uuid)
         fixed_ip = db.fixed_ip_get_by_address(self.ctxt, address)
@@ -5323,7 +5323,7 @@ class FloatingIpTestCase(test.TestCase, ModelsObjectComparatorMixin):
         ips_for_non_delete = []
 
         def create_ips(i, j):
-            return [{'address': '1.1.%s.%s' % (i, k)} for k in range(1, j + 1)]
+            return [{'address': '1.1.{0!s}.{1!s}'.format(i, k)} for k in range(1, j + 1)]
 
         # NOTE(boris-42): Create more than 256 ip to check that
         #                 _ip_range_splitter works properly.
@@ -6112,11 +6112,11 @@ class BlockDeviceMappingTestCase(test.TestCase):
         with_device_name = [b for b in bdms if b['device_name'] is not None]
         without_device_name = [b for b in bdms if b['device_name'] is None]
         self.assertEqual(len(with_device_name), 1,
-                         'expected 1 bdm with device_name, found %d' %
-                         len(with_device_name))
+                         'expected 1 bdm with device_name, found {0:d}'.format(
+                         len(with_device_name)))
         self.assertEqual(len(without_device_name), 1,
-                         'expected 1 bdm without device_name, found %d' %
-                         len(without_device_name))
+                         'expected 1 bdm without device_name, found {0:d}'.format(
+                         len(without_device_name)))
 
         # check create multiple devices without device_name
         bdm2 = dict(values)
@@ -6126,11 +6126,11 @@ class BlockDeviceMappingTestCase(test.TestCase):
         with_device_name = [b for b in bdms if b['device_name'] is not None]
         without_device_name = [b for b in bdms if b['device_name'] is None]
         self.assertEqual(len(with_device_name), 1,
-                         'expected 1 bdm with device_name, found %d' %
-                         len(with_device_name))
+                         'expected 1 bdm with device_name, found {0:d}'.format(
+                         len(with_device_name)))
         self.assertEqual(len(without_device_name), 2,
-                         'expected 2 bdms without device_name, found %d' %
-                         len(without_device_name))
+                         'expected 2 bdms without device_name, found {0:d}'.format(
+                         len(without_device_name)))
 
     def test_block_device_mapping_update_or_create_multiple_ephemeral(self):
         uuid = self.instance['uuid']
@@ -6945,10 +6945,10 @@ class QuotaTestCase(test.TestCase, ModelsObjectComparatorMixin):
     def test_quota_get_all_by_project(self):
         for i in range(3):
             for j in range(3):
-                db.quota_create(self.ctxt, 'proj%d' % i, 'resource%d' % j, j)
+                db.quota_create(self.ctxt, 'proj{0:d}'.format(i), 'resource{0:d}'.format(j), j)
         for i in range(3):
-            quotas_db = db.quota_get_all_by_project(self.ctxt, 'proj%d' % i)
-            self.assertEqual(quotas_db, {'project_id': 'proj%d' % i,
+            quotas_db = db.quota_get_all_by_project(self.ctxt, 'proj{0:d}'.format(i))
+            self.assertEqual(quotas_db, {'project_id': 'proj{0:d}'.format(i),
                                                         'resource0': 0,
                                                         'resource1': 1,
                                                         'resource2': 2})
@@ -6956,14 +6956,14 @@ class QuotaTestCase(test.TestCase, ModelsObjectComparatorMixin):
     def test_quota_get_all_by_project_and_user(self):
         for i in range(3):
             for j in range(3):
-                db.quota_create(self.ctxt, 'proj%d' % i, 'resource%d' % j,
-                                j - 1, user_id='user%d' % i)
+                db.quota_create(self.ctxt, 'proj{0:d}'.format(i), 'resource{0:d}'.format(j),
+                                j - 1, user_id='user{0:d}'.format(i))
         for i in range(3):
             quotas_db = db.quota_get_all_by_project_and_user(self.ctxt,
-                                                             'proj%d' % i,
-                                                             'user%d' % i)
-            self.assertEqual(quotas_db, {'project_id': 'proj%d' % i,
-                                         'user_id': 'user%d' % i,
+                                                             'proj{0:d}'.format(i),
+                                                             'user{0:d}'.format(i))
+            self.assertEqual(quotas_db, {'project_id': 'proj{0:d}'.format(i),
+                                         'user_id': 'user{0:d}'.format(i),
                                                         'resource0': -1,
                                                         'resource1': 0,
                                                         'resource2': 1})
@@ -7006,7 +7006,7 @@ class QuotaTestCase(test.TestCase, ModelsObjectComparatorMixin):
         usages['fixed_ips'] = 2
         network = db.network_create_safe(self.ctxt, {})
         for i in range(2):
-            address = '192.168.0.%d' % i
+            address = '192.168.0.{0:d}'.format(i)
             db.fixed_ip_create(self.ctxt, {'project_id': 'project1',
                                            'address': address,
                                            'network_id': network['id']})
@@ -7035,7 +7035,7 @@ class QuotaTestCase(test.TestCase, ModelsObjectComparatorMixin):
             usage = db.quota_usage_get(self.ctxt, 'project1',
                                        reservation.resource)
             self.assertEqual(usage.in_use, usages[reservation.resource],
-                             'Resource: %s' % reservation.resource)
+                             'Resource: {0!s}'.format(reservation.resource))
             self.assertEqual(usage.reserved, deltas[reservation.resource])
             self.assertIn(reservation.resource, resources_names)
             resources_names.remove(reservation.resource)
@@ -7309,11 +7309,11 @@ class QuotaClassTestCase(test.TestCase, ModelsObjectComparatorMixin):
     def test_quota_class_get_all_by_name(self):
         for i in range(3):
             for j in range(3):
-                db.quota_class_create(self.ctxt, 'class%d' % i,
-                                                'resource%d' % j, j)
+                db.quota_class_create(self.ctxt, 'class{0:d}'.format(i),
+                                                'resource{0:d}'.format(j), j)
         for i in range(3):
-            classes = db.quota_class_get_all_by_name(self.ctxt, 'class%d' % i)
-            self.assertEqual(classes, {'class_name': 'class%d' % i,
+            classes = db.quota_class_get_all_by_name(self.ctxt, 'class{0:d}'.format(i))
+            self.assertEqual(classes, {'class_name': 'class{0:d}'.format(i),
                             'resource0': 0, 'resource1': 1, 'resource2': 2})
 
     def test_quota_class_update(self):
@@ -7546,14 +7546,14 @@ class ComputeNodeTestCase(test.TestCase, ModelsObjectComparatorMixin):
         for x in range(2, 5):
             # Create a service
             service_data = self.service_dict.copy()
-            service_data['host'] = 'host-%s' % x
+            service_data['host'] = 'host-{0!s}'.format(x)
             service = db.service_create(self.ctxt, service_data)
 
             # Create a compute node
             compute_node_data = self.compute_node_dict.copy()
             compute_node_data['service_id'] = service['id']
             compute_node_data['stats'] = jsonutils.dumps(self.stats.copy())
-            compute_node_data['hypervisor_hostname'] = 'hypervisor-%s' % x
+            compute_node_data['hypervisor_hostname'] = 'hypervisor-{0!s}'.format(x)
             node = db.compute_node_create(self.ctxt, compute_node_data)
 
             # Ensure the "new" compute node is found
@@ -8558,8 +8558,8 @@ class ArchiveTestCase(test.TestCase, ModelsObjectComparatorMixin):
         metadata.reflect()
         for table in metadata.tables:
             if table.startswith("shadow_") and table not in exceptions:
-                rows = self.conn.execute("select * from %s" % table).fetchall()
-                self.assertEqual(rows, [], "Table %s not empty" % table)
+                rows = self.conn.execute("select * from {0!s}".format(table)).fetchall()
+                self.assertEqual(rows, [], "Table {0!s} not empty".format(table))
 
     def test_shadow_tables(self):
         metadata = MetaData(bind=self.engine)

--- a/nova/tests/unit/db/test_migrations.py
+++ b/nova/tests/unit/db/test_migrations.py
@@ -102,11 +102,11 @@ class NovaMigrationsCheckers(test_migrations.ModelsMigrationsSync,
 
     def assertColumnExists(self, engine, table_name, column):
         self.assertTrue(oslodbutils.column_exists(engine, table_name, column),
-                        'Column %s.%s does not exist' % (table_name, column))
+                        'Column {0!s}.{1!s} does not exist'.format(table_name, column))
 
     def assertColumnNotExists(self, engine, table_name, column):
         self.assertFalse(oslodbutils.column_exists(engine, table_name, column),
-                        'Column %s.%s should not exist' % (table_name, column))
+                        'Column {0!s}.{1!s} should not exist'.format(table_name, column))
 
     def assertTableNotExists(self, engine, table):
         self.assertRaises(sqlalchemy.exc.NoSuchTableError,
@@ -114,13 +114,11 @@ class NovaMigrationsCheckers(test_migrations.ModelsMigrationsSync,
 
     def assertIndexExists(self, engine, table_name, index):
         self.assertTrue(oslodbutils.index_exists(engine, table_name, index),
-                        'Index %s on table %s does not exist' %
-                        (index, table_name))
+                        'Index {0!s} on table {1!s} does not exist'.format(index, table_name))
 
     def assertIndexNotExists(self, engine, table_name, index):
         self.assertFalse(oslodbutils.index_exists(engine, table_name, index),
-                         'Index %s on table %s should not exist' %
-                         (index, table_name))
+                         'Index {0!s} on table {1!s} should not exist'.format(index, table_name))
 
     def assertIndexMembers(self, engine, table, index, members):
         # NOTE(johannes): Order of columns can matter. Most SQL databases
@@ -183,7 +181,7 @@ class NovaMigrationsCheckers(test_migrations.ModelsMigrationsSync,
 
     def migrate_up(self, version, with_data=False):
         if with_data:
-            check = getattr(self, "_check_%03d" % version, None)
+            check = getattr(self, "_check_{0:03d}".format(version), None)
             if version not in self._skippable_migrations():
                 self.assertIsNotNone(check,
                                      ('DB Migration %i does not have a '
@@ -921,7 +919,7 @@ class TestNovaMigrationsMySQL(NovaMigrationsCheckers,
             "AND TABLE_NAME != 'migrate_version'" %
             {'database': self.migrate_engine.url.database})
         count = noninnodb.scalar()
-        self.assertEqual(count, 0, "%d non InnoDB tables created" % count)
+        self.assertEqual(count, 0, "{0:d} non InnoDB tables created".format(count))
 
 
 class TestNovaMigrationsPostgreSQL(NovaMigrationsCheckers,

--- a/nova/tests/unit/fake_build_request.py
+++ b/nova/tests/unit/fake_build_request.py
@@ -72,7 +72,7 @@ def fake_db_req(**updates):
         elif field.default != fields.UnspecifiedDefault:
             db_build_request[name] = field.default
         else:
-            raise Exception('fake_db_req needs help with %s' % name)
+            raise Exception('fake_db_req needs help with {0!s}'.format(name))
 
     if updates:
         db_build_request.update(updates)

--- a/nova/tests/unit/fake_flavor.py
+++ b/nova/tests/unit/fake_flavor.py
@@ -40,7 +40,7 @@ def fake_db_flavor(**updates):
         elif field.default != fields.UnspecifiedDefault:
             db_flavor[name] = field.default
         else:
-            raise Exception('fake_db_flavor needs help with %s' % name)
+            raise Exception('fake_db_flavor needs help with {0!s}'.format(name))
 
     if updates:
         db_flavor.update(updates)

--- a/nova/tests/unit/fake_instance.py
+++ b/nova/tests/unit/fake_instance.py
@@ -24,7 +24,7 @@ from nova.objects import fields
 def fake_db_secgroups(instance, names):
     secgroups = []
     for i, name in enumerate(names):
-        group_name = 'secgroup-%i' % i
+        group_name = 'secgroup-{0:d}'.format(i)
         if isinstance(name, dict) and name.get('name'):
             group_name = name.get('name')
         secgroups.append(
@@ -88,7 +88,7 @@ def fake_db_instance(**updates):
         elif name in ['flavor', 'ec2_ids']:
             pass
         else:
-            raise Exception('fake_db_instance needs help with %s' % name)
+            raise Exception('fake_db_instance needs help with {0!s}'.format(name))
 
     if updates:
         db_instance.update(updates)

--- a/nova/tests/unit/fake_ldap.py
+++ b/nova/tests/unit/fake_ldap.py
@@ -233,7 +233,7 @@ class FakeLDAP(object):
         if server_fail:
             raise SERVER_DOWN()
 
-        key = "%s%s" % (self.__prefix, dn)
+        key = "{0!s}{1!s}".format(self.__prefix, dn)
         value_dict = {k: _to_json(v) for k, v in attr}
         Store.instance().hmset(key, value_dict)
 
@@ -242,7 +242,7 @@ class FakeLDAP(object):
         if server_fail:
             raise SERVER_DOWN()
 
-        Store.instance().delete("%s%s" % (self.__prefix, dn))
+        Store.instance().delete("{0!s}{1!s}".format(self.__prefix, dn))
 
     def modify_s(self, dn, attrs):
         """Modify the object at dn using the attribute list.
@@ -257,7 +257,7 @@ class FakeLDAP(object):
             raise SERVER_DOWN()
 
         store = Store.instance()
-        key = "%s%s" % (self.__prefix, dn)
+        key = "{0!s}{1!s}".format(self.__prefix, dn)
 
         for cmd, k, v in attrs:
             values = _from_json(store.hget(key, k))
@@ -273,7 +273,7 @@ class FakeLDAP(object):
         oldobj = self.search_s(dn, SCOPE_BASE)
         if not oldobj:
             raise NO_SUCH_OBJECT()
-        newdn = "%s,%s" % (newrdn, dn.partition(',')[2])
+        newdn = "{0!s},{1!s}".format(newrdn, dn.partition(',')[2])
         newattrs = oldobj[0][1]
 
         modlist = []
@@ -300,10 +300,10 @@ class FakeLDAP(object):
             raise NotImplementedError(str(scope))
         store = Store.instance()
         if scope == SCOPE_BASE:
-            pattern = "%s%s" % (self.__prefix, dn)
+            pattern = "{0!s}{1!s}".format(self.__prefix, dn)
             keys = store.keys(pattern)
         else:
-            keys = store.keys("%s*%s" % (self.__prefix, dn))
+            keys = store.keys("{0!s}*{1!s}".format(self.__prefix, dn))
 
         if not keys:
             raise NO_SUCH_OBJECT()

--- a/nova/tests/unit/fake_network.py
+++ b/nova/tests/unit/fake_network.py
@@ -113,7 +113,7 @@ class FakeNetworkManager(network_manager.NetworkManager):
             return fakenet
 
         def network_get(self, context, network_id, project_only="allow_none"):
-            return {'cidr_v6': '2001:db8:69:%x::/64' % network_id}
+            return {'cidr_v6': '2001:db8:69:{0:x}::/64'.format(network_id)}
 
         def network_get_by_uuid(self, context, network_uuid):
             raise exception.NetworkNotFoundForUUID(uuid=network_uuid)
@@ -166,26 +166,26 @@ def fake_network(network_id, ipv6=None):
     if ipv6 is None:
         ipv6 = CONF.use_ipv6
     fake_network = {'id': network_id,
-             'uuid': getattr(uuids, 'network%i' % network_id),
-             'label': 'test%d' % network_id,
+             'uuid': getattr(uuids, 'network{0:d}'.format(network_id)),
+             'label': 'test{0:d}'.format(network_id),
              'injected': False,
              'multi_host': False,
-             'cidr': '192.168.%d.0/24' % network_id,
+             'cidr': '192.168.{0:d}.0/24'.format(network_id),
              'cidr_v6': None,
              'netmask': '255.255.255.0',
              'netmask_v6': None,
-             'bridge': 'fake_br%d' % network_id,
-             'bridge_interface': 'fake_eth%d' % network_id,
-             'gateway': '192.168.%d.1' % network_id,
+             'bridge': 'fake_br{0:d}'.format(network_id),
+             'bridge_interface': 'fake_eth{0:d}'.format(network_id),
+             'gateway': '192.168.{0:d}.1'.format(network_id),
              'gateway_v6': None,
-             'broadcast': '192.168.%d.255' % network_id,
-             'dns1': '192.168.%d.3' % network_id,
-             'dns2': '192.168.%d.4' % network_id,
-             'dns3': '192.168.%d.3' % network_id,
+             'broadcast': '192.168.{0:d}.255'.format(network_id),
+             'dns1': '192.168.{0:d}.3'.format(network_id),
+             'dns2': '192.168.{0:d}.4'.format(network_id),
+             'dns3': '192.168.{0:d}.3'.format(network_id),
              'vlan': None,
              'host': None,
              'project_id': uuids.project,
-             'vpn_public_address': '192.168.%d.2' % network_id,
+             'vpn_public_address': '192.168.{0:d}.2'.format(network_id),
              'vpn_public_port': None,
              'vpn_private_address': None,
              'dhcp_start': None,
@@ -196,12 +196,12 @@ def fake_network(network_id, ipv6=None):
              'updated_at': None,
              'deleted_at': None,
              'mtu': None,
-             'dhcp_server': '192.168.%d.1' % network_id,
+             'dhcp_server': '192.168.{0:d}.1'.format(network_id),
              'enable_dhcp': True,
              'share_address': False}
     if ipv6:
-        fake_network['cidr_v6'] = '2001:db8:0:%x::/64' % network_id
-        fake_network['gateway_v6'] = '2001:db8:0:%x::1' % network_id
+        fake_network['cidr_v6'] = '2001:db8:0:{0:x}::/64'.format(network_id)
+        fake_network['gateway_v6'] = '2001:db8:0:{0:x}::1'.format(network_id)
         fake_network['netmask_v6'] = '64'
     if CONF.flat_injected:
         fake_network['injected'] = True
@@ -220,8 +220,8 @@ def fake_vif(x):
            'updated_at': None,
            'deleted_at': None,
            'deleted': 0,
-           'address': 'DE:AD:BE:EF:00:%02x' % x,
-           'uuid': getattr(uuids, 'vif%i' % x),
+           'address': 'DE:AD:BE:EF:00:{0:02x}'.format(x),
+           'uuid': getattr(uuids, 'vif{0:d}'.format(x)),
            'network_id': x,
            'instance_uuid': uuids.vifs_1}
 
@@ -246,7 +246,7 @@ def next_fixed_ip(network_id, num_floating_ips=0):
              for i in range(num_floating_ips)]
     return {'id': next_id,
             'network_id': network_id,
-            'address': '192.168.%d.%03d' % (network_id, (next_id + 99)),
+            'address': '192.168.{0:d}.{1:03d}'.format(network_id, (next_id + 99)),
             'instance_uuid': uuids.fixed_ip,
             'allocated': False,
             'reserved': False,
@@ -266,7 +266,7 @@ def next_fixed_ip(network_id, num_floating_ips=0):
 def next_floating_ip(fixed_ip_id):
     next_id = next(floating_ip_id)
     return {'id': next_id,
-            'address': '10.10.10.%03d' % (next_id + 99),
+            'address': '10.10.10.{0:03d}'.format((next_id + 99)),
             'fixed_ip_id': fixed_ip_id,
             'project_id': None,
             'auto_assigned': False}

--- a/nova/tests/unit/fake_volume.py
+++ b/nova/tests/unit/fake_volume.py
@@ -184,7 +184,7 @@ class API(object):
 
     def check_attach(self, context, volume, instance=None):
         if volume['status'] != 'available':
-            msg = "Status of volume '%s' must be available" % volume
+            msg = "Status of volume '{0!s}' must be available".format(volume)
             raise exception.InvalidVolume(reason=msg)
         if volume['attach_status'] == 'attached':
             msg = "already attached"

--- a/nova/tests/unit/image/test_glance.py
+++ b/nova/tests/unit/image/test_glance.py
@@ -250,7 +250,7 @@ class TestGlanceClientWrapper(test.NoDBTestCase):
         ctx = context.RequestContext('fake', 'fake')
         host = 'host4'
         port = 9295
-        endpoint = 'http://%s:%s' % (host, port)
+        endpoint = 'http://{0!s}:{1!s}'.format(host, port)
         client = glance.GlanceClientWrapper(context=ctx, endpoint=endpoint)
         create_client_mock.assert_called_once_with(ctx, mock.ANY, 1)
         self.assertRaises(exception.GlanceConnectionFailed,
@@ -272,7 +272,7 @@ class TestGlanceClientWrapper(test.NoDBTestCase):
         ctx = context.RequestContext('fake', 'fake')
         host = 'host4'
         port = 9295
-        endpoint = 'http://%s:%s' % (host, port)
+        endpoint = 'http://{0!s}:{1!s}'.format(host, port)
 
         client = glance.GlanceClientWrapper(context=ctx, endpoint=endpoint)
 
@@ -301,7 +301,7 @@ class TestGlanceClientWrapper(test.NoDBTestCase):
         ctx = context.RequestContext('fake', 'fake')
         host = 'host4'
         port = 9295
-        endpoint = 'http://%s:%s' % (host, port)
+        endpoint = 'http://{0!s}:{1!s}'.format(host, port)
 
         client = glance.GlanceClientWrapper(context=ctx, endpoint=endpoint)
         client.call(ctx, 1, 'get', 'meow')

--- a/nova/tests/unit/image_fixtures.py
+++ b/nova/tests/unit/image_fixtures.py
@@ -62,7 +62,7 @@ def get_image_fixtures():
         deleted = False if status != 'deleted' else True
         deleted_at = NOW_DATE if deleted else None
 
-        add_fixture(id=str(image_id), name='%s snapshot' % status,
+        add_fixture(id=str(image_id), name='{0!s} snapshot'.format(status),
                     is_public=False, status=status,
                     properties=snapshot_properties, size='25165824',
                     deleted=deleted, deleted_at=deleted_at)

--- a/nova/tests/unit/matchers.py
+++ b/nova/tests/unit/matchers.py
@@ -62,7 +62,7 @@ class DictMatches(object):
         self.tolerance = tolerance
 
     def __str__(self):
-        return 'DictMatches(%s)' % (pprint.pformat(self.d1))
+        return 'DictMatches({0!s})'.format((pprint.pformat(self.d1)))
 
     # Useful assertions
     def match(self, d2):
@@ -132,7 +132,7 @@ class DictListMatches(object):
         self.tolerance = tolerance
 
     def __str__(self):
-        return 'DictListMatches(%s)' % (pprint.pformat(self.l1))
+        return 'DictListMatches({0!s})'.format((pprint.pformat(self.l1)))
 
     # Useful assertions
     def match(self, l2):
@@ -167,8 +167,7 @@ class SubDictMismatch(object):
         if self.keys:
             return "Keys between dictionaries did not match"
         else:
-            return("Dictionaries do not match at %s. d1: %s d2: %s"
-                   % (self.key,
+            return("Dictionaries do not match at {0!s}. d1: {1!s} d2: {2!s}".format(self.key,
                       self.super_value,
                       self.sub_value))
 
@@ -182,7 +181,7 @@ class IsSubDictOf(object):
         self.super_dict = super_dict
 
     def __str__(self):
-        return 'IsSubDictOf(%s)' % (self.super_dict)
+        return 'IsSubDictOf({0!s})'.format((self.super_dict))
 
     def match(self, sub_dict):
         """Assert a sub_dict is subset of super_dict."""
@@ -226,7 +225,7 @@ class XMLMismatch(object):
         self.actual = state.actual
 
     def describe(self):
-        return "%(path)s: XML does not match" % {'path': self.path}
+        return "{path!s}: XML does not match".format(**{'path': self.path})
 
     def get_details(self):
         return {
@@ -385,7 +384,7 @@ class XMLMatchState(object):
         """
 
         if idx is not None:
-            self.path.append("%s[%d]" % (tag, idx))
+            self.path.append("{0!s}[{1:d}]".format(tag, idx))
         else:
             self.path.append(tag)
         return self
@@ -405,7 +404,7 @@ class XMLMatches(object):
         self.skip_values = set(skip_values)
 
     def __str__(self):
-        return 'XMLMatches(%r)' % self.expected_xml
+        return 'XMLMatches({0!r})'.format(self.expected_xml)
 
     def match(self, actual_xml):
         actual = etree.parse(six.StringIO(actual_xml))
@@ -539,7 +538,7 @@ class EncodedByUTF8(object):
                     obj.decode("utf-8")
                 except UnicodeDecodeError:
                     return testtools.matchers.Mismatch(
-                        "%s is not encoded in UTF-8." % obj)
+                        "{0!s} is not encoded in UTF-8.".format(obj))
         else:
             reason = ("Type of '%(obj)s' is '%(obj_type)s', "
                       "should be '%(correct_type)s'."

--- a/nova/tests/unit/network/security_group/test_neutron_driver.py
+++ b/nova/tests/unit/network/security_group/test_neutron_driver.py
@@ -337,8 +337,8 @@ class TestNeutronDriver(test.NoDBTestCase):
         ports = []
         sg_bindings = {}
         for i in range(0, num_servers):
-            server_id = "server-%d" % i
-            port_id = "port-%d" % i
+            server_id = "server-{0:d}".format(i)
+            port_id = "port-{0:d}".format(i)
             servers.append({'id': server_id})
             device_ids.append(server_id)
             ports.append({'id': port_id,

--- a/nova/tests/unit/network/test_linux_net.py
+++ b/nova/tests/unit/network/test_linux_net.py
@@ -770,28 +770,28 @@ class LinuxNetworkTestCase(test.NoDBTestCase):
             fixedips = self._get_fixedips(network_ref)
             linux_net.restart_dhcp(self.context, dev, network_ref, fixedips)
             expected = ['env',
-            'CONFIG_FILE=%s' % jsonutils.dumps(CONF.dhcpbridge_flagfile),
+            'CONFIG_FILE={0!s}'.format(jsonutils.dumps(CONF.dhcpbridge_flagfile)),
             'NETWORK_ID=fake',
             'dnsmasq',
             '--strict-order',
             '--bind-interfaces',
-            '--conf-file=%s' % CONF.dnsmasq_config_file,
-            '--pid-file=%s' % linux_net._dhcp_file(dev, 'pid'),
-            '--dhcp-optsfile=%s' % linux_net._dhcp_file(dev, 'opts'),
-            '--listen-address=%s' % network_ref['dhcp_server'],
+            '--conf-file={0!s}'.format(CONF.dnsmasq_config_file),
+            '--pid-file={0!s}'.format(linux_net._dhcp_file(dev, 'pid')),
+            '--dhcp-optsfile={0!s}'.format(linux_net._dhcp_file(dev, 'opts')),
+            '--listen-address={0!s}'.format(network_ref['dhcp_server']),
             '--except-interface=lo',
-            "--dhcp-range=set:%s,%s,static,%s,%ss" % (network_ref['label'],
+            "--dhcp-range=set:{0!s},{1!s},static,{2!s},{3!s}s".format(network_ref['label'],
                                                     network_ref['dhcp_start'],
                                                     network_ref['netmask'],
                                                     CONF.dhcp_lease_time),
             '--dhcp-lease-max=256',
-            '--dhcp-hostsfile=%s' % linux_net._dhcp_file(dev, 'conf'),
-            '--dhcp-script=%s' % CONF.dhcpbridge,
+            '--dhcp-hostsfile={0!s}'.format(linux_net._dhcp_file(dev, 'conf')),
+            '--dhcp-script={0!s}'.format(CONF.dhcpbridge),
             '--no-hosts',
             '--leasefile-ro']
 
             if CONF.dhcp_domain:
-                expected.append('--domain=%s' % CONF.dhcp_domain)
+                expected.append('--domain={0!s}'.format(CONF.dhcp_domain))
 
             if extra_expected:
                 expected += extra_expected

--- a/nova/tests/unit/network/test_manager.py
+++ b/nova/tests/unit/network/test_manager.py
@@ -203,32 +203,32 @@ class FlatNetworkTestCase(test.TestCase):
 
         for i, vif in enumerate(nw_info):
             nid = i + 1
-            check = {'bridge': 'fake_br%d' % nid,
-                     'cidr': '192.168.%s.0/24' % nid,
-                     'cidr_v6': '2001:db8:0:%x::/64' % nid,
-                     'id': getattr(uuids, 'vif%i' % nid),
+            check = {'bridge': 'fake_br{0:d}'.format(nid),
+                     'cidr': '192.168.{0!s}.0/24'.format(nid),
+                     'cidr_v6': '2001:db8:0:{0:x}::/64'.format(nid),
+                     'id': getattr(uuids, 'vif{0:d}'.format(nid)),
                      'multi_host': False,
                      'injected': False,
                      'bridge_interface': None,
                      'vlan': None,
-                     'broadcast': '192.168.%d.255' % nid,
+                     'broadcast': '192.168.{0:d}.255'.format(nid),
                      'dhcp_server': '192.168.1.1',
-                     'dns': ['192.168.%d.3' % nid, '192.168.%d.4' % nid],
-                     'gateway': '192.168.%d.1' % nid,
+                     'dns': ['192.168.{0:d}.3'.format(nid), '192.168.{0:d}.4'.format(nid)],
+                     'gateway': '192.168.{0:d}.1'.format(nid),
                      'gateway_v6': '2001:db8:0:1::1',
-                     'label': 'test%d' % nid,
-                     'mac': 'DE:AD:BE:EF:00:%02x' % nid,
+                     'label': 'test{0:d}'.format(nid),
+                     'mac': 'DE:AD:BE:EF:00:{0:02x}'.format(nid),
                      'rxtx_cap': 30,
                      'vif_type': net_model.VIF_TYPE_BRIDGE,
                      'vif_devname': None,
-                     'vif_uuid': getattr(uuids, 'vif%i' % nid),
+                     'vif_uuid': getattr(uuids, 'vif{0:d}'.format(nid)),
                      'ovs_interfaceid': None,
                      'qbh_params': None,
                      'qbg_params': None,
                      'should_create_vlan': False,
                      'should_create_bridge': False,
-                     'ip': '192.168.%d.%03d' % (nid, nid + 99),
-                     'ip_v6': '2001:db8:0:1:dcad:beff:feef:%x' % nid,
+                     'ip': '192.168.{0:d}.{1:03d}'.format(nid, nid + 99),
+                     'ip_v6': '2001:db8:0:1:dcad:beff:feef:{0:x}'.format(nid),
                      'netmask': '255.255.255.0',
                      'netmask_v6': 64,
                      'physical_network': None,
@@ -445,14 +445,14 @@ class FlatNetworkTestCase(test.TestCase):
                                       broadcast_v6=None,
                                       netmask_v6=None,
                                       rxtx_base=None,
-                                      gateway='192.168.%s.1' % index,
-                                      dhcp_server='192.168.%s.1' % index,
-                                      broadcast='192.168.%s.255' % index,
-                                      cidr='192.168.%s.0/24' % index)
+                                      gateway='192.168.{0!s}.1'.format(index),
+                                      dhcp_server='192.168.{0!s}.1'.format(index),
+                                      broadcast='192.168.{0!s}.255'.format(index),
+                                      cidr='192.168.{0!s}.0/24'.format(index))
             return objects.FixedIP(virtual_interface=vif,
                                    network=network,
                                    floating_ips=objects.FloatingIPList(),
-                                   address='192.168.%s.2' % index)
+                                   address='192.168.{0!s}.2'.format(index))
         objs = [make_ip(index) for index in ('3', '1', '2')]
         get.return_value = objects.FixedIPList(objects=objs)
         nw_info = self.network.get_instance_nw_info(self.context, None,
@@ -2495,11 +2495,9 @@ class CommonNetworkTestCase(test.TestCase):
                           % (binary_name, networks[0]['cidr'],
                                           CONF.routing_source_ip,
                                           CONF.public_interface),
-                          '[0:0] -A %s-POSTROUTING -s %s -d %s/32 -j ACCEPT'
-                          % (binary_name, networks[0]['cidr'],
+                          '[0:0] -A {0!s}-POSTROUTING -s {1!s} -d {2!s}/32 -j ACCEPT'.format(binary_name, networks[0]['cidr'],
                                           CONF.metadata_host),
-                          '[0:0] -A %s-POSTROUTING -s %s -d %s -j ACCEPT'
-                          % (binary_name, networks[0]['cidr'],
+                          '[0:0] -A {0!s}-POSTROUTING -s {1!s} -d {2!s} -j ACCEPT'.format(binary_name, networks[0]['cidr'],
                                           CONF.dmz_cidr[0]),
                           '[0:0] -A %s-POSTROUTING -s %s -d %s -m conntrack ! '
                           '--ctstate DNAT -j ACCEPT' % (binary_name,
@@ -2510,11 +2508,9 @@ class CommonNetworkTestCase(test.TestCase):
                           % (binary_name, networks[1]['cidr'],
                                           CONF.routing_source_ip,
                                           CONF.public_interface),
-                          '[0:0] -A %s-POSTROUTING -s %s -d %s/32 -j ACCEPT'
-                          % (binary_name, networks[1]['cidr'],
+                          '[0:0] -A {0!s}-POSTROUTING -s {1!s} -d {2!s}/32 -j ACCEPT'.format(binary_name, networks[1]['cidr'],
                                           CONF.metadata_host),
-                          '[0:0] -A %s-POSTROUTING -s %s -d %s -j ACCEPT'
-                          % (binary_name, networks[1]['cidr'],
+                          '[0:0] -A {0!s}-POSTROUTING -s {1!s} -d {2!s} -j ACCEPT'.format(binary_name, networks[1]['cidr'],
                                           CONF.dmz_cidr[0]),
                           '[0:0] -A %s-POSTROUTING -s %s -d %s -m conntrack ! '
                           '--ctstate DNAT -j ACCEPT' % (binary_name,
@@ -2568,11 +2564,9 @@ class CommonNetworkTestCase(test.TestCase):
                            % (binary_name, new_network['cidr'],
                                            CONF.routing_source_ip,
                                            CONF.public_interface),
-                           '[0:0] -A %s-POSTROUTING -s %s -d %s/32 -j ACCEPT'
-                           % (binary_name, new_network['cidr'],
+                           '[0:0] -A {0!s}-POSTROUTING -s {1!s} -d {2!s}/32 -j ACCEPT'.format(binary_name, new_network['cidr'],
                                            CONF.metadata_host),
-                           '[0:0] -A %s-POSTROUTING -s %s -d %s -j ACCEPT'
-                           % (binary_name, new_network['cidr'],
+                           '[0:0] -A {0!s}-POSTROUTING -s {1!s} -d {2!s} -j ACCEPT'.format(binary_name, new_network['cidr'],
                                            CONF.dmz_cidr[0]),
                            '[0:0] -A %s-POSTROUTING -s %s -d %s -m conntrack '
                            '! --ctstate DNAT -j ACCEPT' % (binary_name,
@@ -3429,7 +3423,7 @@ class LdapDNSTestCase(test.NoDBTestCase):
 
         self.driver.delete_entry(name1, domain1)
         entries = self.driver.get_entries_by_address(address1, domain1)
-        LOG.debug("entries: %s" % entries)
+        LOG.debug("entries: {0!s}".format(entries))
         self.assertEqual(1, len(entries))
         self.assertEqual(name2, entries[0])
 

--- a/nova/tests/unit/network/test_neutronv2.py
+++ b/nova/tests/unit/network/test_neutronv2.py
@@ -609,18 +609,18 @@ class TestNeutronv2Base(test.TestCase):
 
     def _verify_nw_info(self, nw_inf, index=0):
         id_suffix = index + 1
-        self.assertEqual('10.0.%s.2' % id_suffix,
+        self.assertEqual('10.0.{0!s}.2'.format(id_suffix),
                          nw_inf.fixed_ips()[index]['address'])
-        self.assertEqual('172.0.%s.2' % id_suffix,
+        self.assertEqual('172.0.{0!s}.2'.format(id_suffix),
             nw_inf.fixed_ips()[index].floating_ip_addresses()[0])
-        self.assertEqual('my_netname%s' % id_suffix,
+        self.assertEqual('my_netname{0!s}'.format(id_suffix),
                          nw_inf[index]['network']['label'])
-        self.assertEqual('my_portid%s' % id_suffix, nw_inf[index]['id'])
-        self.assertEqual('my_mac%s' % id_suffix, nw_inf[index]['address'])
-        self.assertEqual('10.0.%s.0/24' % id_suffix,
+        self.assertEqual('my_portid{0!s}'.format(id_suffix), nw_inf[index]['id'])
+        self.assertEqual('my_mac{0!s}'.format(id_suffix), nw_inf[index]['address'])
+        self.assertEqual('10.0.{0!s}.0/24'.format(id_suffix),
             nw_inf[index]['network']['subnets'][0]['cidr'])
 
-        ip_addr = model.IP(address='8.8.%s.1' % id_suffix,
+        ip_addr = model.IP(address='8.8.{0!s}.1'.format(id_suffix),
                            version=4, type='dns')
         self.assertIn(ip_addr, nw_inf[index]['network']['subnets'][0]['dns'])
 
@@ -656,7 +656,7 @@ class TestNeutronv2Base(test.TestCase):
                         {'floatingips': float_data})
             subnet_data = i == 1 and self.subnet_data1 or self.subnet_data2
             self.moxed_client.list_subnets(
-                id=mox.SameElementsAs(['my_subid%s' % i])).AndReturn(
+                id=mox.SameElementsAs(['my_subid{0!s}'.format(i)])).AndReturn(
                     {'subnets': subnet_data})
             self.moxed_client.list_ports(
                 network_id=subnet_data[0]['network_id'],
@@ -938,8 +938,8 @@ class TestNeutronv2(TestNeutronv2Base):
         id_suffix = 3
         self.assertEqual(0, len(nw_inf.fixed_ips()))
         self.assertEqual('my_netname1', nw_inf[0]['network']['label'])
-        self.assertEqual('my_portid%s' % id_suffix, nw_inf[0]['id'])
-        self.assertEqual('my_mac%s' % id_suffix, nw_inf[0]['address'])
+        self.assertEqual('my_portid{0!s}'.format(id_suffix), nw_inf[0]['id'])
+        self.assertEqual('my_mac{0!s}'.format(id_suffix), nw_inf[0]['address'])
         self.assertEqual(0, len(nw_inf[0]['network']['subnets']))
 
     def test_refresh_neutron_extensions_cache(self):
@@ -1930,7 +1930,7 @@ class TestNeutronv2(TestNeutronv2Base):
             port_data = self.port_data2
         address = self.port_address
         self.moxed_client.list_ports(
-            fixed_ips=MyComparator('ip_address=%s' % address)).AndReturn(
+            fixed_ips=MyComparator('ip_address={0!s}'.format(address))).AndReturn(
                 {'ports': port_data})
         self.mox.ReplayAll()
         return address
@@ -2394,10 +2394,10 @@ class TestNeutronv2(TestNeutronv2Base):
         api = neutronapi.API()
         self._setup_mock_for_refresh_cache(api, [instance])
         address = '10.0.0.3'
-        zone = 'compute:%s' % self.instance['availability_zone']
+        zone = 'compute:{0!s}'.format(self.instance['availability_zone'])
         search_opts = {'device_id': self.instance['uuid'],
                        'device_owner': zone,
-                       'fixed_ips': 'ip_address=%s' % address}
+                       'fixed_ips': 'ip_address={0!s}'.format(address)}
         self.moxed_client.list_ports(
             **search_opts).AndReturn({'ports': self.port_data1})
         port_req_body = {
@@ -2965,7 +2965,7 @@ class TestNeutronv2WithMock(test.TestCase):
         mock_lock.side_effect = test.TestingException
         self.assertRaises(test.TestingException,
                           api.get_instance_nw_info, 'context', instance)
-        mock_lock.assert_called_once_with('refresh_cache-%s' % instance.uuid)
+        mock_lock.assert_called_once_with('refresh_cache-{0!s}'.format(instance.uuid))
 
     @mock.patch('nova.network.neutronv2.api.LOG')
     def test_get_instance_nw_info_verify_duplicates_ignored(self, mock_log):
@@ -3040,7 +3040,7 @@ class TestNeutronv2WithMock(test.TestCase):
             for args, return_value in list_port_values:
                 if args == search_opts:
                     return return_value
-            self.fail('Unexpected call to list_ports %s' % search_opts)
+            self.fail('Unexpected call to list_ports {0!s}'.format(search_opts))
 
         with test.nested(
             mock.patch.object(client.Client, 'list_ports',
@@ -3214,7 +3214,7 @@ class TestNeutronv2WithMock(test.TestCase):
         with mock.patch.object(client.Client, 'create_port',
             side_effect=exceptions.IpAddressGenerationFailureClient()) as (
             create_port_mock):
-            zone = 'compute:%s' % instance['availability_zone']
+            zone = 'compute:{0!s}'.format(instance['availability_zone'])
             port_req_body = {'port': {'device_id': instance['uuid'],
                                       'device_owner': zone}}
             self.assertRaises(exception.NoMoreFixedIps,
@@ -3233,7 +3233,7 @@ class TestNeutronv2WithMock(test.TestCase):
                'name': 'my_netname1',
                'subnets': ['mysubnid1'],
                'tenant_id': instance['project_id']}
-        zone = 'compute:%s' % instance['availability_zone']
+        zone = 'compute:{0!s}'.format(instance['availability_zone'])
         port_req_body = {'port': {'device_id': instance['uuid'],
                                   'device_owner': zone,
                                   'mac_address': 'XX:XX:XX:XX:XX:XX'}}
@@ -3256,7 +3256,7 @@ class TestNeutronv2WithMock(test.TestCase):
                'name': 'my_netname1',
                'subnets': ['mysubnid1'],
                'tenant_id': instance['project_id']}
-        zone = 'compute:%s' % instance['availability_zone']
+        zone = 'compute:{0!s}'.format(instance['availability_zone'])
         port_req_body = {'port': {'device_id': instance['uuid'],
                                   'device_owner': zone,
                                   'mac_address': 'XX:XX:XX:XX:XX:XX'}}
@@ -3279,7 +3279,7 @@ class TestNeutronv2WithMock(test.TestCase):
                'name': 'my_netname1',
                'subnets': ['mysubnid1'],
                'tenant_id': instance['project_id']}
-        zone = 'compute:%s' % instance['availability_zone']
+        zone = 'compute:{0!s}'.format(instance['availability_zone'])
         port_req_body = {'port': {'device_id': instance['uuid'],
                                   'device_owner': zone,
                                   'mac_address': 'XX:XX:XX:XX:XX:XX'}}

--- a/nova/tests/unit/objects/test_bandwidth_usage.py
+++ b/nova/tests/unit/objects/test_bandwidth_usage.py
@@ -45,7 +45,7 @@ class _TestBandwidthUsage(test.TestCase):
             if obj_field == 'uuid':
                 obj_field = 'instance_uuid'
             test.assertEqual(db[field], obj[obj_field],
-                    'Field %s is not equal' % field)
+                    'Field {0!s} is not equal'.format(field))
 
     @staticmethod
     def _fake_bw_usage(time=None, start_period=None, bw_in=100,

--- a/nova/tests/unit/objects/test_fields.py
+++ b/nova/tests/unit/objects/test_fields.py
@@ -27,10 +27,10 @@ from nova import utils
 
 class FakeFieldType(fields.FieldType):
     def coerce(self, obj, attr, value):
-        return '*%s*' % value
+        return '*{0!s}*'.format(value)
 
     def to_primitive(self, obj, attr, value):
-        return '!%s!' % value
+        return '!{0!s}!'.format(value)
 
     def from_primitive(self, obj, attr, value):
         return value[1:-1]

--- a/nova/tests/unit/objects/test_instance.py
+++ b/nova/tests/unit/objects/test_instance.py
@@ -1062,7 +1062,7 @@ class _TestInstanceObject(object):
         inst = objects.Instance.get_by_uuid(self.context, db_inst['uuid'])
         self.assertFalse(inst.obj_attr_is_set('fault'))
         self.flags(instance_name_template='foo-%(uuid)s')
-        self.assertEqual('foo-%s' % db_inst['uuid'], inst.name)
+        self.assertEqual('foo-{0!s}'.format(db_inst['uuid']), inst.name)
         self.assertFalse(inst.obj_attr_is_set('fault'))
 
     def test_from_db_object_not_overwrite_info_cache(self):
@@ -1332,9 +1332,9 @@ class TestInstanceObject(test_objects._LocalTest,
         instance = fake_instance.fake_instance_obj(self.context,
                                                    expected_attrs=attrs)
         fields_with_save_methods = [field for field in instance.fields
-                                    if hasattr(instance, '_save_%s' % field)]
+                                    if hasattr(instance, '_save_{0!s}'.format(field))]
         for field in fields_with_save_methods:
-            @mock.patch.object(instance, '_save_%s' % field)
+            @mock.patch.object(instance, '_save_{0!s}'.format(field))
             @mock.patch.object(instance, 'obj_attr_is_set')
             def _test(mock_is_set, mock_save_field):
                 mock_is_set.return_value = True

--- a/nova/tests/unit/objects/test_network.py
+++ b/nova/tests/unit/objects/test_network.py
@@ -67,7 +67,7 @@ class _TestNetworkObject(object):
             if isinstance(obj_val, netaddr.IPNetwork):
                 obj_val = str(obj_val)
             if field == 'netmask_v6':
-                db_val = str(netaddr.IPNetwork('1::/%i' % db_val).netmask)
+                db_val = str(netaddr.IPNetwork('1::/{0:d}'.format(db_val)).netmask)
             self.assertEqual(db_val, obj_val)
 
     @mock.patch('nova.db.network_get')

--- a/nova/tests/unit/objects/test_objects.py
+++ b/nova/tests/unit/objects/test_objects.py
@@ -112,7 +112,7 @@ class MyObj(base.NovaPersistentObject, base.NovaObject,
         # NOTE(danms): Simulate an older version that had a different
         # format for the 'bar' attribute
         if target_version == '1.1' and 'bar' in primitive:
-            primitive['bar'] = 'old%s' % primitive['bar']
+            primitive['bar'] = 'old{0!s}'.format(primitive['bar'])
 
 
 class RandomMixInWithNoFields(object):
@@ -1254,9 +1254,8 @@ class TestObjectVersions(test.NoDBTestCase):
             obj_class = obj_classes[obj_name][0]
             version = versionutils.convert_version_to_tuple(obj_class.VERSION)
             for n in range(version[1]):
-                test_version = '%d.%d' % (version[0], n)
-                LOG.info('testing obj: %s version: %s' %
-                         (obj_name, test_version))
+                test_version = '{0:d}.{1:d}'.format(version[0], n)
+                LOG.info('testing obj: {0!s} version: {1!s}'.format(obj_name, test_version))
                 obj_class().obj_to_primitive(target_version=test_version,
                                              version_manifest=versions)
 

--- a/nova/tests/unit/objects/test_pci_device.py
+++ b/nova/tests/unit/objects/test_pci_device.py
@@ -496,9 +496,9 @@ class _TestSRIOVPciDeviceObject(object):
         self.sriov_pf_devices = []
         for dev in range(num_pfs):
             pci_dev = {'compute_node_id': 1,
-                       'address': '0000:81:00.%d' % dev,
+                       'address': '0000:81:00.{0:d}'.format(dev),
                        'vendor_id': '8086',
-                       'product_id': '%d' % pf_product_id,
+                       'product_id': '{0:d}'.format(pf_product_id),
                        'status': 'available',
                        'request_id': None,
                        'dev_type': fields.PciDeviceType.SRIOV_PF,
@@ -511,13 +511,13 @@ class _TestSRIOVPciDeviceObject(object):
         self.sriov_vf_devices = []
         for dev in range(num_vfs):
             pci_dev = {'compute_node_id': 1,
-                       'address': '0000:81:10.%d' % dev,
+                       'address': '0000:81:10.{0:d}'.format(dev),
                        'vendor_id': '8086',
-                       'product_id': '%d' % vf_product_id,
+                       'product_id': '{0:d}'.format(vf_product_id),
                        'status': 'available',
                        'request_id': None,
                        'dev_type': fields.PciDeviceType.SRIOV_VF,
-                       'parent_addr': '0000:81:00.%d' % int(dev / 4),
+                       'parent_addr': '0000:81:00.{0:d}'.format(int(dev / 4)),
                        'numa_node': 0}
             pci_dev_obj = objects.PciDevice.create(None, pci_dev)
             pci_dev_obj.id = num_vfs + 1

--- a/nova/tests/unit/objects/test_request_spec.py
+++ b/nova/tests/unit/objects/test_request_spec.py
@@ -291,7 +291,7 @@ class _TestRequestSpecObject(object):
         # Make sure that all fields are set using that helper method
         for field in [f for f in spec.obj_fields if f != 'id']:
             self.assertTrue(spec.obj_attr_is_set(field),
-                             'Field: %s is not set' % field)
+                             'Field: {0!s} is not set'.format(field))
         # just making sure that the context is set by the method
         self.assertEqual(ctxt, spec._context)
 
@@ -310,7 +310,7 @@ class _TestRequestSpecObject(object):
         # Make sure that all fields are set using that helper method
         for field in [f for f in spec.obj_fields if f != 'id']:
             self.assertEqual(True, spec.obj_attr_is_set(field),
-                             'Field: %s is not set' % field)
+                             'Field: {0!s} is not set'.format(field))
         # just making sure that the context is set by the method
         self.assertEqual(ctxt, spec._context)
 

--- a/nova/tests/unit/pci/test_devspec.py
+++ b/nova/tests/unit/pci/test_devspec.py
@@ -45,7 +45,7 @@ class PciAddressTestCase(test.NoDBTestCase):
             devspec.PciDeviceSpec, pci_info)
 
     def test_max_func(self):
-        pci_info = {"address": "0000:0a:00.%s" % (devspec.MAX_FUNC + 1),
+        pci_info = {"address": "0000:0a:00.{0!s}".format((devspec.MAX_FUNC + 1)),
                     "physical_network": "hr_net"}
         exc = self.assertRaises(exception.PciDeviceInvalidAddressField,
                   devspec.PciDeviceSpec, pci_info)
@@ -55,30 +55,27 @@ class PciAddressTestCase(test.NoDBTestCase):
         self.assertEqual(msg, six.text_type(exc))
 
     def test_max_domain(self):
-        pci_info = {"address": "%x:0a:00.5" % (devspec.MAX_DOMAIN + 1),
+        pci_info = {"address": "{0:x}:0a:00.5".format((devspec.MAX_DOMAIN + 1)),
                     "physical_network": "hr_net"}
         exc = self.assertRaises(exception.PciConfigInvalidWhitelist,
                   devspec.PciDeviceSpec, pci_info)
-        msg = ('Invalid PCI devices Whitelist config invalid domain %x'
-               % (devspec.MAX_DOMAIN + 1))
+        msg = ('Invalid PCI devices Whitelist config invalid domain {0:x}'.format((devspec.MAX_DOMAIN + 1)))
         self.assertEqual(msg, six.text_type(exc))
 
     def test_max_bus(self):
-        pci_info = {"address": "0000:%x:00.5" % (devspec.MAX_BUS + 1),
+        pci_info = {"address": "0000:{0:x}:00.5".format((devspec.MAX_BUS + 1)),
                     "physical_network": "hr_net"}
         exc = self.assertRaises(exception.PciConfigInvalidWhitelist,
                   devspec.PciDeviceSpec, pci_info)
-        msg = ('Invalid PCI devices Whitelist config invalid bus %x'
-               % (devspec.MAX_BUS + 1))
+        msg = ('Invalid PCI devices Whitelist config invalid bus {0:x}'.format((devspec.MAX_BUS + 1)))
         self.assertEqual(msg, six.text_type(exc))
 
     def test_max_slot(self):
-        pci_info = {"address": "0000:0a:%x.5" % (devspec.MAX_SLOT + 1),
+        pci_info = {"address": "0000:0a:{0:x}.5".format((devspec.MAX_SLOT + 1)),
                     "physical_network": "hr_net"}
         exc = self.assertRaises(exception.PciConfigInvalidWhitelist,
                   devspec.PciDeviceSpec, pci_info)
-        msg = ('Invalid PCI devices Whitelist config invalid slot %x'
-               % (devspec.MAX_SLOT + 1))
+        msg = ('Invalid PCI devices Whitelist config invalid slot {0:x}'.format((devspec.MAX_SLOT + 1)))
         self.assertEqual(msg, six.text_type(exc))
 
     def test_address_is_undefined(self):

--- a/nova/tests/unit/pci/test_stats.py
+++ b/nova/tests/unit/pci/test_stats.py
@@ -233,7 +233,7 @@ class PciDeviceStatsWithTagsTestCase(test.NoDBTestCase):
         self.pci_tagged_devices = []
         for dev in range(4):
             pci_dev = {'compute_node_id': 1,
-                       'address': '0000:0a:00.%d' % dev,
+                       'address': '0000:0a:00.{0:d}'.format(dev),
                        'vendor_id': '1137',
                        'product_id': '0071',
                        'status': 'available',
@@ -247,7 +247,7 @@ class PciDeviceStatsWithTagsTestCase(test.NoDBTestCase):
         self.pci_untagged_devices = []
         for dev in range(3):
             pci_dev = {'compute_node_id': 1,
-                       'address': '0000:0b:00.%d' % dev,
+                       'address': '0000:0b:00.{0:d}'.format(dev),
                        'vendor_id': '1137',
                        'product_id': '0072',
                        'status': 'available',
@@ -359,9 +359,9 @@ class PciDeviceVFPFStatsTestCase(test.NoDBTestCase):
         self.sriov_pf_devices = []
         for dev in range(2):
             pci_dev = {'compute_node_id': 1,
-                       'address': '0000:81:00.%d' % dev,
+                       'address': '0000:81:00.{0:d}'.format(dev),
                        'vendor_id': '8086',
-                       'product_id': '%d' % pf_product_id,
+                       'product_id': '{0:d}'.format(pf_product_id),
                        'status': 'available',
                        'request_id': None,
                        'dev_type': fields.PciDeviceType.SRIOV_PF,
@@ -373,13 +373,13 @@ class PciDeviceVFPFStatsTestCase(test.NoDBTestCase):
         self.sriov_vf_devices = []
         for dev in range(8):
             pci_dev = {'compute_node_id': 1,
-                       'address': '0000:81:10.%d' % dev,
+                       'address': '0000:81:10.{0:d}'.format(dev),
                        'vendor_id': '8086',
-                       'product_id': '%d' % vf_product_id,
+                       'product_id': '{0:d}'.format(vf_product_id),
                        'status': 'available',
                        'request_id': None,
                        'dev_type': fields.PciDeviceType.SRIOV_VF,
-                       'parent_addr': '0000:81:00.%d' % int(dev / 4),
+                       'parent_addr': '0000:81:00.{0:d}'.format(int(dev / 4)),
                        'numa_node': 0}
             self.sriov_vf_devices.append(objects.PciDevice.create(None,
                                                                   pci_dev))

--- a/nova/tests/unit/pci/test_utils.py
+++ b/nova/tests/unit/pci/test_utils.py
@@ -167,7 +167,7 @@ class GetMacByPciAddressTestCase(test.NoDBTestCase):
         mock_join.return_value = self.fake_file
         mac = utils.get_mac_by_pci_address(self.pci_address)
         mock_join.assert_called_once_with(
-            "/sys/bus/pci/devices/%s/net" % self.pci_address, self.if_name,
+            "/sys/bus/pci/devices/{0!s}/net".format(self.pci_address), self.if_name,
             "address")
         self.assertEqual("a0:36:9f:72:00:00", mac)
 
@@ -199,7 +199,7 @@ class GetMacByPciAddressTestCase(test.NoDBTestCase):
         mock_join.return_value = self.fake_file
         mac = utils.get_mac_by_pci_address(self.pci_address, pf_interface=True)
         mock_join.assert_called_once_with(
-            "/sys/bus/pci/devices/%s/physfn/net" % self.pci_address,
+            "/sys/bus/pci/devices/{0!s}/physfn/net".format(self.pci_address),
             self.if_name, "address")
         self.assertEqual("a0:36:9f:72:00:00", mac)
 

--- a/nova/tests/unit/policy_fixture.py
+++ b/nova/tests/unit/policy_fixture.py
@@ -104,7 +104,7 @@ class RoleBasedPolicyFixture(RealPolicyFixture):
 
         # Convert all actions to require specified role
         for action, rule in six.iteritems(policy):
-            policy[action] = 'role:%s' % self.role
+            policy[action] = 'role:{0!s}'.format(self.role)
 
         self.policy_dir = self.useFixture(fixtures.TempDir())
         self.policy_file = os.path.join(self.policy_dir.path,

--- a/nova/tests/unit/scheduler/test_caching_scheduler.py
+++ b/nova/tests/unit/scheduler/test_caching_scheduler.py
@@ -133,8 +133,8 @@ class CachingSchedulerTestCase(test_scheduler.SchedulerTestCase):
 
     def _get_fake_host_state(self, index=0):
         host_state = host_manager.HostState(
-            'host_%s' % index,
-            'node_%s' % index)
+            'host_{0!s}'.format(index),
+            'node_{0!s}'.format(index))
         host_state.free_ram_mb = 50000
         host_state.total_usable_ram_mb = 50000
         host_state.free_disk_mb = 4096

--- a/nova/tests/unit/scheduler/test_filters.py
+++ b/nova/tests/unit/scheduler/test_filters.py
@@ -201,7 +201,7 @@ class FiltersTestCase(test.NoDBTestCase):
             exp_output = ("['FilterA: (start: 3, end: 2)', "
                           "'FilterB: (start: 2, end: 0)']")
             cargs = mock_log.call_args[0][0]
-            self.assertIn("with instance ID '%s'" % fake_uuid, cargs)
+            self.assertIn("with instance ID '{0!s}'".format(fake_uuid), cargs)
             self.assertIn(exp_output, cargs)
 
     def test_get_filtered_objects_debug_log_none_returned(self):
@@ -231,7 +231,7 @@ class FiltersTestCase(test.NoDBTestCase):
             exp_output = ("[('FilterA', [('Host1', ''), ('Host2', '')]), " +
                           "('FilterB', None)]")
             cargs = mock_log.call_args[0][0]
-            self.assertIn("with instance ID '%s'" % fake_uuid, cargs)
+            self.assertIn("with instance ID '{0!s}'".format(fake_uuid), cargs)
             self.assertIn(exp_output, cargs)
 
     def test_get_filtered_objects_compatible_with_filt_props_dicts(self):
@@ -262,5 +262,5 @@ class FiltersTestCase(test.NoDBTestCase):
             exp_output = ("['FilterA: (start: 3, end: 2)', "
                           "'FilterB: (start: 2, end: 0)']")
             cargs = mock_log.call_args[0][0]
-            self.assertIn("with instance ID '%s'" % fake_uuid, cargs)
+            self.assertIn("with instance ID '{0!s}'".format(fake_uuid), cargs)
             self.assertIn(exp_output, cargs)

--- a/nova/tests/unit/scheduler/test_host_manager.py
+++ b/nova/tests/unit/scheduler/test_host_manager.py
@@ -61,15 +61,15 @@ class HostManagerTestCase(test.NoDBTestCase):
     @mock.patch.object(host_manager.HostManager, '_init_aggregates')
     def setUp(self, mock_init_agg, mock_init_inst):
         super(HostManagerTestCase, self).setUp()
-        self.flags(scheduler_available_filters=['%s.%s' % (__name__, cls) for
+        self.flags(scheduler_available_filters=['{0!s}.{1!s}'.format(__name__, cls) for
                                                 cls in ['FakeFilterClass1',
                                                         'FakeFilterClass2']])
         self.flags(scheduler_default_filters=['FakeFilterClass1'])
         self.host_manager = host_manager.HostManager()
-        self.fake_hosts = [host_manager.HostState('fake_host%s' % x,
+        self.fake_hosts = [host_manager.HostState('fake_host{0!s}'.format(x),
                 'fake-node') for x in range(1, 5)]
         self.fake_hosts += [host_manager.HostState('fake_multihost',
-                'fake-node%s' % x) for x in range(1, 5)]
+                'fake-node{0!s}'.format(x)) for x in range(1, 5)]
 
         self.useFixture(fixtures.SpawnIsSynchronousFixture())
 
@@ -83,7 +83,7 @@ class HostManagerTestCase(test.NoDBTestCase):
                                         mock_get_by_filters):
         cn_list = objects.ComputeNodeList()
         for num in range(22):
-            host_name = 'host_%s' % num
+            host_name = 'host_{0!s}'.format(num)
             cn_list.objects.append(objects.ComputeNode(host=host_name))
         mock_get_all.return_value = cn_list
         self.host_manager._init_instance_info()
@@ -847,10 +847,10 @@ class HostStateTestCase(test.NoDBTestCase):
             'num_instances': '5',
             'num_proj_12345': '3',
             'num_proj_23456': '1',
-            'num_vm_%s' % vm_states.BUILDING: '2',
-            'num_vm_%s' % vm_states.SUSPENDED: '1',
-            'num_task_%s' % task_states.RESIZE_MIGRATING: '1',
-            'num_task_%s' % task_states.MIGRATING: '2',
+            'num_vm_{0!s}'.format(vm_states.BUILDING): '2',
+            'num_vm_{0!s}'.format(vm_states.SUSPENDED): '1',
+            'num_task_{0!s}'.format(task_states.RESIZE_MIGRATING): '1',
+            'num_task_{0!s}'.format(task_states.MIGRATING): '2',
             'num_os_type_linux': '4',
             'num_os_type_windoze': '1',
             'io_workload': '42',
@@ -890,10 +890,10 @@ class HostStateTestCase(test.NoDBTestCase):
             'num_instances': '5',
             'num_proj_12345': '3',
             'num_proj_23456': '1',
-            'num_vm_%s' % vm_states.BUILDING: '2',
-            'num_vm_%s' % vm_states.SUSPENDED: '1',
-            'num_task_%s' % task_states.RESIZE_MIGRATING: '1',
-            'num_task_%s' % task_states.MIGRATING: '2',
+            'num_vm_{0!s}'.format(vm_states.BUILDING): '2',
+            'num_vm_{0!s}'.format(vm_states.SUSPENDED): '1',
+            'num_task_{0!s}'.format(task_states.RESIZE_MIGRATING): '1',
+            'num_task_{0!s}'.format(task_states.MIGRATING): '2',
             'num_os_type_linux': '4',
             'num_os_type_windoze': '1',
             'io_workload': '42',
@@ -923,10 +923,10 @@ class HostStateTestCase(test.NoDBTestCase):
             'num_instances': '5',
             'num_proj_12345': '3',
             'num_proj_23456': '1',
-            'num_vm_%s' % vm_states.BUILDING: '2',
-            'num_vm_%s' % vm_states.SUSPENDED: '1',
-            'num_task_%s' % task_states.UNSHELVING: '1',
-            'num_task_%s' % task_states.RESCUING: '2',
+            'num_vm_{0!s}'.format(vm_states.BUILDING): '2',
+            'num_vm_{0!s}'.format(vm_states.SUSPENDED): '1',
+            'num_task_{0!s}'.format(task_states.UNSHELVING): '1',
+            'num_task_{0!s}'.format(task_states.RESCUING): '2',
             'num_os_type_linux': '4',
             'num_os_type_windoze': '1',
             'io_workload': '42',

--- a/nova/tests/unit/scheduler/test_ironic_host_manager.py
+++ b/nova/tests/unit/scheduler/test_ironic_host_manager.py
@@ -254,16 +254,16 @@ class IronicHostManagerTestFilters(test.NoDBTestCase):
     @mock.patch.object(host_manager.HostManager, '_init_aggregates')
     def setUp(self, mock_init_agg, mock_init_inst):
         super(IronicHostManagerTestFilters, self).setUp()
-        self.flags(scheduler_available_filters=['%s.%s' % (__name__, cls) for
+        self.flags(scheduler_available_filters=['{0!s}.{1!s}'.format(__name__, cls) for
                                                 cls in ['FakeFilterClass1',
                                                         'FakeFilterClass2']])
         self.flags(scheduler_default_filters=['FakeFilterClass1'])
         self.flags(baremetal_scheduler_default_filters=['FakeFilterClass2'])
         self.host_manager = ironic_host_manager.IronicHostManager()
         self.fake_hosts = [ironic_host_manager.IronicNodeState(
-                'fake_host%s' % x, 'fake-node') for x in range(1, 5)]
+                'fake_host{0!s}'.format(x), 'fake-node') for x in range(1, 5)]
         self.fake_hosts += [ironic_host_manager.IronicNodeState(
-                'fake_multihost', 'fake-node%s' % x) for x in range(1, 5)]
+                'fake_multihost', 'fake-node{0!s}'.format(x)) for x in range(1, 5)]
 
     def test_default_filters(self):
         default_filters = self.host_manager.default_filters

--- a/nova/tests/unit/scheduler/test_scheduler_utils.py
+++ b/nova/tests/unit/scheduler/test_scheduler_utils.py
@@ -79,7 +79,7 @@ class SchedulerUtilsTestCase(test.NoDBTestCase):
                        state='fake-vm-state',
                        method=method,
                        reason=exc_info)
-        event_type = '%s.%s' % (service, method)
+        event_type = '{0!s}.{1!s}'.format(service, method)
 
         scheduler_utils.set_vm_state_and_notify(self.context,
                                                 expected_uuid,

--- a/nova/tests/unit/test_api_validation.py
+++ b/nova/tests/unit/test_api_validation.py
@@ -105,7 +105,7 @@ class APIValidationTestCase(test.NoDBTestCase):
                 self.assertEqual(expected_detail, ex.kwargs['detail'],
                                  'Exception details did not match expected')
         except Exception as ex:
-            self.fail('An unexpected exception happens: %s' % ex)
+            self.fail('An unexpected exception happens: {0!s}'.format(ex))
         else:
             self.fail('Any exception does not happen.')
 

--- a/nova/tests/unit/test_crypto.py
+++ b/nova/tests/unit/test_crypto.py
@@ -71,7 +71,7 @@ class X509Test(test.NoDBTestCase):
                                      'rsautl',
                                      '-certin',
                                      '-encrypt',
-                                     '-inkey', '%s' % public_key,
+                                     '-inkey', '{0!s}'.format(public_key),
                                      process_input=process_input,
                                      binary=True)
 

--- a/nova/tests/unit/test_exception.py
+++ b/nova/tests/unit/test_exception.py
@@ -197,7 +197,7 @@ class ExceptionValidMessageTestCase(test.NoDBTestCase):
 
             e = obj
             if e.msg_fmt == "An unknown exception occurred.":
-                failures.append('%s needs a more specific msg_fmt' % name)
+                failures.append('{0!s} needs a more specific msg_fmt'.format(name))
 
         if failures:
             self.fail('\n'.join(failures))

--- a/nova/tests/unit/test_fixtures.py
+++ b/nova/tests/unit/test_fixtures.py
@@ -192,7 +192,7 @@ class TestDatabaseFixture(testtools.TestCase):
         conn = engine.connect()
         result = conn.execute("select * from instance_types")
         rows = result.fetchall()
-        self.assertEqual(5, len(rows), "Rows %s" % rows)
+        self.assertEqual(5, len(rows), "Rows {0!s}".format(rows))
 
         # insert a 6th instance type, column 5 below is an int id
         # which has a constraint on it, so if new standard instance
@@ -202,7 +202,7 @@ class TestDatabaseFixture(testtools.TestCase):
                      ", 1.0, 40, 0, 0, 1, 0)")
         result = conn.execute("select * from instance_types")
         rows = result.fetchall()
-        self.assertEqual(6, len(rows), "Rows %s" % rows)
+        self.assertEqual(6, len(rows), "Rows {0!s}".format(rows))
 
         # reset by invoking the fixture again
         #
@@ -213,7 +213,7 @@ class TestDatabaseFixture(testtools.TestCase):
         conn = engine.connect()
         result = conn.execute("select * from instance_types")
         rows = result.fetchall()
-        self.assertEqual(5, len(rows), "Rows %s" % rows)
+        self.assertEqual(5, len(rows), "Rows {0!s}".format(rows))
 
     def test_api_fixture_reset(self):
         # This sets up reasonable db connection strings
@@ -223,14 +223,14 @@ class TestDatabaseFixture(testtools.TestCase):
         conn = engine.connect()
         result = conn.execute("select * from cell_mappings")
         rows = result.fetchall()
-        self.assertEqual(0, len(rows), "Rows %s" % rows)
+        self.assertEqual(0, len(rows), "Rows {0!s}".format(rows))
 
         uuid = uuidutils.generate_uuid()
         conn.execute("insert into cell_mappings (uuid, name) VALUES "
                      "('%s', 'fake-cell')" % (uuid,))
         result = conn.execute("select * from cell_mappings")
         rows = result.fetchall()
-        self.assertEqual(1, len(rows), "Rows %s" % rows)
+        self.assertEqual(1, len(rows), "Rows {0!s}".format(rows))
 
         # reset by invoking the fixture again
         #
@@ -241,7 +241,7 @@ class TestDatabaseFixture(testtools.TestCase):
         conn = engine.connect()
         result = conn.execute("select * from cell_mappings")
         rows = result.fetchall()
-        self.assertEqual(0, len(rows), "Rows %s" % rows)
+        self.assertEqual(0, len(rows), "Rows {0!s}".format(rows))
 
     def test_fixture_cleanup(self):
         # because this sets up reasonable db connection strings
@@ -272,7 +272,7 @@ class TestDatabaseFixture(testtools.TestCase):
                      "('%s', 'fake-cell')" % (uuid,))
         result = conn.execute("select * from cell_mappings")
         rows = result.fetchall()
-        self.assertEqual(1, len(rows), "Rows %s" % rows)
+        self.assertEqual(1, len(rows), "Rows {0!s}".format(rows))
 
         # Manually do the cleanup that addCleanup will do
         fix.cleanup()
@@ -344,13 +344,13 @@ class TestSpawnIsSynchronousFixture(testtools.TestCase):
 
     def test_spawn_return_has_wait(self):
         self.useFixture(fixtures.SpawnIsSynchronousFixture())
-        gt = utils.spawn(lambda x: '%s' % x, 'foo')
+        gt = utils.spawn(lambda x: '{0!s}'.format(x), 'foo')
         foo = gt.wait()
         self.assertEqual('foo', foo)
 
     def test_spawn_n_return_has_wait(self):
         self.useFixture(fixtures.SpawnIsSynchronousFixture())
-        gt = utils.spawn_n(lambda x: '%s' % x, 'foo')
+        gt = utils.spawn_n(lambda x: '{0!s}'.format(x), 'foo')
         foo = gt.wait()
         self.assertEqual('foo', foo)
 

--- a/nova/tests/unit/test_flavors.py
+++ b/nova/tests/unit/test_flavors.py
@@ -184,8 +184,8 @@ class InstanceTypeToolsTest(test.TestCase):
         example_prefix = {}
 
         for key in flavors.system_metadata_flavor_props.keys():
-            example['instance_type_%s' % key] = instance_type[key]
-            example_prefix['fooinstance_type_%s' % key] = instance_type[key]
+            example['instance_type_{0!s}'.format(key)] = instance_type[key]
+            example_prefix['fooinstance_type_{0!s}'.format(key)] = instance_type[key]
 
         metadata = {}
         flavors.save_flavor_info(metadata, instance_type)

--- a/nova/tests/unit/test_hacking.py
+++ b/nova/tests/unit/test_hacking.py
@@ -255,20 +255,20 @@ class HackingTestCase(test.NoDBTestCase):
         self.assertEqual(
             0, len(list(checks.validate_log_translations(debug, debug, 'f'))))
         for log in logs:
-            bad = 'LOG.%s("Bad")' % log
+            bad = 'LOG.{0!s}("Bad")'.format(log)
             self.assertEqual(1,
                 len(list(
                     checks.validate_log_translations(bad, bad, 'f'))))
-            ok = "LOG.%s('OK')    # noqa" % log
+            ok = "LOG.{0!s}('OK')    # noqa".format(log)
             self.assertEqual(0,
                 len(list(
                     checks.validate_log_translations(ok, ok, 'f'))))
-            ok = "LOG.%s(variable)" % log
+            ok = "LOG.{0!s}(variable)".format(log)
             self.assertEqual(0,
                 len(list(
                     checks.validate_log_translations(ok, ok, 'f'))))
             for level in levels:
-                ok = "LOG.%s(%s('OK'))" % (log, level)
+                ok = "LOG.{0!s}({1!s}('OK'))".format(log, level)
                 self.assertEqual(0,
                     len(list(
                         checks.validate_log_translations(ok, ok, 'f'))))
@@ -321,13 +321,13 @@ class HackingTestCase(test.NoDBTestCase):
         for method in ('dump', 'dumps', 'load', 'loads'):
             self.assertEqual(
                 __get_msg(method),
-                list(checks.use_jsonutils("json.%s(" % method,
+                list(checks.use_jsonutils("json.{0!s}(".format(method),
                                      "./nova/virt/xenapi/driver.py")))
             self.assertEqual(0,
-                len(list(checks.use_jsonutils("json.%s(" % method,
+                len(list(checks.use_jsonutils("json.{0!s}(".format(method),
                                      "./plugins/xenserver/script.py"))))
             self.assertEqual(0,
-                len(list(checks.use_jsonutils("jsonx.%s(" % method,
+                len(list(checks.use_jsonutils("jsonx.{0!s}(".format(method),
                                      "./nova/virt/xenapi/driver.py"))))
         self.assertEqual(0,
             len(list(checks.use_jsonutils("json.dumb",

--- a/nova/tests/unit/test_iptables_network.py
+++ b/nova/tests/unit/test_iptables_network.py
@@ -32,17 +32,17 @@ class IptablesManagerTestCase(test.NoDBTestCase):
                      ':OUTPUT ACCEPT [2172501:140856656]',
                      ':iptables-top-rule - [0:0]',
                      ':iptables-bottom-rule - [0:0]',
-                     ':%s-FORWARD - [0:0]' % (binary_name),
-                     ':%s-INPUT - [0:0]' % (binary_name),
-                     ':%s-OUTPUT - [0:0]' % (binary_name),
-                     ':%s-local - [0:0]' % (binary_name),
+                     ':{0!s}-FORWARD - [0:0]'.format((binary_name)),
+                     ':{0!s}-INPUT - [0:0]'.format((binary_name)),
+                     ':{0!s}-OUTPUT - [0:0]'.format((binary_name)),
+                     ':{0!s}-local - [0:0]'.format((binary_name)),
                      ':nova-filter-top - [0:0]',
                      '[0:0] -A FORWARD -j nova-filter-top',
                      '[0:0] -A OUTPUT -j nova-filter-top',
-                     '[0:0] -A nova-filter-top -j %s-local' % (binary_name),
-                     '[0:0] -A INPUT -j %s-INPUT' % (binary_name),
-                     '[0:0] -A OUTPUT -j %s-OUTPUT' % (binary_name),
-                     '[0:0] -A FORWARD -j %s-FORWARD' % (binary_name),
+                     '[0:0] -A nova-filter-top -j {0!s}-local'.format((binary_name)),
+                     '[0:0] -A INPUT -j {0!s}-INPUT'.format((binary_name)),
+                     '[0:0] -A OUTPUT -j {0!s}-OUTPUT'.format((binary_name)),
+                     '[0:0] -A FORWARD -j {0!s}-FORWARD'.format((binary_name)),
                      '[0:0] -A INPUT -i virbr0 -p udp -m udp --dport 53 '
                      '-j ACCEPT',
                      '[0:0] -A INPUT -i virbr0 -p tcp -m tcp --dport 53 '
@@ -67,15 +67,15 @@ class IptablesManagerTestCase(test.NoDBTestCase):
                   ':INPUT ACCEPT [2447:225266]',
                   ':OUTPUT ACCEPT [63491:4191863]',
                   ':POSTROUTING ACCEPT [63112:4108641]',
-                  ':%s-OUTPUT - [0:0]' % (binary_name),
-                  ':%s-POSTROUTING - [0:0]' % (binary_name),
-                  ':%s-PREROUTING - [0:0]' % (binary_name),
-                  ':%s-float-snat - [0:0]' % (binary_name),
-                  ':%s-snat - [0:0]' % (binary_name),
+                  ':{0!s}-OUTPUT - [0:0]'.format((binary_name)),
+                  ':{0!s}-POSTROUTING - [0:0]'.format((binary_name)),
+                  ':{0!s}-PREROUTING - [0:0]'.format((binary_name)),
+                  ':{0!s}-float-snat - [0:0]'.format((binary_name)),
+                  ':{0!s}-snat - [0:0]'.format((binary_name)),
                   ':nova-postrouting-bottom - [0:0]',
-                  '[0:0] -A PREROUTING -j %s-PREROUTING' % (binary_name),
-                  '[0:0] -A OUTPUT -j %s-OUTPUT' % (binary_name),
-                  '[0:0] -A POSTROUTING -j %s-POSTROUTING' % (binary_name),
+                  '[0:0] -A PREROUTING -j {0!s}-PREROUTING'.format((binary_name)),
+                  '[0:0] -A OUTPUT -j {0!s}-OUTPUT'.format((binary_name)),
+                  '[0:0] -A POSTROUTING -j {0!s}-POSTROUTING'.format((binary_name)),
                   '[0:0] -A nova-postrouting-bottom '
                   '-j %s-snat' % (binary_name),
                   '[0:0] -A %s-snat '
@@ -160,18 +160,18 @@ class IptablesManagerTestCase(test.NoDBTestCase):
                                                self.manager.ipv4['nat'],
                                                'nat')
 
-        for line in [':%s-OUTPUT - [0:0]' % (self.binary_name),
-                     ':%s-float-snat - [0:0]' % (self.binary_name),
-                     ':%s-snat - [0:0]' % (self.binary_name),
-                     ':%s-PREROUTING - [0:0]' % (self.binary_name),
-                     ':%s-POSTROUTING - [0:0]' % (self.binary_name)]:
+        for line in [':{0!s}-OUTPUT - [0:0]'.format((self.binary_name)),
+                     ':{0!s}-float-snat - [0:0]'.format((self.binary_name)),
+                     ':{0!s}-snat - [0:0]'.format((self.binary_name)),
+                     ':{0!s}-PREROUTING - [0:0]'.format((self.binary_name)),
+                     ':{0!s}-POSTROUTING - [0:0]'.format((self.binary_name))]:
             self.assertIn(line, new_lines, "One of our chains went"
                                                " missing.")
 
         seen_lines = set()
         for line in new_lines:
             line = line.strip()
-            self.assertNotIn(line, seen_lines, "Duplicate line: %s" % line)
+            self.assertNotIn(line, seen_lines, "Duplicate line: {0!s}".format(line))
             seen_lines.add(line)
 
         last_postrouting_line = ''
@@ -185,9 +185,8 @@ class IptablesManagerTestCase(test.NoDBTestCase):
                         "nova-postouting-bottom: %s" % last_postrouting_line)
 
         for chain in ['POSTROUTING', 'PREROUTING', 'OUTPUT']:
-            self.assertTrue('[0:0] -A %s -j %s-%s' %
-                            (chain, self.binary_name, chain) in new_lines,
-                            "Built-in chain %s not wrapped" % (chain,))
+            self.assertTrue('[0:0] -A {0!s} -j {1!s}-{2!s}'.format(chain, self.binary_name, chain) in new_lines,
+                            "Built-in chain {0!s} not wrapped".format(chain))
 
     def test_filter_rules(self):
         current_lines = self.sample_filter
@@ -195,22 +194,22 @@ class IptablesManagerTestCase(test.NoDBTestCase):
                                                self.manager.ipv4['filter'],
                                                'nat')
 
-        for line in [':%s-FORWARD - [0:0]' % (self.binary_name),
-                     ':%s-INPUT - [0:0]' % (self.binary_name),
-                     ':%s-local - [0:0]' % (self.binary_name),
-                     ':%s-OUTPUT - [0:0]' % (self.binary_name)]:
+        for line in [':{0!s}-FORWARD - [0:0]'.format((self.binary_name)),
+                     ':{0!s}-INPUT - [0:0]'.format((self.binary_name)),
+                     ':{0!s}-local - [0:0]'.format((self.binary_name)),
+                     ':{0!s}-OUTPUT - [0:0]'.format((self.binary_name))]:
             self.assertIn(line, new_lines, "One of our chains went"
                                                " missing.")
 
         seen_lines = set()
         for line in new_lines:
             line = line.strip()
-            self.assertNotIn(line, seen_lines, "Duplicate line: %s" % line)
+            self.assertNotIn(line, seen_lines, "Duplicate line: {0!s}".format(line))
             seen_lines.add(line)
 
         for chain in ['FORWARD', 'OUTPUT']:
             for line in new_lines:
-                if line.startswith('[0:0] -A %s' % chain):
+                if line.startswith('[0:0] -A {0!s}'.format(chain)):
                     self.assertIn('-j nova-filter-top', line,
                                   "First %s rule does not "
                                   "jump to nova-filter-top" % chain)
@@ -221,9 +220,8 @@ class IptablesManagerTestCase(test.NoDBTestCase):
                         "nova-filter-top does not jump to wrapped local chain")
 
         for chain in ['INPUT', 'OUTPUT', 'FORWARD']:
-            self.assertTrue('[0:0] -A %s -j %s-%s' %
-                            (chain, self.binary_name, chain) in new_lines,
-                            "Built-in chain %s not wrapped" % (chain,))
+            self.assertTrue('[0:0] -A {0!s} -j {1!s}-{2!s}'.format(chain, self.binary_name, chain) in new_lines,
+                            "Built-in chain {0!s} not wrapped".format(chain))
 
     def test_missing_table(self):
         current_lines = []

--- a/nova/tests/unit/test_metadata.py
+++ b/nova/tests/unit/test_metadata.py
@@ -205,7 +205,7 @@ class MetadataTestCase(test.TestCase):
         md = fake_InstanceMetadata(self.stubs, self.instance.obj_clone())
         data = md.get_ec2_metadata(version='2009-04-04')
         self.assertEqual(data['meta-data']['local-hostname'],
-            "%s.%s" % (self.instance['hostname'], CONF.dhcp_domain))
+            "{0!s}.{1!s}".format(self.instance['hostname'], CONF.dhcp_domain))
 
     def test_format_instance_mapping(self):
         # Make sure that _format_instance_mappings works.
@@ -269,7 +269,7 @@ class MetadataTestCase(test.TestCase):
         pubkey_ent = md.lookup("/2009-04-04/meta-data/public-keys")
 
         self.assertEqual(base.ec2_md_print(pubkey_ent),
-            "0=%s" % self.instance['key_name'])
+            "0={0!s}".format(self.instance['key_name']))
         self.assertEqual(base.ec2_md_print(pubkey_ent['0']['openssh-key']),
             self.instance['key_data'])
 
@@ -548,7 +548,7 @@ class OpenStackMetadataTestCase(test.TestCase):
             fent = [f for f in mddict['files'] if f['path'] == path]
             self.assertEqual(1, len(fent))
             fent = fent[0]
-            found = mdinst.lookup("/openstack%s" % fent['content_path'])
+            found = mdinst.lookup("/openstack{0!s}".format(fent['content_path']))
             self.assertEqual(found, content)
 
     def test_x509_keypair(self):
@@ -820,8 +820,7 @@ class MetadataHandlerTestCase(test.TestCase):
             if address == expected_addr:
                 return self.mdinst
             else:
-                raise Exception("Expected addr of %s, got %s" %
-                                (expected_addr, address))
+                raise Exception("Expected addr of {0!s}, got {1!s}".format(expected_addr, address))
 
         self.flags(use_forwarded_for=True)
         response = fake_request(self.stubs, self.mdinst,
@@ -866,8 +865,7 @@ class MetadataHandlerTestCase(test.TestCase):
             return self.mdinst
         else:
             # raise the exception to aid with 500 response code test
-            raise Exception("Expected instance_id of %s, got %s" %
-                            (self.expected_instance_id, instance_id))
+            raise Exception("Expected instance_id of {0!s}, got {1!s}".format(self.expected_instance_id, instance_id))
 
     def test_user_data_with_neutron_instance_id(self):
         self.expected_instance_id = 'a-b-c-d'

--- a/nova/tests/unit/test_nova_manage.py
+++ b/nova/tests/unit/test_nova_manage.py
@@ -95,17 +95,17 @@ class FloatingIpCommandsTestCase(test.NoDBTestCase):
         self.assertRaises(exception.InvalidInput, address_to_hosts,
                           '192.168.100.1/31')
         # /30
-        expected = ["192.168.100.%s" % i for i in range(1, 3)]
+        expected = ["192.168.100.{0!s}".format(i) for i in range(1, 3)]
         result = address_to_hosts('192.168.100.0/30')
         self.assertEqual(2, len(list(result)))
         assert_loop(result, expected)
         # /29
-        expected = ["192.168.100.%s" % i for i in range(1, 7)]
+        expected = ["192.168.100.{0!s}".format(i) for i in range(1, 7)]
         result = address_to_hosts('192.168.100.0/29')
         self.assertEqual(6, len(list(result)))
         assert_loop(result, expected)
         # /28
-        expected = ["192.168.100.%s" % i for i in range(1, 15)]
+        expected = ["192.168.100.{0!s}".format(i) for i in range(1, 15)]
         result = address_to_hosts('192.168.100.0/28')
         self.assertEqual(14, len(list(result)))
         assert_loop(result, expected)
@@ -239,7 +239,7 @@ class NetworkCommandsTestCase(test.NoDBTestCase):
                        'vlan': self.net['vlan'],
                        'project_id': self.net['project_id'],
                        'uuid': self.net['uuid']}
-        answer = '%s\n%s\n' % (head, body)
+        answer = '{0!s}\n{1!s}\n'.format(head, body)
         self.assertEqual(result, answer)
 
     def test_delete(self):
@@ -326,7 +326,7 @@ class ProjectCommandsTestCase(test.TestCase):
 
         sys.stdout = sys.__stdout__
         result = output.getvalue()
-        print_format = "%-36s %-10s" % ('instances', 'unlimited')
+        print_format = "{0:<36!s} {1:<10!s}".format('instances', 'unlimited')
         self.assertIn(print_format, result)
 
     def test_quota_update_invalid_key(self):
@@ -704,7 +704,7 @@ class CellV2CommandsTestCase(test.TestCase):
                 'cpu_info': 'Schmintel i786',
             }
         for i in range(3):
-            host = 'host%s' % i
+            host = 'host{0!s}'.format(i)
             compute_node = objects.ComputeNode(ctxt, host=host, **values)
             compute_node.create()
         cell_transport_url = "fake://guest:devstack@127.0.0.1:9999/"
@@ -717,7 +717,7 @@ class CellV2CommandsTestCase(test.TestCase):
         self.assertEqual(cell_transport_url, cell_mapping.transport_url)
         # Verify the host mappings
         for i in range(3):
-            host = 'host%s' % i
+            host = 'host{0!s}'.format(i)
             host_mapping = objects.HostMapping.get_by_host(ctxt, host)
             self.assertEqual(cell_mapping.uuid, host_mapping.cell_mapping.uuid)
 
@@ -742,7 +742,7 @@ class CellV2CommandsTestCase(test.TestCase):
                 'cpu_info': 'Schmintel i786',
             }
         for i in range(3):
-            host = 'host%s' % i
+            host = 'host{0!s}'.format(i)
             compute_node = objects.ComputeNode(ctxt, host=host, **values)
             compute_node.create()
             host_mapping = objects.HostMapping(
@@ -756,8 +756,7 @@ class CellV2CommandsTestCase(test.TestCase):
         output = sys.stdout.getvalue().strip()
         expected = ''
         for i in range(3):
-            expected += ('Host host%s is already mapped to cell %s\n' %
-                         (i, cell_mapping_uuid))
+            expected += ('Host host{0!s} is already mapped to cell {1!s}\n'.format(i, cell_mapping_uuid))
         expected += 'All hosts are already mapped to cell(s), exiting.'
         self.assertEqual(expected, output)
 
@@ -783,12 +782,12 @@ class CellV2CommandsTestCase(test.TestCase):
                 'cpu_info': 'Schmintel i786',
             }
         for i in range(3):
-            host = 'host%s' % i
+            host = 'host{0!s}'.format(i)
             compute_node = objects.ComputeNode(ctxt, host=host, **values)
             compute_node.create()
         # Only create 2 existing HostMappings out of 3
         for i in range(2):
-            host = 'host%s' % i
+            host = 'host{0!s}'.format(i)
             host_mapping = objects.HostMapping(
                     ctxt, host=host, cell_mapping=cell_mapping)
             host_mapping.create()
@@ -803,8 +802,7 @@ class CellV2CommandsTestCase(test.TestCase):
         output = sys.stdout.getvalue().strip()
         expected = ''
         for i in range(2):
-            expected += ('Host host%s is already mapped to cell %s\n' %
-                         (i, cell_mapping_uuid))
+            expected += ('Host host{0!s} is already mapped to cell {1!s}\n'.format(i, cell_mapping_uuid))
         # The expected CellMapping UUID for the last host should be the same
         expected += cell_mapping.uuid
         self.assertEqual(expected, output)

--- a/nova/tests/unit/test_pipelib.py
+++ b/nova/tests/unit/test_pipelib.py
@@ -50,7 +50,7 @@ class PipelibTest(test.TestCase):
             self.cloudpipe.launch_vpn_instance(self.context)
 
     def test_setup_security_group(self):
-        group_name = "%s%s" % (self.project, CONF.vpn_key_suffix)
+        group_name = "{0!s}{1!s}".format(self.project, CONF.vpn_key_suffix)
 
         # First attempt, does not exist (thus its created)
         res1_group = self.cloudpipe.setup_security_group(self.context)
@@ -61,7 +61,7 @@ class PipelibTest(test.TestCase):
         self.assertEqual(res1_group, res2_group)
 
     def test_setup_key_pair(self):
-        key_name = "%s%s" % (self.project, CONF.vpn_key_suffix)
+        key_name = "{0!s}{1!s}".format(self.project, CONF.vpn_key_suffix)
         with utils.tempdir() as tmpdir:
             self.flags(keys_path=tmpdir)
 

--- a/nova/tests/unit/test_quota.py
+++ b/nova/tests/unit/test_quota.py
@@ -152,7 +152,7 @@ class QuotaIntegrationTestCase(test.TestCase):
     def test_too_many_metadata_items(self):
         metadata = {}
         for i in range(CONF.quota_metadata_items + 1):
-            metadata['key%s' % i] = 'value%s' % i
+            metadata['key{0!s}'.format(i)] = 'value{0!s}'.format(i)
         inst_type = flavors.get_flavor_by_name('m1.small')
         image_uuid = 'cedef40a-ed67-4d10-800e-17455edce175'
         self.assertRaises(exception.QuotaError, self.compute_api.create,
@@ -182,13 +182,13 @@ class QuotaIntegrationTestCase(test.TestCase):
     def test_max_injected_files(self):
         files = []
         for i in range(CONF.quota_injected_files):
-            files.append(('/my/path%d' % i, 'config = test\n'))
+            files.append(('/my/path{0:d}'.format(i), 'config = test\n'))
         self._create_with_injected_files(files)  # no QuotaError
 
     def test_too_many_injected_files(self):
         files = []
         for i in range(CONF.quota_injected_files + 1):
-            files.append(('/my/path%d' % i, 'my\ncontent%d\n' % i))
+            files.append(('/my/path{0:d}'.format(i), 'my\ncontent{0:d}\n'.format(i)))
         self.assertRaises(exception.QuotaError,
                           self._create_with_injected_files, files)
 
@@ -2410,9 +2410,9 @@ class QuotaReserveSqlAlchemyTestCase(test.TestCase):
         self.addCleanup(restore_sync_functions)
 
         for res_name in ('instances', 'cores', 'ram', 'fixed_ips'):
-            method_name = '_sync_%s' % res_name
+            method_name = '_sync_{0!s}'.format(res_name)
             sqa_api.QUOTA_SYNC_FUNCTIONS[method_name] = make_sync(res_name)
-            res = quota.ReservableResource(res_name, '_sync_%s' % res_name)
+            res = quota.ReservableResource(res_name, '_sync_{0!s}'.format(res_name))
             self.resources[res_name] = res
 
         self.expire = timeutils.utcnow() + datetime.timedelta(seconds=3600)
@@ -2519,8 +2519,7 @@ class QuotaReserveSqlAlchemyTestCase(test.TestCase):
             for key, value in usage.items():
                 actual = getattr(usage_dict[resource], key)
                 self.assertEqual(actual, value,
-                                 "%s != %s on usage for resource %s" %
-                                 (actual, value, resource))
+                                 "{0!s} != {1!s} on usage for resource {2!s}".format(actual, value, resource))
 
     def _make_reservation(self, uuid, usage_id, project_id, user_id, resource,
                           delta, expire, created_at, updated_at):
@@ -2552,8 +2551,7 @@ class QuotaReserveSqlAlchemyTestCase(test.TestCase):
             for key, value in resv.items():
                 actual = getattr(resv_obj, key)
                 self.assertEqual(actual, value,
-                                 "%s != %s on reservation for resource %s" %
-                                 (actual, value, resource))
+                                 "{0!s} != {1!s} on reservation for resource {2!s}".format(actual, value, resource))
 
         self.assertEqual(len(reservations), 0)
 

--- a/nova/tests/unit/test_signature_utils.py
+++ b/nova/tests/unit/test_signature_utils.py
@@ -136,7 +136,7 @@ class TestSignatureUtils(test.NoDBTestCase):
                 signature_utils.SignatureKeyType.lookup(key_type_name)
             except exception.SignatureVerificationError:
                 import warnings
-                warnings.warn("ECC curve '%s' not supported" % curve.name)
+                warnings.warn("ECC curve '{0!s}' not supported".format(curve.name))
                 continue
 
             # Create a private key to use

--- a/nova/tests/unit/test_utils.py
+++ b/nova/tests/unit/test_utils.py
@@ -1024,7 +1024,7 @@ class GetSystemMetadataFromImageTestCase(test.NoDBTestCase):
         # Verify that we inherit all the needed keys
         sys_meta = utils.get_system_metadata_from_image(image)
         for key in utils.SM_INHERITABLE_KEYS:
-            sys_key = "%s%s" % (utils.SM_IMAGE_PROP_PREFIX, key)
+            sys_key = "{0!s}{1!s}".format(utils.SM_IMAGE_PROP_PREFIX, key)
             self.assertEqual(image[key], sys_meta.get(sys_key))
 
         # Verify that everything else is ignored
@@ -1038,7 +1038,7 @@ class GetSystemMetadataFromImageTestCase(test.NoDBTestCase):
 
         # Verify that we inherit all the image properties
         for key, expected in six.iteritems(image["properties"]):
-            sys_key = "%s%s" % (utils.SM_IMAGE_PROP_PREFIX, key)
+            sys_key = "{0!s}{1!s}".format(utils.SM_IMAGE_PROP_PREFIX, key)
             self.assertEqual(sys_meta[sys_key], expected)
 
     def test_skip_image_properties(self):
@@ -1052,7 +1052,7 @@ class GetSystemMetadataFromImageTestCase(test.NoDBTestCase):
 
         # Verify that we inherit all the image properties
         for key, expected in six.iteritems(image["properties"]):
-            sys_key = "%s%s" % (utils.SM_IMAGE_PROP_PREFIX, key)
+            sys_key = "{0!s}{1!s}".format(utils.SM_IMAGE_PROP_PREFIX, key)
 
             if key in utils.SM_SKIP_KEYS:
                 self.assertNotIn(sys_key, sys_meta)
@@ -1069,7 +1069,7 @@ class GetSystemMetadataFromImageTestCase(test.NoDBTestCase):
 
         # Verify that the min_disk property is taken from
         # flavor's root_gb when using vhd disk format
-        sys_key = "%s%s" % (utils.SM_IMAGE_PROP_PREFIX, "min_disk")
+        sys_key = "{0!s}{1!s}".format(utils.SM_IMAGE_PROP_PREFIX, "min_disk")
         self.assertEqual(sys_meta[sys_key], flavor["root_gb"])
 
     def test_dont_inherit_empty_values(self):
@@ -1082,7 +1082,7 @@ class GetSystemMetadataFromImageTestCase(test.NoDBTestCase):
 
         # Verify that the empty properties have not been inherited
         for key in utils.SM_INHERITABLE_KEYS:
-            sys_key = "%s%s" % (utils.SM_IMAGE_PROP_PREFIX, key)
+            sys_key = "{0!s}{1!s}".format(utils.SM_IMAGE_PROP_PREFIX, key)
             self.assertNotIn(sys_key, sys_meta)
 
 
@@ -1099,23 +1099,23 @@ class GetImageFromSystemMetadataTestCase(test.NoDBTestCase):
 
     def test_image_from_system_metadata(self):
         sys_meta = self.get_system_metadata()
-        sys_meta["%soo1" % utils.SM_IMAGE_PROP_PREFIX] = "bar"
-        sys_meta["%soo2" % utils.SM_IMAGE_PROP_PREFIX] = "baz"
-        sys_meta["%simg_block_device_mapping" %
-                 utils.SM_IMAGE_PROP_PREFIX] = "eek"
+        sys_meta["{0!s}oo1".format(utils.SM_IMAGE_PROP_PREFIX)] = "bar"
+        sys_meta["{0!s}oo2".format(utils.SM_IMAGE_PROP_PREFIX)] = "baz"
+        sys_meta["{0!s}img_block_device_mapping".format(
+                 utils.SM_IMAGE_PROP_PREFIX)] = "eek"
 
         image = utils.get_image_from_system_metadata(sys_meta)
 
         # Verify that we inherit all the needed keys
         for key in utils.SM_INHERITABLE_KEYS:
-            sys_key = "%s%s" % (utils.SM_IMAGE_PROP_PREFIX, key)
+            sys_key = "{0!s}{1!s}".format(utils.SM_IMAGE_PROP_PREFIX, key)
             self.assertEqual(image[key], sys_meta.get(sys_key))
 
         # Verify that we inherit the rest of metadata as properties
         self.assertIn("properties", image)
 
         for key, value in six.iteritems(image["properties"]):
-            sys_key = "%s%s" % (utils.SM_IMAGE_PROP_PREFIX, key)
+            sys_key = "{0!s}{1!s}".format(utils.SM_IMAGE_PROP_PREFIX, key)
             self.assertEqual(image["properties"][key], sys_meta[sys_key])
 
         self.assertNotIn("img_block_device_mapping", image["properties"])
@@ -1124,7 +1124,7 @@ class GetImageFromSystemMetadataTestCase(test.NoDBTestCase):
         sys_meta = self.get_system_metadata()
 
         for key in utils.SM_INHERITABLE_KEYS:
-            sys_key = "%s%s" % (utils.SM_IMAGE_PROP_PREFIX, key)
+            sys_key = "{0!s}{1!s}".format(utils.SM_IMAGE_PROP_PREFIX, key)
             sys_meta[sys_key] = None
 
         image = utils.get_image_from_system_metadata(sys_meta)

--- a/nova/tests/unit/test_wsgi.py
+++ b/nova/tests/unit/test_wsgi.py
@@ -165,13 +165,13 @@ class TestWSGIServer(test.NoDBTestCase):
             host="127.0.0.1", max_url_len=16384)
         server.start()
 
-        uri = "http://127.0.0.1:%d/%s" % (server.port, 10000 * 'x')
+        uri = "http://127.0.0.1:{0:d}/{1!s}".format(server.port, 10000 * 'x')
         resp = requests.get(uri, proxies={"http": ""})
         eventlet.sleep(0)
         self.assertNotEqual(resp.status_code,
                             requests.codes.REQUEST_URI_TOO_LARGE)
 
-        uri = "http://127.0.0.1:%d/%s" % (server.port, 20000 * 'x')
+        uri = "http://127.0.0.1:{0:d}/{1!s}".format(server.port, 20000 * 'x')
         resp = requests.get(uri, proxies={"http": ""})
         eventlet.sleep(0)
         self.assertEqual(resp.status_code,
@@ -248,7 +248,7 @@ class TestWSGIServerWithSSL(test.NoDBTestCase):
         self.assertNotEqual(0, fake_ssl_server.port)
 
         response = requests.post(
-            'https://127.0.0.1:%s/' % fake_ssl_server.port,
+            'https://127.0.0.1:{0!s}/'.format(fake_ssl_server.port),
             verify=os.path.join(SSL_CERT_DIR, 'ca.crt'), data='PING')
         self.assertEqual(response.text, 'PONG')
 
@@ -272,11 +272,11 @@ class TestWSGIServerWithSSL(test.NoDBTestCase):
         self.assertNotEqual(0, fake_server.port)
 
         response = requests.post(
-            'https://127.0.0.1:%s/' % fake_ssl_server.port,
+            'https://127.0.0.1:{0!s}/'.format(fake_ssl_server.port),
             verify=os.path.join(SSL_CERT_DIR, 'ca.crt'), data='PING')
         self.assertEqual(response.text, 'PONG')
 
-        response = requests.post('http://127.0.0.1:%s/' % fake_server.port,
+        response = requests.post('http://127.0.0.1:{0!s}/'.format(fake_server.port),
                                  data='PING')
         self.assertEqual(response.text, 'PONG')
 
@@ -323,7 +323,7 @@ class TestWSGIServerWithSSL(test.NoDBTestCase):
 
         server.start()
 
-        response = requests.get('https://[::1]:%d/' % server.port,
+        response = requests.get('https://[::1]:{0:d}/'.format(server.port),
                                 verify=os.path.join(SSL_CERT_DIR, 'ca.crt'))
         self.assertEqual(greetings, response.text)
 

--- a/nova/tests/unit/virt/disk/mount/test_api.py
+++ b/nova/tests/unit/virt/disk/mount/test_api.py
@@ -53,10 +53,10 @@ class MountTestCase(test.NoDBTestCase):
                 if isinstance(v, list):
                     if len(v) > 0:
                         return v.pop(0)
-                    self.fail("Out of items for: %s" % filename)
+                    self.fail("Out of items for: {0!s}".format(filename))
                 return v
             except KeyError:
-                self.fail("Unexpected call with: %s" % filename)
+                self.fail("Unexpected call with: {0!s}".format(filename))
         return exists_effect
 
     def _check_calls(self, exists, filenames):

--- a/nova/tests/unit/virt/disk/vfs/fakeguestfs.py
+++ b/nova/tests/unit/virt/disk/vfs/fakeguestfs.py
@@ -85,7 +85,7 @@ class GuestFS(object):
         else:
             if not self.root_mounted:
                 raise RuntimeError(
-                    "mount: %s: No such file or directory" % mntpoint)
+                    "mount: {0!s}: No such file or directory".format(mntpoint))
         self.mounts.append((options, device, mntpoint))
 
     def mkdir_p(self, path):

--- a/nova/tests/unit/virt/hyperv/test_hostops.py
+++ b/nova/tests/unit/virt/hyperv/test_hostops.py
@@ -177,7 +177,7 @@ class HostOpsTestCase(test_base.HyperVBaseTestCase):
 
         response = self._hostops.get_host_uptime()
         tdelta = datetime.timedelta(milliseconds=int(self.FAKE_TICK_COUNT))
-        expected = "%s up %s,  0 users,  load average: 0, 0, 0" % (
+        expected = "{0!s} up {1!s},  0 users,  load average: 0, 0, 0".format(
                    str(mock_time()), str(tdelta))
 
         self.assertEqual(expected, response)

--- a/nova/tests/unit/virt/hyperv/test_imagecache.py
+++ b/nova/tests/unit/virt/hyperv/test_imagecache.py
@@ -109,7 +109,7 @@ class ImageCacheTestCase(test_base.HyperVBaseTestCase):
 
         expected_path = os.path.join(self.FAKE_BASE_DIR,
                                      self.FAKE_IMAGE_REF)
-        expected_vhd_path = "%s.%s" % (expected_path,
+        expected_vhd_path = "{0!s}.{1!s}".format(expected_path,
                                        constants.DISK_FORMAT_VHD.lower())
         return (expected_path, expected_vhd_path)
 

--- a/nova/tests/unit/virt/hyperv/test_migrationops.py
+++ b/nova/tests/unit/virt/hyperv/test_migrationops.py
@@ -69,7 +69,7 @@ class MigrationOpsTestCase(test_base.HyperVBaseTestCase):
         get_revert_dir.assert_called_with(mock.sentinel.instance_name,
                                           remove_dir=True, create_dir=True)
         if host == mock.sentinel.dest_path:
-            fake_dest_path = '%s_tmp' % instance_path
+            fake_dest_path = '{0!s}_tmp'.format(instance_path)
             self._migrationops._pathutils.exists.assert_called_once_with(
                 fake_dest_path)
             self._migrationops._pathutils.rmtree.assert_called_once_with(
@@ -100,7 +100,7 @@ class MigrationOpsTestCase(test_base.HyperVBaseTestCase):
                        '_cleanup_failed_disk_migration')
     def test_migrate_disk_files_exception(self, mock_cleanup):
         instance_path = 'fake/instance/path'
-        fake_dest_path = '%s_tmp' % instance_path
+        fake_dest_path = '{0!s}_tmp'.format(instance_path)
         self._migrationops._pathutils.get_instance_dir.return_value = (
             instance_path)
         get_revert_dir = (

--- a/nova/tests/unit/virt/hyperv/test_vmops.py
+++ b/nova/tests/unit/virt/hyperv/test_vmops.py
@@ -941,7 +941,7 @@ class VMOpsTestCase(test_base.HyperVBaseTestCase):
                                          fake_instance_uuid)
 
         if not (worker_exists and worker_running):
-            expected_pipe_path = r'\\.\pipe\%s' % fake_instance_uuid
+            expected_pipe_path = r'\\.\pipe\{0!s}'.format(fake_instance_uuid)
             expected_current_worker = mock_io_thread.return_value
             expected_current_worker.start.assert_called_once_with()
             mock_io_thread.assert_called_once_with(
@@ -995,7 +995,7 @@ class VMOpsTestCase(test_base.HyperVBaseTestCase):
         self._vmops.log_vm_serial_output(mock.sentinel.FAKE_VM_NAME,
                                          self.FAKE_UUID)
 
-        pipe_path = r'\\.\pipe\%s' % self.FAKE_UUID
+        pipe_path = r'\\.\pipe\{0!s}'.format(self.FAKE_UUID)
         fake_iothread.assert_called_once_with(
             pipe_path, mock.sentinel.FAKE_PATH,
             self._vmops._MAX_CONSOLE_LOG_FILE_SIZE)
@@ -1051,7 +1051,7 @@ class VMOpsTestCase(test_base.HyperVBaseTestCase):
 
     def test_create_vm_com_port_pipe(self):
         mock_instance = fake_instance.fake_instance_obj(self.context)
-        pipe_path = r'\\.\pipe\%s' % mock_instance['uuid']
+        pipe_path = r'\\.\pipe\{0!s}'.format(mock_instance['uuid'])
 
         self._vmops._create_vm_com_port_pipe(mock_instance)
 

--- a/nova/tests/unit/virt/hyperv/test_volumeops.py
+++ b/nova/tests/unit/virt/hyperv/test_volumeops.py
@@ -465,7 +465,7 @@ class SMBFSVolumeDriverTestCase(test_base.HyperVBaseTestCase):
     _FAKE_DISK_NAME = 'fake_volume_name.vhdx'
     _FAKE_USERNAME = 'fake_username'
     _FAKE_PASSWORD = 'fake_password'
-    _FAKE_SMB_OPTIONS = '-o username=%s,password=%s' % (_FAKE_USERNAME,
+    _FAKE_SMB_OPTIONS = '-o username={0!s},password={1!s}'.format(_FAKE_USERNAME,
                                                         _FAKE_PASSWORD)
     _FAKE_CONNECTION_INFO = {'data': {'export': _FAKE_SHARE,
                                       'name': _FAKE_DISK_NAME,

--- a/nova/tests/unit/virt/libvirt/fakelibvirt.py
+++ b/nova/tests/unit/virt/libvirt/fakelibvirt.py
@@ -632,30 +632,30 @@ class Domain(object):
     def XMLDesc(self, flags):
         disks = ''
         for disk in self._def['devices']['disks']:
-            disks += '''<disk type='%(type)s' device='%(device)s'>
-      <driver name='%(driver_name)s' type='%(driver_type)s'/>
-      <source file='%(source)s'/>
-      <target dev='%(target_dev)s' bus='%(target_bus)s'/>
+            disks += '''<disk type='{type!s}' device='{device!s}'>
+      <driver name='{driver_name!s}' type='{driver_type!s}'/>
+      <source file='{source!s}'/>
+      <target dev='{target_dev!s}' bus='{target_bus!s}'/>
       <address type='drive' controller='0' bus='0' unit='0'/>
-    </disk>''' % disk
+    </disk>'''.format(**disk)
 
         nics = ''
         for nic in self._def['devices']['nics']:
-            nics += '''<interface type='%(type)s'>
-      <mac address='%(mac)s'/>
-      <source %(type)s='%(source)s'/>
+            nics += '''<interface type='{type!s}'>
+      <mac address='{mac!s}'/>
+      <source {type!s}='{source!s}'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x03'
                function='0x0'/>
-    </interface>''' % nic
+    </interface>'''.format(**nic)
 
         return '''<domain type='kvm'>
-  <name>%(name)s</name>
-  <uuid>%(uuid)s</uuid>
-  <memory>%(memory)s</memory>
-  <currentMemory>%(memory)s</currentMemory>
-  <vcpu>%(vcpu)s</vcpu>
+  <name>{name!s}</name>
+  <uuid>{uuid!s}</uuid>
+  <memory>{memory!s}</memory>
+  <currentMemory>{memory!s}</currentMemory>
+  <vcpu>{vcpu!s}</vcpu>
   <os>
-    <type arch='%(arch)s' machine='pc-0.12'>hvm</type>
+    <type arch='{arch!s}' machine='pc-0.12'>hvm</type>
     <boot dev='hd'/>
   </os>
   <features>
@@ -669,12 +669,12 @@ class Domain(object):
   <on_crash>restart</on_crash>
   <devices>
     <emulator>/usr/bin/kvm</emulator>
-    %(disks)s
+    {disks!s}
     <controller type='ide' index='0'>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x01'
                function='0x1'/>
     </controller>
-    %(nics)s
+    {nics!s}
     <serial type='file'>
       <source path='dummy.log'/>
       <target port='0'/>
@@ -704,13 +704,13 @@ class Domain(object):
                function='0x0'/>
     </memballoon>
   </devices>
-</domain>''' % {'name': self._def['name'],
+</domain>'''.format(**{'name': self._def['name'],
                 'uuid': self._def['uuid'],
                 'memory': self._def['memory'],
                 'vcpu': self._def['vcpu'],
                 'arch': self._def['os']['arch'],
                 'disks': disks,
-                'nics': nics}
+                'nics': nics})
 
     def managedSave(self, flags):
         self._connection._mark_not_running(self)
@@ -889,7 +889,7 @@ class Connection(object):
             return self._running_vms[id]
         raise make_libvirtError(
                 libvirtError,
-                'Domain not found: no domain with matching id %d' % id,
+                'Domain not found: no domain with matching id {0:d}'.format(id),
                 error_code=VIR_ERR_NO_DOMAIN,
                 error_domain=VIR_FROM_QEMU)
 
@@ -898,7 +898,7 @@ class Connection(object):
             return self._vms[name]
         raise make_libvirtError(
                 libvirtError,
-                'Domain not found: no domain with matching name "%s"' % name,
+                'Domain not found: no domain with matching name "{0!s}"'.format(name),
                 error_code=VIR_ERR_NO_DOMAIN,
                 error_domain=VIR_FROM_QEMU)
 
@@ -976,7 +976,7 @@ class Connection(object):
       <arch>x86_64</arch>
       <model>Penryn</model>
       <vendor>Intel</vendor>
-      <topology sockets='%(sockets)s' cores='%(cores)s' threads='%(threads)s'/>
+      <topology sockets='{sockets!s}' cores='{cores!s}' threads='{threads!s}'/>
       <feature name='xtpr'/>
       <feature name='tm2'/>
       <feature name='est'/>
@@ -997,7 +997,7 @@ class Connection(object):
         <uri_transport>tcp</uri_transport>
       </uri_transports>
     </migration_features>
-    %(topology)s
+    {topology!s}
     <secmodel>
       <model>apparmor</model>
       <doi>0</doi>
@@ -1195,10 +1195,10 @@ class Connection(object):
     </features>
   </guest>
 
-</capabilities>''' % {'sockets': self.host_info.cpu_sockets,
+</capabilities>'''.format(**{'sockets': self.host_info.cpu_sockets,
                       'cores': self.host_info.cpu_cores,
                       'threads': self.host_info.cpu_threads,
-                      'topology': numa_topology}
+                      'topology': numa_topology})
 
     def compareCPU(self, xml, flags):
         tree = etree.fromstring(xml)
@@ -1243,7 +1243,7 @@ class Connection(object):
         except KeyError:
             raise make_libvirtError(
                     libvirtError,
-                    "no nwfilter with matching name %s" % name,
+                    "no nwfilter with matching name {0!s}".format(name),
                     error_code=VIR_ERR_NO_NWFILTER,
                     error_domain=VIR_FROM_NWFILTER)
 
@@ -1257,7 +1257,7 @@ class Connection(object):
         except KeyError:
             raise make_libvirtError(
                     libvirtError,
-                    "no nodedev with matching name %s" % name,
+                    "no nodedev with matching name {0!s}".format(name),
                     error_code=VIR_ERR_NO_NODE_DEVICE,
                     error_domain=VIR_FROM_NODEDEV)
 

--- a/nova/tests/unit/virt/libvirt/storage/test_dmcrypt.py
+++ b/nova/tests/unit/virt/libvirt/storage/test_dmcrypt.py
@@ -31,7 +31,7 @@ class LibvirtDmcryptTestCase(test.NoDBTestCase):
         self.TARGET = dmcrypt.volume_name(self.NAME)
         self.PATH = '/dev/nova-lvm/instance_disk'
         self.KEY = range(0, self.KEY_SIZE)
-        self.KEY_STR = ''.join(["%02x" % x for x in range(0, self.KEY_SIZE)])
+        self.KEY_STR = ''.join(["{0:02x}".format(x) for x in range(0, self.KEY_SIZE)])
 
     @mock.patch('nova.utils.execute')
     def test_create_volume(self, mock_execute):

--- a/nova/tests/unit/virt/libvirt/storage/test_rbd.py
+++ b/nova/tests/unit/virt/libvirt/storage/test_rbd.py
@@ -188,7 +188,7 @@ class RbdTestCase(test.NoDBTestCase):
         pool = u'images'
         image = u'image-name'
         snap = u'snapshot-name'
-        location = {'url': u'rbd://fsid/%s/%s/%s' % (pool, image, snap)}
+        location = {'url': u'rbd://fsid/{0!s}/{1!s}/{2!s}'.format(pool, image, snap)}
 
         client_stack = []
 
@@ -219,7 +219,7 @@ class RbdTestCase(test.NoDBTestCase):
         pool = u'images'
         image = u'image-name'
         snap = u'snapshot-name'
-        location = {'url': u'rbd://fsid/%s/%s/%s' % (pool, image, snap)}
+        location = {'url': u'rbd://fsid/{0!s}/{1!s}/{2!s}'.format(pool, image, snap)}
 
         client_stack = []
 

--- a/nova/tests/unit/virt/libvirt/test_config.py
+++ b/nova/tests/unit/virt/libvirt/test_config.py
@@ -1263,15 +1263,15 @@ class LibvirtConfigGuestChannelTest(LibvirtConfigBaseTest):
         obj = config.LibvirtConfigGuestChannel()
         obj.type = "unix"
         obj.target_name = "org.qemu.guest_agent.0"
-        obj.source_path = "/var/lib/libvirt/qemu/%s.%s.sock" % (
+        obj.source_path = "/var/lib/libvirt/qemu/{0!s}.{1!s}.sock".format(
                             obj.target_name, "instance-name")
 
         xml = obj.to_xml()
         self.assertXmlEqual(xml, """
             <channel type="unix">
-              <source path="%s" mode="bind"/>
+              <source path="{0!s}" mode="bind"/>
               <target type="virtio" name="org.qemu.guest_agent.0"/>
-            </channel>""" % obj.source_path)
+            </channel>""".format(obj.source_path))
 
 
 class LibvirtConfigGuestInterfaceTest(LibvirtConfigBaseTest):

--- a/nova/tests/unit/virt/libvirt/test_designer.py
+++ b/nova/tests/unit/virt/libvirt/test_designer.py
@@ -33,7 +33,7 @@ class DesignerTestCase(test.NoDBTestCase):
             # 'extra_specs' field.
             designer.set_vif_bandwidth_config(None, {})
         except KeyError as e:
-            self.fail('KeyError: %s' % e)
+            self.fail('KeyError: {0!s}'.format(e))
 
     def test_set_vif_guest_frontend_config(self):
         conf = config.LibvirtConfigGuestInterface()

--- a/nova/tests/unit/virt/libvirt/test_driver.py
+++ b/nova/tests/unit/virt/libvirt/test_driver.py
@@ -315,7 +315,7 @@ class FakeVirtDomain(object):
 
     def name(self):
         if self.domname is None:
-            return "fake-domain %s" % self
+            return "fake-domain {0!s}".format(self)
         else:
             return self.domname
 
@@ -594,8 +594,8 @@ class LibvirtConnTestCase(test.NoDBTestCase):
 
     REQUIRES_LOCKING = True
 
-    _EPHEMERAL_20_DEFAULT = ('ephemeral_20_%s' %
-                             utils.get_hash_str(disk._DEFAULT_FILE_SYSTEM)[:7])
+    _EPHEMERAL_20_DEFAULT = ('ephemeral_20_{0!s}'.format(
+                             utils.get_hash_str(disk._DEFAULT_FILE_SYSTEM)[:7]))
 
     def setUp(self):
         super(LibvirtConnTestCase, self).setUp()
@@ -3567,20 +3567,20 @@ class LibvirtConnTestCase(test.NoDBTestCase):
         xml = """
         <domain type='kvm'>
           <devices>
-            <%(dev_name)s type="tcp">
+            <{dev_name!s} type="tcp">
               <source host="127.0.0.1" service="100" mode="connect"/>
-            </%(dev_name)s>
-            <%(dev_name)s type="tcp">
+            </{dev_name!s}>
+            <{dev_name!s} type="tcp">
               <source host="127.0.0.1" service="101" mode="bind"/>
-            </%(dev_name)s>
-            <%(dev_name)s type="tcp">
+            </{dev_name!s}>
+            <{dev_name!s} type="tcp">
               <source host="127.0.0.2" service="100" mode="bind"/>
-            </%(dev_name)s>
-            <%(dev_name)s type="tcp">
+            </{dev_name!s}>
+            <{dev_name!s} type="tcp">
               <source host="127.0.0.2" service="101" mode="connect"/>
-            </%(dev_name)s>
+            </{dev_name!s}>
           </devices>
-        </domain>""" % {'dev_name': dev_name}
+        </domain>""".format(**{'dev_name': dev_name})
 
         mock_get_xml_desc.return_value = xml
 
@@ -5798,7 +5798,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
         for i, (check, expected_result) in enumerate(check):
             self.assertEqual(check(tree),
                              expected_result,
-                             '%s failed common check %d' % (xml, i))
+                             '{0!s} failed common check {1:d}'.format(xml, i))
 
         target = tree.find('./devices/filesystem/source').get('dir')
         self.assertTrue(len(target) > 0)
@@ -5850,8 +5850,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
             for i, (check, expected_result) in enumerate(checks):
                 self.assertEqual(check(tree),
                                  expected_result,
-                                 '%s != %s failed check %d' %
-                                 (check(tree), expected_result, i))
+                                 '{0!s} != {1!s} failed check {2:d}'.format(check(tree), expected_result, i))
 
     def _check_xml_and_disk_driver(self, image_meta):
         os_open = os.open
@@ -5861,7 +5860,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
             if flags & os.O_DIRECT:
                 if not directio_supported:
                     raise OSError(errno.EINVAL,
-                                  '%s: %s' % (os.strerror(errno.EINVAL), path))
+                                  '{0!s}: {1!s}'.format(os.strerror(errno.EINVAL), path))
                 flags &= ~os.O_DIRECT
             return os_open(path, flags, *args, **kwargs)
 
@@ -6121,14 +6120,12 @@ class LibvirtConnTestCase(test.NoDBTestCase):
                 for i, (check, expected_result) in enumerate(checks):
                     self.assertEqual(check(tree),
                                      expected_result,
-                                     '%s != %s failed check %d' %
-                                     (check(tree), expected_result, i))
+                                     '{0!s} != {1!s} failed check {2:d}'.format(check(tree), expected_result, i))
 
                 for i, (check, expected_result) in enumerate(common_checks):
                     self.assertEqual(check(tree),
                                      expected_result,
-                                     '%s != %s failed common check %d' %
-                                     (check(tree), expected_result, i))
+                                     '{0!s} != {1!s} failed common check {2:d}'.format(check(tree), expected_result, i))
 
                 filterref = './devices/interface/filterref'
                 vif = network_info[0]
@@ -6196,8 +6193,8 @@ class LibvirtConnTestCase(test.NoDBTestCase):
             drvr.ensure_filtering_rules_for_instance(instance_ref,
                                                      network_info)
         except exception.NovaException as e:
-            msg = ('The firewall filter for %s does not exist' %
-                   instance_ref['name'])
+            msg = ('The firewall filter for {0!s} does not exist'.format(
+                   instance_ref['name']))
             c1 = (0 <= six.text_type(e).find(msg))
         self.assertTrue(c1)
 
@@ -8468,7 +8465,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
             self.assertEqual(
                 ret.to_legacy_dict(True)['pre_live_migration_result'],
                 target_ret)
-            self.assertTrue(os.path.exists('%s/%s/' % (tmpdir,
+            self.assertTrue(os.path.exists('{0!s}/{1!s}/'.format(tmpdir,
                                                        inst_ref['name'])))
 
     def test_pre_live_migration_plug_vifs_retry_fails(self):
@@ -9134,8 +9131,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
                 return None
 
         def fake_node_device_lookup_by_name(address):
-            pattern = ("pci_%(hex)s{4}_%(hex)s{2}_%(hex)s{2}_%(oct)s{1}"
-                       % dict(hex='[\da-f]', oct='[0-8]'))
+            pattern = ("pci_{hex!s}{{4}}_{hex!s}{{2}}_{hex!s}{{2}}_{oct!s}{{1}}".format(**dict(hex='[\da-f]', oct='[0-8]')))
             pattern = re.compile(pattern)
             if pattern.match(address) is None:
                 raise fakelibvirt.libvirtError()
@@ -9255,8 +9251,8 @@ class LibvirtConnTestCase(test.NoDBTestCase):
                                       mkfs=False)
 
     def test_create_image_plain_os_type_set_with_fs(self):
-        ephemeral_file_name = ('ephemeral_20_%s' % utils.get_hash_str(
-            'mkfs.ext4 --label %(fs_label)s %(target)s')[:7])
+        ephemeral_file_name = ('ephemeral_20_{0!s}'.format(utils.get_hash_str(
+            'mkfs.ext4 --label %(fs_label)s %(target)s')[:7]))
 
         self._test_create_image_plain(os_type='test',
                                       filename=ephemeral_file_name,
@@ -9606,7 +9602,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
             instance = objects.Instance(**instance_ref)
 
             console_dir = (os.path.join(tmpdir, instance['name']))
-            console_log = '%s/console.log' % (console_dir)
+            console_log = '{0!s}/console.log'.format((console_dir))
             fake_dom_xml = """
                 <domain type='kvm'>
                     <devices>
@@ -9614,12 +9610,12 @@ class LibvirtConnTestCase(test.NoDBTestCase):
                             <source file='filename'/>
                         </disk>
                         <console type='file'>
-                            <source path='%s'/>
+                            <source path='{0!s}'/>
                             <target port='0'/>
                         </console>
                     </devices>
                 </domain>
-            """ % console_log
+            """.format(console_log)
 
             def fake_lookup(id):
                 return FakeVirtDomain(fake_dom_xml)
@@ -9656,12 +9652,12 @@ class LibvirtConnTestCase(test.NoDBTestCase):
                             <source file='filename'/>
                         </disk>
                         <console type='file'>
-                            <source path='%s'/>
+                            <source path='{0!s}'/>
                             <target port='0'/>
                         </console>
                     </devices>
                 </domain>
-            """ % console_log
+            """.format(console_log)
 
             def fake_lookup(id):
                 return FakeVirtDomain(fake_dom_xml)
@@ -9687,7 +9683,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
             instance = objects.Instance(**instance_ref)
 
             console_dir = (os.path.join(tmpdir, instance['name']))
-            pty_file = '%s/fake_pty' % (console_dir)
+            pty_file = '{0!s}/fake_pty'.format((console_dir))
             fake_dom_xml = """
                 <domain type='kvm'>
                     <devices>
@@ -9695,12 +9691,12 @@ class LibvirtConnTestCase(test.NoDBTestCase):
                             <source file='filename'/>
                         </disk>
                         <console type='pty'>
-                            <source path='%s'/>
+                            <source path='{0!s}'/>
                             <target port='0'/>
                         </console>
                     </devices>
                 </domain>
-            """ % pty_file
+            """.format(pty_file)
 
             def fake_lookup(id):
                 return FakeVirtDomain(fake_dom_xml)
@@ -12625,7 +12621,7 @@ class LibvirtConnTestCase(test.NoDBTestCase):
         elif method_name == "detach_interface":
             drvr.detach_interface(instance, network_info[0])
         else:
-            raise ValueError("Unhandled method %s" % method_name)
+            raise ValueError("Unhandled method {0!s}".format(method_name))
 
     @mock.patch.object(lockutils, "external_lock")
     def test_attach_interface_get_config(self, mock_lock):
@@ -15616,12 +15612,12 @@ class LibvirtDriverTestCase(test.NoDBTestCase):
                 <devices>
                   <disk type="block">
                     <driver name='qemu' type='raw' cache='none'/>
-                    <source dev="/dev/mapper/%s"/>
+                    <source dev="/dev/mapper/{0!s}"/>
                     <target dev="vda" bus="virtio" serial="1234"/>
                   </disk>
                 </devices>
               </domain>
-              """ % dev_name
+              """.format(dev_name)
         dom = mock.MagicMock()
         dom.XMLDesc.return_value = dom_xml
         guest = libvirt_guest.Guest(dom)

--- a/nova/tests/unit/virt/libvirt/test_fakelibvirt.py
+++ b/nova/tests/unit/virt/libvirt/test_fakelibvirt.py
@@ -24,11 +24,11 @@ def get_vm_xml(name="testname", uuid=None, source_type='file',
                interface_type='bridge'):
     uuid_tag = ''
     if uuid:
-        uuid_tag = '<uuid>%s</uuid>' % (uuid,)
+        uuid_tag = '<uuid>{0!s}</uuid>'.format(uuid)
 
     return '''<domain type='kvm'>
-  <name>%(name)s</name>
-%(uuid_tag)s
+  <name>{name!s}</name>
+{uuid_tag!s}
   <memory>128000</memory>
   <vcpu>1</vcpu>
   <os>
@@ -43,21 +43,21 @@ def get_vm_xml(name="testname", uuid=None, source_type='file',
   <devices>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
-      <source %(source_type)s='/somefile'/>
+      <source {source_type!s}='/somefile'/>
       <target dev='vda' bus='virtio'/>
     </disk>
-    <interface type='%(interface_type)s'>
+    <interface type='{interface_type!s}'>
       <mac address='05:26:3e:31:28:1f'/>
-      <source %(interface_type)s='br100'/>
+      <source {interface_type!s}='br100'/>
     </interface>
     <input type='mouse' bus='ps2'/>
     <graphics type='vnc' port='5901' autoport='yes' keymap='en-us'/>
     <graphics type='spice' port='5901' autoport='yes' keymap='en-us'/>
   </devices>
-</domain>''' % {'name': name,
+</domain>'''.format(**{'name': name,
                 'uuid_tag': uuid_tag,
                 'source_type': source_type,
-                'interface_type': interface_type}
+                'interface_type': interface_type})
 
 
 class FakeLibvirtTests(test.NoDBTestCase):
@@ -306,11 +306,11 @@ class FakeLibvirtTests(test.NoDBTestCase):
         conn = self.get_openAuth_curry_func()('qemu:///system')
 
         xml = '''<cpu>
-                   <arch>%s</arch>
-                   <model>%s</model>
-                   <vendor>%s</vendor>
-                   <topology sockets="%d" cores="%d" threads="%d"/>
-                 </cpu>''' % (conn.host_info.arch,
+                   <arch>{0!s}</arch>
+                   <model>{1!s}</model>
+                   <vendor>{2!s}</vendor>
+                   <topology sockets="{3:d}" cores="{4:d}" threads="{5:d}"/>
+                 </cpu>'''.format(conn.host_info.arch,
                               conn.host_info.cpu_model,
                               conn.host_info.cpu_vendor,
                               conn.host_info.cpu_sockets,
@@ -323,11 +323,11 @@ class FakeLibvirtTests(test.NoDBTestCase):
         conn = self.get_openAuth_curry_func()('qemu:///system')
 
         xml = '''<cpu>
-                   <arch>%s</arch>
-                   <model>%s</model>
-                   <vendor>%s</vendor>
-                   <topology sockets="%d" cores="%d" threads="%d"/>
-                 </cpu>''' % (conn.host_info.arch,
+                   <arch>{0!s}</arch>
+                   <model>{1!s}</model>
+                   <vendor>{2!s}</vendor>
+                   <topology sockets="{3:d}" cores="{4:d}" threads="{5:d}"/>
+                 </cpu>'''.format(conn.host_info.arch,
                               conn.host_info.cpu_model,
                               "AnotherVendor",
                               conn.host_info.cpu_sockets,
@@ -340,11 +340,11 @@ class FakeLibvirtTests(test.NoDBTestCase):
         conn = self.get_openAuth_curry_func()('qemu:///system')
 
         xml = '''<cpu>
-                   <arch>%s</arch>
-                   <model>%s</model>
-                   <vendor>%s</vendor>
-                   <topology sockets="%d" cores="%d" threads="%d"/>
-                 </cpu>''' % ('not-a-valid-arch',
+                   <arch>{0!s}</arch>
+                   <model>{1!s}</model>
+                   <vendor>{2!s}</vendor>
+                   <topology sockets="{3:d}" cores="{4:d}" threads="{5:d}"/>
+                 </cpu>'''.format('not-a-valid-arch',
                               conn.host_info.cpu_model,
                               conn.host_info.cpu_vendor,
                               conn.host_info.cpu_sockets,
@@ -357,11 +357,11 @@ class FakeLibvirtTests(test.NoDBTestCase):
         conn = self.get_openAuth_curry_func()('qemu:///system')
 
         xml = '''<cpu>
-                   <arch>%s</arch>
-                   <model>%s</model>
-                   <vendor>%s</vendor>
-                   <topology sockets="%d" cores="%d" threads="%d"/>
-                 </cpu>''' % (conn.host_info.arch,
+                   <arch>{0!s}</arch>
+                   <model>{1!s}</model>
+                   <vendor>{2!s}</vendor>
+                   <topology sockets="{3:d}" cores="{4:d}" threads="{5:d}"/>
+                 </cpu>'''.format(conn.host_info.arch,
                               "AnotherModel",
                               conn.host_info.cpu_vendor,
                               conn.host_info.cpu_sockets,
@@ -374,10 +374,10 @@ class FakeLibvirtTests(test.NoDBTestCase):
         conn = self.get_openAuth_curry_func()('qemu:///system')
 
         xml = '''<cpu>
-                   <arch>%s</arch>
-                   <vendor>%s</vendor>
-                   <topology sockets="%d" cores="%d" threads="%d"/>
-                 </cpu>''' % (conn.host_info.arch,
+                   <arch>{0!s}</arch>
+                   <vendor>{1!s}</vendor>
+                   <topology sockets="{2:d}" cores="{3:d}" threads="{4:d}"/>
+                 </cpu>'''.format(conn.host_info.arch,
                               conn.host_info.cpu_vendor,
                               conn.host_info.cpu_sockets,
                               conn.host_info.cpu_cores,

--- a/nova/tests/unit/virt/libvirt/test_firewall.py
+++ b/nova/tests/unit/virt/libvirt/test_firewall.py
@@ -74,8 +74,7 @@ class NWFilterFakes(object):
         else:
             if self.filters[name].uuid != u:
                 raise fakelibvirt.libvirtError(
-                    "Mismatching name '%s' with uuid '%s' vs '%s'"
-                    % (name, self.filters[name].uuid, u))
+                    "Mismatching name '{0!s}' with uuid '{1!s}' vs '{2!s}'".format(name, self.filters[name].uuid, u))
             self.filters[name].xml = xml
         return True
 
@@ -259,7 +258,7 @@ class IptablesFirewallTestCase(test.NoDBTestCase):
         for rule in in_rules:
             if 'nova' not in rule:
                 self.assertIn(rule, self.out_rules,
-                              'Rule went missing: %s' % rule)
+                              'Rule went missing: {0!s}'.format(rule))
 
         instance_chain = None
         for rule in self.out_rules:
@@ -273,7 +272,7 @@ class IptablesFirewallTestCase(test.NoDBTestCase):
         security_group_chain = None
         for rule in self.out_rules:
             # This is pretty crude, but it'll do for now
-            if '-A %s -j' % instance_chain in rule:
+            if '-A {0!s} -j'.format(instance_chain) in rule:
                 security_group_chain = rule.split(' ')[-1]
                 break
         self.assertTrue(security_group_chain,
@@ -492,7 +491,7 @@ class NWFilterTestCase(test.NoDBTestCase):
         self._create_security_group(instance_ref)
 
         def _ensure_all_called(mac, allow_dhcp):
-            instance_filter = 'nova-instance-%s-%s' % (instance_ref['name'],
+            instance_filter = 'nova-instance-{0!s}-{1!s}'.format(instance_ref['name'],
                     mac.translate({ord(':'): None}))
             requiredlist = ['no-arp-spoofing', 'no-ip-spoofing',
                              'no-mac-spoofing']
@@ -504,12 +503,12 @@ class NWFilterTestCase(test.NoDBTestCase):
             for required in requiredlist:
                 self.assertIn(required,
                               self.recursive_depends[instance_filter],
-                              "Instance's filter does not include %s" %
-                              required)
+                              "Instance's filter does not include {0!s}".format(
+                              required))
             for required_not in required_not_list:
                 self.assertNotIn(required_not,
                                  self.recursive_depends[instance_filter],
-                                 "Instance filter includes %s" % required_not)
+                                 "Instance filter includes {0!s}".format(required_not))
 
         network_info = _fake_network_info(self, 1)
         # since there is one (network_info) there is one vif

--- a/nova/tests/unit/virt/libvirt/test_imagebackend.py
+++ b/nova/tests/unit/virt/libvirt/test_imagebackend.py
@@ -115,9 +115,9 @@ class _ImageTestCase(object):
         image.cache(fake_fetch, self.TEMPLATE_PATH, self.SIZE)
 
         self.assertEqual(fake_processutils.fake_execute_get_log(),
-            ['fallocate -l 1 %s.fallocate_test' % self.PATH,
-             'fallocate -n -l %s %s' % (self.SIZE, self.PATH),
-             'fallocate -n -l %s %s' % (self.SIZE, self.PATH)])
+            ['fallocate -l 1 {0!s}.fallocate_test'.format(self.PATH),
+             'fallocate -n -l {0!s} {1!s}'.format(self.SIZE, self.PATH),
+             'fallocate -n -l {0!s} {1!s}'.format(self.SIZE, self.PATH)])
 
     def test_prealloc_image_without_write_access(self):
         CONF.set_override('preallocate_images', 'space')
@@ -355,7 +355,7 @@ class Qcow2TestCase(_ImageTestCase, test.NoDBTestCase):
         self.image_class = imagebackend.Qcow2
         super(Qcow2TestCase, self).setUp()
         self.QCOW2_BASE = (self.TEMPLATE_PATH +
-                           '_%d' % (self.SIZE / units.Gi))
+                           '_{0:d}'.format((self.SIZE / units.Gi)))
 
     def prepare_mocks(self):
         fn = self.mox.CreateMockAnything()
@@ -578,7 +578,7 @@ class LvmTestCase(_ImageTestCase, test.NoDBTestCase):
         self.flags(images_volume_group=self.VG, group='libvirt')
         self.flags(enabled=False, group='ephemeral_storage_encryption')
         self.INSTANCE['ephemeral_key_uuid'] = None
-        self.LV = '%s_%s' % (self.INSTANCE['uuid'], self.NAME)
+        self.LV = '{0!s}_{1!s}'.format(self.INSTANCE['uuid'], self.NAME)
         self.OLD_STYLE_INSTANCE_PATH = None
         self.PATH = os.path.join('/dev', self.VG, self.LV)
         self.disk = imagebackend.disk
@@ -790,7 +790,7 @@ class EncryptedLvmTestCase(_ImageTestCase, test.NoDBTestCase):
                              '00000000000000000000000000000000',
                    group='keymgr')
         self.flags(images_volume_group=self.VG, group='libvirt')
-        self.LV = '%s_%s' % (self.INSTANCE['uuid'], self.NAME)
+        self.LV = '{0!s}_{1!s}'.format(self.INSTANCE['uuid'], self.NAME)
         self.OLD_STYLE_INSTANCE_PATH = None
         self.LV_PATH = os.path.join('/dev', self.VG, self.LV)
         self.PATH = os.path.join('/dev/mapper',
@@ -1256,7 +1256,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
         image.create_image(fn, self.TEMPLATE_PATH, None)
 
-        rbd_name = "%s_%s" % (self.INSTANCE['uuid'], self.NAME)
+        rbd_name = "{0!s}_{1!s}".format(self.INSTANCE['uuid'], self.NAME)
         cmd = ('rbd', 'import', '--pool', self.POOL, self.TEMPLATE_PATH,
                rbd_name, '--image-format=2', '--id', self.USER,
                '--conf', self.CONF)
@@ -1278,7 +1278,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
         self.mox.StubOutWithMock(image, 'check_image_exists')
         image.check_image_exists().AndReturn(False)
         image.check_image_exists().AndReturn(False)
-        rbd_name = "%s_%s" % (self.INSTANCE['uuid'], self.NAME)
+        rbd_name = "{0!s}_{1!s}".format(self.INSTANCE['uuid'], self.NAME)
         cmd = ('rbd', 'import', '--pool', self.POOL, self.TEMPLATE_PATH,
                rbd_name, '--image-format=2', '--id', self.USER,
                '--conf', self.CONF)
@@ -1306,7 +1306,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
         self.mox.StubOutWithMock(image, 'get_disk_size')
         image.get_disk_size(self.TEMPLATE_PATH).AndReturn(self.SIZE)
         image.check_image_exists().AndReturn(True)
-        rbd_name = "%s_%s" % (self.INSTANCE['uuid'], self.NAME)
+        rbd_name = "{0!s}_{1!s}".format(self.INSTANCE['uuid'], self.NAME)
         image.get_disk_size(rbd_name).AndReturn(self.SIZE)
 
         self.mox.ReplayAll()
@@ -1348,7 +1348,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
         self.flags(images_rbd_ceph_conf=conf, group='libvirt')
         self.flags(rbd_user=user, group='libvirt')
         image = self.image_class(self.INSTANCE, self.NAME)
-        rbd_path = "rbd:%s/%s:id=%s:conf=%s" % (pool, image.rbd_name,
+        rbd_path = "rbd:{0!s}/{1!s}:id={2!s}:conf={3!s}".format(pool, image.rbd_name,
                                                 user, conf)
 
         self.assertEqual(image.path, rbd_path)
@@ -1418,7 +1418,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
             mock_exists.return_value = True
             image.import_file(self.INSTANCE, mock.sentinel.file,
                               mock.sentinel.remote_name)
-            name = '%s_%s' % (self.INSTANCE.uuid,
+            name = '{0!s}_{1!s}'.format(self.INSTANCE.uuid,
                               mock.sentinel.remote_name)
             mock_exists.assert_called_once_with()
             mock_remove.assert_called_once_with(name)
@@ -1435,7 +1435,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
             mock_exists.return_value = False
             image.import_file(self.INSTANCE, mock.sentinel.file,
                               mock.sentinel.remote_name)
-            name = '%s_%s' % (self.INSTANCE.uuid,
+            name = '{0!s}_{1!s}'.format(self.INSTANCE.uuid,
                               mock.sentinel.remote_name)
             mock_exists.assert_called_once_with()
             self.assertFalse(mock_remove.called)
@@ -1452,7 +1452,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
     def test_get_parent_pool_no_parent_info(self):
         image = self.image_class(self.INSTANCE, self.NAME)
-        rbd_uri = 'rbd://%s/%s/fake-image/fake-snap' % (self.FSID, self.POOL)
+        rbd_uri = 'rbd://{0!s}/{1!s}/fake-image/fake-snap'.format(self.FSID, self.POOL)
         with test.nested(mock.patch.object(rbd_utils.RBDDriver, 'parent_info'),
                          mock.patch.object(imagebackend.IMAGE_API, 'get'),
                          ) as (mock_pi, mock_get):
@@ -1479,7 +1479,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
     def test_direct_snapshot(self):
         image = self.image_class(self.INSTANCE, self.NAME)
-        test_snap = 'rbd://%s/%s/fake-image-id/snap' % (self.FSID, self.POOL)
+        test_snap = 'rbd://{0!s}/{1!s}/fake-image-id/snap'.format(self.FSID, self.POOL)
         with test.nested(
                 mock.patch.object(rbd_utils.RBDDriver, 'get_fsid',
                                   return_value=self.FSID),
@@ -1514,7 +1514,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
     def test_direct_snapshot_cleans_up_on_failures(self):
         image = self.image_class(self.INSTANCE, self.NAME)
-        test_snap = 'rbd://%s/%s/%s/snap' % (self.FSID, image.pool,
+        test_snap = 'rbd://{0!s}/{1!s}/{2!s}/snap'.format(self.FSID, image.pool,
                                              image.rbd_name)
         with test.nested(
                 mock.patch.object(rbd_utils.RBDDriver, 'get_fsid',
@@ -1538,7 +1538,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
     def test_cleanup_direct_snapshot(self):
         image = self.image_class(self.INSTANCE, self.NAME)
-        test_snap = 'rbd://%s/%s/%s/snap' % (self.FSID, image.pool,
+        test_snap = 'rbd://{0!s}/{1!s}/{2!s}/snap'.format(self.FSID, image.pool,
                                              image.rbd_name)
         with test.nested(
                 mock.patch.object(rbd_utils.RBDDriver, 'remove_snap'),
@@ -1557,7 +1557,7 @@ class RbdTestCase(_ImageTestCase, test.NoDBTestCase):
 
     def test_cleanup_direct_snapshot_destroy_volume(self):
         image = self.image_class(self.INSTANCE, self.NAME)
-        test_snap = 'rbd://%s/%s/%s/snap' % (self.FSID, image.pool,
+        test_snap = 'rbd://{0!s}/{1!s}/{2!s}/snap'.format(self.FSID, image.pool,
                                              image.rbd_name)
         with test.nested(
                 mock.patch.object(rbd_utils.RBDDriver, 'remove_snap'),

--- a/nova/tests/unit/virt/libvirt/test_imagecache.py
+++ b/nova/tests/unit/virt/libvirt/test_imagecache.py
@@ -103,7 +103,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
             csum_output = imagecache.read_stored_checksum(fname,
                                                           timestamped=False)
             self.assertEqual(csum_input.rstrip(),
-                             '{"sha1": "%s"}' % csum_output)
+                             '{{"sha1": "{0!s}"}}'.format(csum_output))
 
     def test_read_stored_checksum_legacy_essex(self):
         with utils.tempdir() as tmpdir:
@@ -281,7 +281,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
     def test_find_base_file_small(self):
         fingerprint = '968dd6cc49e01aaa044ed11c0cce733e0fa44a6a'
         self.stub_out('os.path.exists',
-                       lambda x: x.endswith('%s_sm' % fingerprint))
+                       lambda x: x.endswith('{0!s}_sm'.format(fingerprint)))
 
         base_dir = '/var/lib/nova/instances/_base'
         image_cache_manager = imagecache.ImageCacheManager()
@@ -299,7 +299,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
 
         self.stub_out('os.listdir', lambda x: listing)
         self.stub_out('os.path.exists',
-                       lambda x: x.endswith('%s_10737418240' % fingerprint))
+                       lambda x: x.endswith('{0!s}_10737418240'.format(fingerprint)))
         self.stub_out('os.path.isfile', lambda x: True)
 
         base_dir = '/var/lib/nova/instances/_base'
@@ -537,7 +537,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
                 f.write('banana')
 
             d = {'sha1': '21323454'}
-            with open('%s.info' % fname, 'w') as f:
+            with open('{0!s}.info'.format(fname), 'w') as f:
                 f.write(jsonutils.dumps(d))
 
             image_cache_manager = imagecache.ImageCacheManager()
@@ -570,8 +570,8 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
                           hashed_1,
                           hashed_21,
                           hashed_22,
-                          '%s_5368709120' % hashed_1,
-                          '%s_10737418240' % hashed_1,
+                          '{0!s}_5368709120'.format(hashed_1),
+                          '{0!s}_10737418240'.format(hashed_1),
                           '00000004']
 
         def fq_path(path):
@@ -590,7 +590,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
                         '/instance_path/instance-1/disk',
                         '/instance_path/instance-2/disk',
                         '/instance_path/instance-3/disk',
-                        '/instance_path/_base/%s.info' % hashed_42]:
+                        '/instance_path/_base/{0!s}.info'.format(hashed_42)]:
                 return True
 
             for p in base_file_list:
@@ -599,13 +599,13 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
                 if path == fq_path(p) + '.info':
                     return False
 
-            if path in ['/instance_path/_base/%s_sm' % i for i in [hashed_1,
+            if path in ['/instance_path/_base/{0!s}_sm'.format(i) for i in [hashed_1,
                                                                    hashed_21,
                                                                    hashed_22,
                                                                    hashed_42]]:
                 return False
 
-            self.fail('Unexpected path existence check: %s' % path)
+            self.fail('Unexpected path existence check: {0!s}'.format(path))
 
         self.stub_out('os.path.exists', lambda x: exists(x))
 
@@ -623,7 +623,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
             if path == '/instance_path/_base':
                 return base_file_list
 
-            self.fail('Unexpected directory listed: %s' % path)
+            self.fail('Unexpected directory listed: {0!s}'.format(path))
 
         self.stub_out('os.listdir', lambda x: listdir(x))
 
@@ -639,7 +639,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
                 if path == fq_path(p):
                     return True
 
-            self.fail('Unexpected isfile call: %s' % path)
+            self.fail('Unexpected isfile call: {0!s}'.format(path))
 
         self.stub_out('os.path.isfile', lambda x: isfile(x))
 
@@ -666,8 +666,8 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
         def get_disk_backing_file(path):
             if path in ['/instance_path/instance-1/disk',
                         '/instance_path/instance-2/disk']:
-                return fq_path('%s_5368709120' % hashed_1)
-            self.fail('Unexpected backing file lookup: %s' % path)
+                return fq_path('{0!s}_5368709120'.format(hashed_1))
+            self.fail('Unexpected backing file lookup: {0!s}'.format(path))
 
         self.stubs.Set(libvirt_utils, 'get_disk_backing_file',
                        lambda x: get_disk_backing_file(x))
@@ -712,7 +712,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
         image_cache_manager.update(ctxt, all_instances)
 
         # Verify
-        active = [fq_path(hashed_1), fq_path('%s_5368709120' % hashed_1),
+        active = [fq_path(hashed_1), fq_path('{0!s}_5368709120'.format(hashed_1)),
                   fq_path(hashed_21), fq_path(hashed_22)]
         for act in active:
             self.assertIn(act, image_cache_manager.active_base_files)
@@ -722,7 +722,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
         for rem in [fq_path('e97222e91fc4241f49a7f520d1dcf446751129b3_sm'),
                     fq_path('e09c675c2d1cfac32dae3c2d83689c8c94bc693b_sm'),
                     fq_path(hashed_42),
-                    fq_path('%s_10737418240' % hashed_1)]:
+                    fq_path('{0!s}_10737418240'.format(hashed_1))]:
             self.assertIn(rem, image_cache_manager.removable_base_files)
 
         # Ensure there are no "corrupt" images as well
@@ -926,7 +926,7 @@ class VerifyChecksumTestCase(test.NoDBTestCase):
         if info_attr == "csum valid":
             csum = hashlib.sha1()
             csum.update(testdata)
-            f.write('{"sha1": "%s"}\n' % csum.hexdigest())
+            f.write('{{"sha1": "{0!s}"}}\n'.format(csum.hexdigest()))
         elif info_attr == "csum invalid, not json":
             f.write('banana')
         else:

--- a/nova/tests/unit/virt/libvirt/test_utils.py
+++ b/nova/tests/unit/virt/libvirt/test_utils.py
@@ -82,7 +82,7 @@ class LibvirtUtilsTestCase(test.NoDBTestCase):
         path = '/some/path'
         d_type = libvirt_utils.get_disk_type_from_path(path)
         mock_isdir.assert_called_once_with(path)
-        mock_exists.assert_called_once_with("%s/DiskDescriptor.xml" % path)
+        mock_exists.assert_called_once_with("{0!s}/DiskDescriptor.xml".format(path))
         self.assertEqual('ploop', d_type)
 
     @mock.patch('os.path.exists', return_value=True)
@@ -125,7 +125,7 @@ disk size: 96K
             kbytes = bytes / 1024
             mbytes = kbytes / 1024
             output = template_output % ({
-                'v_size': "%sM" % (mbytes),
+                'v_size': "{0!s}M".format((mbytes)),
                 'vsize_b': i,
                 'path': path,
             })
@@ -133,7 +133,7 @@ disk size: 96K
                 return_value=(output, '')) as mock_execute:
                 self._test_disk_size(mock_execute, path, i)
             output = template_output % ({
-                'v_size': "%sK" % (kbytes),
+                'v_size': "{0!s}K".format((kbytes)),
                 'vsize_b': i,
                 'path': path,
             })

--- a/nova/tests/unit/virt/libvirt/test_vif.py
+++ b/nova/tests/unit/virt/libvirt/test_vif.py
@@ -446,11 +446,11 @@ class LibvirtVifTestCase(test.NoDBTestCase):
         if type:
             addr_type = address.get("type")
             self.assertEqual(type, addr_type)
-        pci_slot = "%(domain)s:%(bus)s:%(slot)s.%(func)s" % {
+        pci_slot = "{domain!s}:{bus!s}:{slot!s}.{func!s}".format(**{
                      'domain': address.get("domain")[2:],
                      'bus': address.get("bus")[2:],
                      'slot': address.get("slot")[2:],
-                     'func': address.get("function")[2:]}
+                     'func': address.get("function")[2:]})
 
         pci_slot_want = vif['profile']['pci_slot']
         self.assertEqual(pci_slot, pci_slot_want)
@@ -545,7 +545,7 @@ class LibvirtVifTestCase(test.NoDBTestCase):
         xml = conf.to_xml()
         doc = etree.fromstring(xml)
         for nic in nics:
-            path = "./devices/interface/[@type='%s']" % nic['net_type']
+            path = "./devices/interface/[@type='{0!s}']".format(nic['net_type'])
             node = doc.find(path)
             self.assertEqual(nic['net_type'], node.get("type"))
             self.assertEqual(nic['mac_addr'],

--- a/nova/tests/unit/virt/libvirt/volume/test_iscsi.py
+++ b/nova/tests/unit/virt/libvirt/volume/test_iscsi.py
@@ -38,9 +38,9 @@ class LibvirtISCSIVolumeDriverTestCase(
         sample_input = """Loading iscsi modules: done
 Starting iSCSI initiator service: done
 Setting up iSCSI targets: unused
-%s %s
-%s %s
-""" % (targets[0][0], targets[0][1], targets[1][0], targets[1][1])
+{0!s} {1!s}
+{2!s} {3!s}
+""".format(targets[0][0], targets[0][1], targets[1][0], targets[1][1])
         driver = iscsi.LibvirtISCSIVolumeDriver("none")
         out = driver.connector._get_target_portals_from_iscsiadm_output(
             sample_input)

--- a/nova/tests/unit/virt/libvirt/volume/test_net.py
+++ b/nova/tests/unit/virt/libvirt/volume/test_net.py
@@ -30,13 +30,13 @@ class LibvirtNetVolumeDriverTestCase(
     def _assertNetworkAndProtocolEquals(self, tree):
         self.assertEqual('network', tree.get('type'))
         self.assertEqual('rbd', tree.find('./source').get('protocol'))
-        rbd_name = '%s/%s' % ('rbd', self.name)
+        rbd_name = '{0!s}/{1!s}'.format('rbd', self.name)
         self.assertEqual(rbd_name, tree.find('./source').get('name'))
 
     def _assertISCSINetworkAndProtocolEquals(self, tree):
         self.assertEqual('network', tree.get('type'))
         self.assertEqual('iscsi', tree.find('./source').get('protocol'))
-        iscsi_name = '%s/%s' % (self.iqn, self.vol['id'])
+        iscsi_name = '{0!s}/{1!s}'.format(self.iqn, self.vol['id'])
         self.assertEqual(iscsi_name, tree.find('./source').get('name'))
 
     def sheepdog_connection(self, volume):
@@ -61,7 +61,7 @@ class LibvirtNetVolumeDriverTestCase(
         return {
             'driver_volume_type': 'rbd',
             'data': {
-                'name': '%s/%s' % ('rbd', volume['name']),
+                'name': '{0!s}/{1!s}'.format('rbd', volume['name']),
                 'auth_enabled': CONF.libvirt.rbd_secret_uuid is not None,
                 'auth_username': CONF.libvirt.rbd_user,
                 'secret_type': 'ceph',

--- a/nova/tests/unit/virt/libvirt/volume/test_volume.py
+++ b/nova/tests/unit/virt/libvirt/volume/test_volume.py
@@ -83,7 +83,7 @@ class LibvirtVolumeBaseTestCase(test.NoDBTestCase):
         }
         self.name = 'volume-00000001'
         self.location = '10.0.2.15:3260'
-        self.iqn = 'iqn.2010-10.org.openstack:%s' % self.name
+        self.iqn = 'iqn.2010-10.org.openstack:{0!s}'.format(self.name)
         self.vol = {'id': 1, 'name': self.name}
         self.uuid = '875a8070-d0b9-4949-8b31-104d125c9a64'
         self.user = 'foo'
@@ -98,10 +98,10 @@ class LibvirtISCSIVolumeBaseTestCase(LibvirtVolumeBaseTestCase):
 
     def iscsi_connection(self, volume, location, iqn, auth=False,
                          transport=None):
-        dev_name = 'ip-%s-iscsi-%s-lun-1' % (location, iqn)
+        dev_name = 'ip-{0!s}-iscsi-{1!s}-lun-1'.format(location, iqn)
         if transport is not None:
             dev_name = 'pci-0000:00:00.0-' + dev_name
-        dev_path = '/dev/disk/by-path/%s' % (dev_name)
+        dev_path = '/dev/disk/by-path/{0!s}'.format((dev_name))
         ret = {
                 'driver_volume_type': 'iscsi',
                 'data': {

--- a/nova/tests/unit/virt/test_block_device.py
+++ b/nova/tests/unit/virt/test_block_device.py
@@ -226,10 +226,10 @@ class TestDriverBlockDevice(test.NoDBTestCase):
                               cls, bdm)
 
     def _test_driver_device(self, name):
-        db_bdm = getattr(self, "%s_bdm" % name)
+        db_bdm = getattr(self, "{0!s}_bdm".format(name))
         test_bdm = self.driver_classes[name](db_bdm)
         self.assertThat(test_bdm, matchers.DictMatches(
-            getattr(self, "%s_driver_bdm" % name)))
+            getattr(self, "{0!s}_driver_bdm".format(name))))
 
         for k, v in six.iteritems(db_bdm):
             field_val = getattr(test_bdm._bdm_obj, k)
@@ -239,7 +239,7 @@ class TestDriverBlockDevice(test.NoDBTestCase):
 
         self.assertThat(test_bdm.legacy(),
                         matchers.DictMatches(
-                            getattr(self, "%s_legacy_driver_bdm" % name)))
+                            getattr(self, "{0!s}_legacy_driver_bdm".format(name))))
 
         # Test passthru attributes
         for passthru in test_bdm._proxy_as_attr:
@@ -252,7 +252,7 @@ class TestDriverBlockDevice(test.NoDBTestCase):
                 continue
             self.assertRaises(driver_block_device._InvalidType,
                               cls,
-                              getattr(self, '%s_bdm' % name))
+                              getattr(self, '{0!s}_bdm'.format(name)))
 
         # Test the save method
         with mock.patch.object(test_bdm._bdm_obj, 'save') as save_mock:
@@ -280,7 +280,7 @@ class TestDriverBlockDevice(test.NoDBTestCase):
 
     def _test_driver_default_size(self, name):
         size = 'swap_size' if name == 'swap' else 'size'
-        no_size_bdm = getattr(self, "%s_bdm_dict" % name).copy()
+        no_size_bdm = getattr(self, "{0!s}_bdm_dict".format(name)).copy()
         no_size_bdm['volume_size'] = None
 
         driver_bdm = self.driver_classes[name](

--- a/nova/tests/unit/virt/test_events.py
+++ b/nova/tests/unit/virt/test_events.py
@@ -26,11 +26,10 @@ class TestEvents(test.NoDBTestCase):
         lifecycle = event.EVENT_LIFECYCLE_RESUMED
 
         e = event.Event(t)
-        self.assertEqual(str(e), "<Event: %s>" % t)
+        self.assertEqual(str(e), "<Event: {0!s}>".format(t))
 
         e = event.InstanceEvent(uuid, timestamp=t)
-        self.assertEqual(str(e), "<InstanceEvent: %s, %s>" % (t, uuid))
+        self.assertEqual(str(e), "<InstanceEvent: {0!s}, {1!s}>".format(t, uuid))
 
         e = event.LifecycleEvent(uuid, lifecycle, timestamp=t)
-        self.assertEqual(str(e), "<LifecycleEvent: %s, %s => Resumed>" %
-                         (t, uuid))
+        self.assertEqual(str(e), "<LifecycleEvent: {0!s}, {1!s} => Resumed>".format(t, uuid))

--- a/nova/tests/unit/virt/test_hardware.py
+++ b/nova/tests/unit/virt/test_hardware.py
@@ -1956,7 +1956,7 @@ class _CPUPinningTestCaseBase(object):
     def assertEqualTopology(self, expected, got):
         for attr in ('sockets', 'cores', 'threads'):
             self.assertEqual(getattr(expected, attr), getattr(got, attr),
-                             "Mismatch on %s" % attr)
+                             "Mismatch on {0!s}".format(attr))
 
     def assertInstanceCellPinned(self, instance_cell, cell_ids=None):
         default_cell_id = 0

--- a/nova/tests/unit/virt/test_virt_drivers.py
+++ b/nova/tests/unit/virt/test_virt_drivers.py
@@ -226,10 +226,10 @@ class VirtDriverLoaderTestCase(_FakeDriverBackendTestCase, test.TestCase):
             try:
                 cm = manager.ComputeManager()
             except Exception as e:
-                self.fail("Couldn't load driver %s - %s" % (cls, e))
+                self.fail("Couldn't load driver {0!s} - {1!s}".format(cls, e))
 
             self.assertEqual(cm.driver.__class__.__name__, driver,
-                             "Could't load driver %s" % cls)
+                             "Could't load driver {0!s}".format(cls))
 
     def test_fail_to_load_new_drivers(self):
         self.flags(compute_driver='nova.virt.amiga')

--- a/nova/tests/unit/virt/vmwareapi/fake.py
+++ b/nova/tests/unit/virt/vmwareapi/fake.py
@@ -115,7 +115,7 @@ def _create_array_of_type(t):
     if t in _array_types:
         return _array_types[t]()
 
-    array_type_name = 'ArrayOf%s' % t
+    array_type_name = 'ArrayOf{0!s}'.format(t)
     array_type = type(array_type_name, (DataObject,), {})
 
     def __init__(self):
@@ -427,7 +427,7 @@ class VirtualMachine(ManagedObject):
                  _convert_to_array_of_opt_val(exconfig_do))
         if exconfig_do:
             for optval in exconfig_do:
-                self.set('config.extraConfig["%s"]' % optval.key, optval)
+                self.set('config.extraConfig["{0!s}"]'.format(optval.key), optval)
         self.set('runtime.host', kwargs.get("runtime_host", None))
         self.device = kwargs.get("virtual_device", [])
         # Sample of diagnostics data is below.
@@ -727,7 +727,7 @@ class HostSystem(ManagedObject):
         self.set("configManager.storageSystem", host_storage_sys_key)
 
         if not ds_ref:
-            ds_ref = create_datastore('local-host-%s' % name, 500, 500)
+            ds_ref = create_datastore('local-host-{0!s}'.format(name), 500, 500)
         datastores = DataObject()
         datastores.ManagedObjectReference = [ds_ref]
         self.set("datastore", datastores)
@@ -856,13 +856,13 @@ class HostSystem(ManagedObject):
         vswitch_do = DataObject()
         vswitch_do.pnic = ["vmnic0"]
         vswitch_do.name = vswitch_name
-        vswitch_do.portgroup = ["PortGroup-%s" % pg_name]
+        vswitch_do.portgroup = ["PortGroup-{0!s}".format(pg_name)]
 
         vswitches = self.get("config.network.vswitch").HostVirtualSwitch
         vswitches.append(vswitch_do)
 
         host_pg_do = DataObject()
-        host_pg_do.key = "PortGroup-%s" % pg_name
+        host_pg_do.key = "PortGroup-{0!s}".format(pg_name)
 
         pg_spec = DataObject()
         pg_spec.vlanId = vlanid
@@ -1432,7 +1432,7 @@ class FakeVim(object):
         matched_files = set()
         # Check if we are searching for a file or a directory
         directory = False
-        dname = '%s/' % ds_path
+        dname = '{0!s}/'.format(ds_path)
         for file in _db_content.get("files"):
             if file == dname:
                 directory = True
@@ -1488,7 +1488,7 @@ class FakeVim(object):
         ds_path = kwargs.get("name")
         if get_file(ds_path):
             raise vexc.FileAlreadyExistsException()
-        _db_content["files"].append('%s/' % ds_path)
+        _db_content["files"].append('{0!s}/'.format(ds_path))
 
     def _set_power_state(self, method, vm_ref, pwr_state="poweredOn"):
         """Sets power state for the VM."""

--- a/nova/tests/unit/virt/vmwareapi/test_driver_api.py
+++ b/nova/tests/unit/virt/vmwareapi/test_driver_api.py
@@ -217,7 +217,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         try:
             self.conn.init_host("fake_host")
         except Exception as ex:
-            self.fail("init_host raised: %s" % ex)
+            self.fail("init_host raised: {0!s}".format(ex))
 
     def _set_exception_vars(self):
         self.wait_task = self.conn._session._wait_for_task
@@ -230,7 +230,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         try:
             self.conn.cleanup_host("fake_host")
         except Exception as ex:
-            self.fail("cleanup_host raised: %s" % ex)
+            self.fail("cleanup_host raised: {0!s}".format(ex))
 
     def test_driver_capabilities(self):
         self.assertTrue(self.conn.capabilities['has_imagecache'])
@@ -446,7 +446,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
     def _cached_files_exist(self, exists=True):
         cache = ds_obj.DatastorePath(self.ds, 'vmware_base',
                                       self.fake_image_uuid,
-                                      '%s.vmdk' % self.fake_image_uuid)
+                                      '{0!s}.vmdk'.format(self.fake_image_uuid))
         if exists:
             vmwareapi_fake.assertPathExists(self, str(cache))
         else:
@@ -464,7 +464,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
 
         mock_from_image.return_value = img_props
         self._create_vm()
-        path = ds_obj.DatastorePath(self.ds, self.uuid, '%s.vmdk' % self.uuid)
+        path = ds_obj.DatastorePath(self.ds, self.uuid, '{0!s}.vmdk'.format(self.uuid))
         vmwareapi_fake.assertPathExists(self, str(path))
         self._cached_files_exist()
 
@@ -484,10 +484,10 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         self._create_vm()
         path = ds_obj.DatastorePath(self.ds, 'vmware_base',
                                      self.fake_image_uuid,
-                                     '%s.vmdk' % self.fake_image_uuid)
+                                     '{0!s}.vmdk'.format(self.fake_image_uuid))
         root = ds_obj.DatastorePath(self.ds, 'vmware_base',
                                      self.fake_image_uuid,
-                                     '%s.80.vmdk' % self.fake_image_uuid)
+                                     '{0!s}.80.vmdk'.format(self.fake_image_uuid))
         vmwareapi_fake.assertPathExists(self, str(path))
         vmwareapi_fake.assertPathExists(self, str(root))
 
@@ -496,23 +496,23 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         self._create_vm(instance_type=instance_type)
         path = ds_obj.DatastorePath(self.ds, 'vmware_base',
                                      self.fake_image_uuid,
-                                     '%s.iso' % self.fake_image_uuid)
+                                     '{0!s}.iso'.format(self.fake_image_uuid))
         vmwareapi_fake.assertPathExists(self, str(path))
 
     def test_iso_disk_type_created(self):
         self._iso_disk_type_created()
-        path = ds_obj.DatastorePath(self.ds, self.uuid, '%s.vmdk' % self.uuid)
+        path = ds_obj.DatastorePath(self.ds, self.uuid, '{0!s}.vmdk'.format(self.uuid))
         vmwareapi_fake.assertPathExists(self, str(path))
 
     def test_iso_disk_type_created_with_root_gb_0(self):
         self._iso_disk_type_created(instance_type='m1.micro')
-        path = ds_obj.DatastorePath(self.ds, self.uuid, '%s.vmdk' % self.uuid)
+        path = ds_obj.DatastorePath(self.ds, self.uuid, '{0!s}.vmdk'.format(self.uuid))
         vmwareapi_fake.assertPathNotExists(self, str(path))
 
     def test_iso_disk_cdrom_attach(self):
         iso_path = ds_obj.DatastorePath(self.ds, 'vmware_base',
                                          self.fake_image_uuid,
-                                         '%s.iso' % self.fake_image_uuid)
+                                         '{0!s}.iso'.format(self.fake_image_uuid))
 
         def fake_attach_cdrom(vm_ref, instance, data_store_ref,
                               iso_uploaded_path):
@@ -539,7 +539,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         iso_path = [
             ds_obj.DatastorePath(self.ds, 'vmware_base',
                                   self.fake_image_uuid,
-                                  '%s.iso' % self.fake_image_uuid),
+                                  '{0!s}.iso'.format(self.fake_image_uuid)),
             ds_obj.DatastorePath(self.ds, 'fake-config-drive')]
         self.iso_index = 0
 
@@ -710,10 +710,8 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         self._create_vm(instance_type='m1.micro')
         info = self._get_info()
         self._check_vm_info(info, power_state.RUNNING)
-        cache = ('[%s] vmware_base/%s/%s.vmdk' %
-                 (self.ds, self.fake_image_uuid, self.fake_image_uuid))
-        gb_cache = ('[%s] vmware_base/%s/%s.0.vmdk' %
-                    (self.ds, self.fake_image_uuid, self.fake_image_uuid))
+        cache = ('[{0!s}] vmware_base/{1!s}/{2!s}.vmdk'.format(self.ds, self.fake_image_uuid, self.fake_image_uuid))
+        gb_cache = ('[{0!s}] vmware_base/{1!s}/{2!s}.0.vmdk'.format(self.ds, self.fake_image_uuid, self.fake_image_uuid))
         vmwareapi_fake.assertPathExists(self, cache)
         vmwareapi_fake.assertPathNotExists(self, gb_cache)
 
@@ -768,7 +766,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
     def test_spawn_disk_extend_exists(self):
         root = ds_obj.DatastorePath(self.ds, 'vmware_base',
                                      self.fake_image_uuid,
-                                     '%s.80.vmdk' % self.fake_image_uuid)
+                                     '{0!s}.80.vmdk'.format(self.fake_image_uuid))
 
         def _fake_extend(instance, requested_size, name, dc_ref):
             vmwareapi_fake._add_file(str(root))
@@ -805,7 +803,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
             self._create_vm()
             iid = img_props.image_id
             cached_image = ds_obj.DatastorePath(self.ds, 'vmware_base',
-                                                 iid, '%s.80.vmdk' % iid)
+                                                 iid, '{0!s}.80.vmdk'.format(iid))
             mock_extend.assert_called_once_with(
                     self.instance, self.instance.root_gb * units.Mi,
                     str(cached_image), "fake_dc_ref")
@@ -846,7 +844,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         self.flags(use_linked_clone=True, group='vmware')
         self.task_ref = None
         uuid = self.fake_image_uuid
-        cached_image = '[%s] vmware_base/%s/%s.80.vmdk' % (self.ds,
+        cached_image = '[{0!s}] vmware_base/{1!s}/{2!s}.80.vmdk'.format(self.ds,
                                                            uuid, uuid)
 
         CopyError = vexc.FileFaultException
@@ -884,7 +882,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         self.flags(use_linked_clone=True, group='vmware')
         self.task_ref = None
         uuid = self.fake_image_uuid
-        cached_image = '[%s] vmware_base/%s/%s.80.vmdk' % (self.ds,
+        cached_image = '[{0!s}] vmware_base/{1!s}/{2!s}.80.vmdk'.format(self.ds,
                                                            uuid, uuid)
 
         CopyError = vexc.FileFaultException
@@ -945,12 +943,12 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
 
         cached_image = ds_obj.DatastorePath(self.ds, 'vmware_base',
                                              self.fake_image_uuid,
-                                             '%s.80.vmdk' %
-                                              self.fake_image_uuid)
+                                             '{0!s}.80.vmdk'.format(
+                                              self.fake_image_uuid))
         tmp_file = ds_obj.DatastorePath(self.ds, 'vmware_base',
                                          self.fake_image_uuid,
-                                         '%s.80-flat.vmdk' %
-                                          self.fake_image_uuid)
+                                         '{0!s}.80-flat.vmdk'.format(
+                                          self.fake_image_uuid))
 
         NoDiskSpace = vexc.get_fault_class('NoDiskSpace')
 
@@ -1570,7 +1568,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
                                    'node': self.instance_node})
         self._check_vm_info(info, power_state.RUNNING)
         info = self.conn.get_info({'name': '1-orig',
-                                   'uuid': '%s-orig' % self.uuid,
+                                   'uuid': '{0!s}-orig'.format(self.uuid),
                                    'node': self.instance_node})
         self._check_vm_info(info, power_state.SHUTDOWN)
         self.assertIsNotNone(vm_util.vm_ref_cache_get(self.uuid))
@@ -1872,7 +1870,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         self._cached_files_exist()
 
     def _get_timestamp_filename(self):
-        return '%s%s' % (imagecache.TIMESTAMP_PREFIX,
+        return '{0!s}{1!s}'.format(imagecache.TIMESTAMP_PREFIX,
                          self.old_time.strftime(imagecache.TIMESTAMP_FORMAT))
 
     def _override_time(self):
@@ -2114,7 +2112,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
         vm = self._get_vm_record()
         found_iface_id = False
         extras = vm.get("config.extraConfig")
-        key = "nvp.iface-id.%s" % index
+        key = "nvp.iface-id.{0!s}".format(index)
         num_found = 0
         for c in extras.OptionValue:
             if c.key.startswith("nvp.iface-id."):
@@ -2265,7 +2263,7 @@ class VMwareAPIVMTestCase(test.NoDBTestCase):
 
     def test_nodename(self):
         test_mor = "domain-26"
-        self.assertEqual("%s.%s" % (test_mor,
+        self.assertEqual("{0!s}.{1!s}".format(test_mor,
                                     vmwareapi_fake._FAKE_VCENTER_UUID),
                          self.conn._create_nodename(test_mor),
                          "VC driver failed to create the proper node name")

--- a/nova/tests/unit/virt/vmwareapi/test_ds_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_ds_util.py
@@ -281,7 +281,7 @@ class DsUtilTestCase(test.NoDBTestCase):
                 return
 
             # Sentinel that get_datastore's use of vim has changed
-            self.fail('Unexpected vim call in get_datastore: %s' % method)
+            self.fail('Unexpected vim call in get_datastore: {0!s}'.format(method))
 
         return mock.patch.object(self.session, '_call_method',
                                  side_effect=fake_call_method)
@@ -344,8 +344,7 @@ class DsUtilTestCase(test.NoDBTestCase):
         # Test with a regex that has no match
         # Checks if code raises DatastoreNotFound with a specific message
         datastore_invalid_regex = re.compile("unknown-ds")
-        exp_message = ("Datastore regex %s did not match any datastores"
-                       % datastore_invalid_regex.pattern)
+        exp_message = ("Datastore regex {0!s} did not match any datastores".format(datastore_invalid_regex.pattern))
         fake_objects = fake.FakeRetrieveResult()
         fake_objects.add_object(fake.Datastore("fake-ds0"))
         fake_objects.add_object(fake.Datastore("fake-ds1"))

--- a/nova/tests/unit/virt/vmwareapi/test_ds_util_datastore_selection.py
+++ b/nova/tests/unit/virt/vmwareapi/test_ds_util_datastore_selection.py
@@ -47,7 +47,7 @@ class VMwareDSUtilDatastoreSelectionTestCase(test.NoDBTestCase):
         objects = []
         for id, row in enumerate(mock_data):
             obj = ObjectContent(
-                obj=MoRef(value="ds-%03d" % id),
+                obj=MoRef(value="ds-{0:03d}".format(id)),
                 propSet=[])
             for index, value in enumerate(row):
                 obj.propSet.append(

--- a/nova/tests/unit/virt/vmwareapi/test_imagecache.py
+++ b/nova/tests/unit/virt/vmwareapi/test_imagecache.py
@@ -54,7 +54,7 @@ class ImageCacheManagerTestCase(test.NoDBTestCase):
             self.assertEqual('[fake-ds] fake-path', str(ds_path))
             if not self.exists:
                 return
-            ts = '%s%s' % (imagecache.TIMESTAMP_PREFIX,
+            ts = '{0!s}{1!s}'.format(imagecache.TIMESTAMP_PREFIX,
                            self._time.strftime(imagecache.TIMESTAMP_FORMAT))
             return ts
 

--- a/nova/tests/unit/virt/vmwareapi/test_read_write_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_read_write_util.py
@@ -39,6 +39,6 @@ class ReadWriteUtilTestCase(test.NoDBTestCase):
                                                         dict(),
                                                         folder)
             param_list = {"dcPath": 'fake_dc', "dsName": 'fake_ds'}
-            base_url = 'https://[%s]:%s/folder/%s' % (ipv6_host, port, folder)
+            base_url = 'https://[{0!s}]:{1!s}/folder/{2!s}'.format(ipv6_host, port, folder)
             base_url += '?' + urllib.urlencode(param_list)
             self.assertEqual(base_url, reader._base_url)

--- a/nova/tests/unit/virt/vmwareapi/test_vm_util.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vm_util.py
@@ -1785,12 +1785,12 @@ class VMwareVMUtilTestCase(test.NoDBTestCase):
         self.assertEqual(expected, name)
 
         display_name = 'fira'
-        expected = 'fira (%s)' % uuid
+        expected = 'fira ({0!s})'.format(uuid)
         name = vm_util._get_vm_name(display_name, uuid)
         self.assertEqual(expected, name)
 
         display_name = 'X' * 255
-        expected = '%s (%s)' % ('X' * 41, uuid)
+        expected = '{0!s} ({1!s})'.format('X' * 41, uuid)
         name = vm_util._get_vm_name(display_name, uuid)
         self.assertEqual(expected, name)
         self.assertEqual(len(name), 80)

--- a/nova/tests/unit/virt/vmwareapi/test_vmops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_vmops.py
@@ -88,7 +88,7 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
             'memory_mb': 512,
             'image_ref': self._image_id,
             'root_gb': 10,
-            'node': '%s(%s)' % (cluster.mo_id, cluster.name),
+            'node': '{0!s}({1!s})'.format(cluster.mo_id, cluster.name),
             'expected_attrs': ['system_metadata'],
         }
         self._instance = fake_instance.fake_instance_obj(
@@ -1163,7 +1163,7 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
                 self._ds, self._dc_info, mock_imagecache, extra_specs)
 
         sized_cached_image_ds_loc = cache_root_folder.join(
-                "%s.%s.vmdk" % (self._image_id, vi.root_gb))
+                "{0!s}.{1!s}.vmdk".format(self._image_id, vi.root_gb))
 
         self._vmops._volumeops = mock.Mock()
         mock_attach_disk_to_vm = self._vmops._volumeops.attach_disk_to_vm
@@ -1220,7 +1220,7 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
 
         self._vmops._use_disk_image_as_full_clone("fake_vm_ref", vi)
 
-        fake_path = '[fake_ds] %(uuid)s/%(uuid)s.vmdk' % {'uuid': self._uuid}
+        fake_path = '[fake_ds] {uuid!s}/{uuid!s}.vmdk'.format(**{'uuid': self._uuid})
         mock_copy_virtual_disk.assert_called_once_with(
                 self._session, self._dc_info.ref,
                 str(vi.cache_image_path),
@@ -1271,7 +1271,7 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
                 "fake_vm_ref", self._instance, self._ds.ref,
                 str(vi.cache_image_path))
 
-        fake_path = '[fake_ds] %(uuid)s/%(uuid)s.vmdk' % {'uuid': self._uuid}
+        fake_path = '[fake_ds] {uuid!s}/{uuid!s}.vmdk'.format(**{'uuid': self._uuid})
         if with_root_disk:
             mock_create_virtual_disk.assert_called_once_with(
                     self._session, self._dc_info.ref,
@@ -1460,7 +1460,7 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
             mock_enlist_image.assert_called_once_with(
                         self._image_id, self._ds, self._dc_info.ref)
 
-            upload_file_name = 'vmware_temp/tmp-uuid/%s/%s-flat.vmdk' % (
+            upload_file_name = 'vmware_temp/tmp-uuid/{0!s}/{1!s}-flat.vmdk'.format(
                     self._image_id, self._image_id)
             _fetch_image.assert_called_once_with(
                     self._context,
@@ -1480,10 +1480,8 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
             self._verify_spawn_method_calls(_call_method, extras)
 
             dc_ref = 'fake_dc_ref'
-            source_file = six.text_type('[fake_ds] vmware_base/%s/%s.vmdk' %
-                          (self._image_id, self._image_id))
-            dest_file = six.text_type('[fake_ds] vmware_base/%s/%s.%d.vmdk' %
-                          (self._image_id, self._image_id,
+            source_file = six.text_type('[fake_ds] vmware_base/{0!s}/{1!s}.vmdk'.format(self._image_id, self._image_id))
+            dest_file = six.text_type('[fake_ds] vmware_base/{0!s}/{1!s}.{2:d}.vmdk'.format(self._image_id, self._image_id,
                           self._instance['root_gb']))
             # TODO(dims): add more tests for copy_virtual_disk after
             # the disk/image code in spawn gets refactored
@@ -1523,11 +1521,11 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
         self.assertEqual(self._instance.uuid, vi.instance.uuid)
         self.assertEqual(extra_specs, vi._extra_specs)
 
-        cache_image_path = '[%s] vmware_base/%s/%s.vmdk' % (
+        cache_image_path = '[{0!s}] vmware_base/{1!s}/{2!s}.vmdk'.format(
             self._ds.name, self._image_id, self._image_id)
         self.assertEqual(cache_image_path, str(vi.cache_image_path))
 
-        cache_image_folder = '[%s] vmware_base/%s' % (
+        cache_image_folder = '[{0!s}] vmware_base/{1!s}'.format(
             self._ds.name, self._image_id)
         self.assertEqual(cache_image_folder, str(vi.cache_image_folder))
 
@@ -1730,7 +1728,7 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
             mock_caa.assert_called_once_with(
                 self._instance, 'fake-vm-ref',
                 vi.dc_info, 1 * units.Mi, 'virtio',
-                '[fake_ds] %s/ephemeral_0.vmdk' % self._uuid)
+                '[fake_ds] {0!s}/ephemeral_0.vmdk'.format(self._uuid))
 
     def _test_create_ephemeral_from_instance(self, bdi):
         vi = self._get_fake_vi()
@@ -1745,7 +1743,7 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
             mock_caa.assert_called_once_with(
                 self._instance, 'fake-vm-ref',
                 vi.dc_info, 1 * units.Mi, constants.DEFAULT_ADAPTER_TYPE,
-                '[fake_ds] %s/ephemeral_0.vmdk' % self._uuid)
+                '[fake_ds] {0!s}/ephemeral_0.vmdk'.format(self._uuid))
 
     def test_create_ephemeral_with_bdi_but_no_ephemerals(self):
         block_device_info = {'ephemerals': []}
@@ -2160,8 +2158,8 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
         vi = self._make_vm_config_info(is_iso=True)
         tmp_dir_loc, tmp_image_ds_loc = self._vmops._prepare_iso_image(vi)
 
-        expected_tmp_dir_path = '[%s] vmware_temp/tmp-uuid' % (self._ds.name)
-        expected_image_path = '[%s] vmware_temp/tmp-uuid/%s/%s.iso' % (
+        expected_tmp_dir_path = '[{0!s}] vmware_temp/tmp-uuid'.format((self._ds.name))
+        expected_image_path = '[{0!s}] vmware_temp/tmp-uuid/{1!s}/{2!s}.iso'.format(
                 self._ds.name, self._image_id, self._image_id)
 
         self.assertEqual(str(tmp_dir_loc), expected_tmp_dir_path)
@@ -2172,8 +2170,8 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
         vi = self._make_vm_config_info(is_sparse_disk=True)
         tmp_dir_loc, tmp_image_ds_loc = self._vmops._prepare_sparse_image(vi)
 
-        expected_tmp_dir_path = '[%s] vmware_temp/tmp-uuid' % (self._ds.name)
-        expected_image_path = '[%s] vmware_temp/tmp-uuid/%s/%s' % (
+        expected_tmp_dir_path = '[{0!s}] vmware_temp/tmp-uuid'.format((self._ds.name))
+        expected_image_path = '[{0!s}] vmware_temp/tmp-uuid/{1!s}/{2!s}'.format(
                 self._ds.name, self._image_id, "tmp-sparse.vmdk")
 
         self.assertEqual(str(tmp_dir_loc), expected_tmp_dir_path)
@@ -2191,12 +2189,12 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
         vi = self._make_vm_config_info()
         tmp_dir_loc, tmp_image_ds_loc = self._vmops._prepare_flat_image(vi)
 
-        expected_tmp_dir_path = '[%s] vmware_temp/tmp-uuid' % (self._ds.name)
-        expected_image_path = '[%s] vmware_temp/tmp-uuid/%s/%s-flat.vmdk' % (
+        expected_tmp_dir_path = '[{0!s}] vmware_temp/tmp-uuid'.format((self._ds.name))
+        expected_image_path = '[{0!s}] vmware_temp/tmp-uuid/{1!s}/{2!s}-flat.vmdk'.format(
                 self._ds.name, self._image_id, self._image_id)
-        expected_image_path_parent = '[%s] vmware_temp/tmp-uuid/%s' % (
+        expected_image_path_parent = '[{0!s}] vmware_temp/tmp-uuid/{1!s}'.format(
                 self._ds.name, self._image_id)
-        expected_path_to_create = '[%s] vmware_temp/tmp-uuid/%s/%s.vmdk' % (
+        expected_path_to_create = '[{0!s}] vmware_temp/tmp-uuid/{1!s}/{2!s}.vmdk'.format(
                 self._ds.name, self._image_id, self._image_id)
 
         mock_mkdir.assert_called_once_with(
@@ -2227,7 +2225,7 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
         mock_file_move.assert_called_once_with(
                 self._session, self._dc_info.ref,
                 tmp_image_ds_loc.parent,
-                DsPathMatcher('[fake_ds] vmware_base/%s' % self._image_id))
+                DsPathMatcher('[fake_ds] vmware_base/{0!s}'.format(self._image_id)))
 
     @mock.patch.object(ds_util, 'file_move')
     def test_cache_flat_image(self, mock_file_move):
@@ -2239,7 +2237,7 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
         mock_file_move.assert_called_once_with(
                 self._session, self._dc_info.ref,
                 tmp_image_ds_loc.parent,
-                DsPathMatcher('[fake_ds] vmware_base/%s' % self._image_id))
+                DsPathMatcher('[fake_ds] vmware_base/{0!s}'.format(self._image_id)))
 
     @mock.patch.object(ds_util, 'disk_move')
     @mock.patch.object(ds_util, 'mkdir')
@@ -2250,13 +2248,12 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
 
         mock_mkdir.assert_called_once_with(
             self._session,
-            DsPathMatcher('[fake_ds] vmware_base/%s' % self._image_id),
+            DsPathMatcher('[fake_ds] vmware_base/{0!s}'.format(self._image_id)),
             self._dc_info.ref)
         mock_disk_move.assert_called_once_with(
                 self._session, self._dc_info.ref,
                 mock.sentinel.tmp_image,
-                DsPathMatcher('[fake_ds] vmware_base/%s/%s.vmdk' %
-                              (self._image_id, self._image_id)))
+                DsPathMatcher('[fake_ds] vmware_base/{0!s}/{1!s}.vmdk'.format(self._image_id, self._image_id)))
 
     @mock.patch.object(ds_util, 'file_move')
     @mock.patch.object(vm_util, 'copy_virtual_disk')
@@ -2269,13 +2266,13 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
                                 mock_file_move):
         vi = self._make_vm_config_info(is_sparse_disk=True)
 
-        sparse_disk_path = "[%s] vmware_temp/tmp-uuid/%s/tmp-sparse.vmdk" % (
+        sparse_disk_path = "[{0!s}] vmware_temp/tmp-uuid/{1!s}/tmp-sparse.vmdk".format(
                 self._ds.name, self._image_id)
         tmp_image_ds_loc = ds_obj.DatastorePath.parse(sparse_disk_path)
 
         self._vmops._cache_sparse_image(vi, tmp_image_ds_loc)
 
-        target_disk_path = "[%s] vmware_temp/tmp-uuid/%s/%s.vmdk" % (
+        target_disk_path = "[{0!s}] vmware_temp/tmp-uuid/{1!s}/{2!s}.vmdk".format(
                 self._ds.name,
                 self._image_id, self._image_id)
         mock_copy_virtual_disk.assert_called_once_with(
@@ -2484,12 +2481,12 @@ class VMwareVMOpsTestCase(test.NoDBTestCase):
     def test_get_folder_name(self):
         uuid = uuidutils.generate_uuid()
         name = 'fira'
-        expected = 'fira (%s)' % uuid
+        expected = 'fira ({0!s})'.format(uuid)
         folder_name = self._vmops._get_folder_name(name, uuid)
         self.assertEqual(expected, folder_name)
 
         name = 'X' * 255
-        expected = '%s (%s)' % ('X' * 40, uuid)
+        expected = '{0!s} ({1!s})'.format('X' * 40, uuid)
         folder_name = self._vmops._get_folder_name(name, uuid)
         self.assertEqual(expected, folder_name)
         self.assertEqual(79, len(folder_name))

--- a/nova/tests/unit/virt/vmwareapi/test_volumeops.py
+++ b/nova/tests/unit/virt/vmwareapi/test_volumeops.py
@@ -92,7 +92,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
 
     def _fake_call_get_object_property(self, uuid, result):
         def fake_call_method(vim, method, vm_ref, prop):
-            expected_prop = 'config.extraConfig["volume-%s"]' % uuid
+            expected_prop = 'config.extraConfig["volume-{0!s}"]'.format(uuid)
             self.assertEqual('VirtualMachine', vm_ref._type)
             self.assertEqual(expected_prop, prop)
             return result
@@ -102,7 +102,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
         vm_ref = vmwareapi_fake.ManagedObjectReference('VirtualMachine',
                                                        'vm-134')
         uuid = '1234'
-        opt_val = vmwareapi_fake.OptionValue('volume-%s' % uuid, 'volume-val')
+        opt_val = vmwareapi_fake.OptionValue('volume-{0!s}'.format(uuid), 'volume-val')
         fake_call = self._fake_call_get_object_property(uuid, opt_val)
         with mock.patch.object(self._session, "_call_method", fake_call):
             val = self._volumeops._get_volume_uuid(vm_ref, uuid)
@@ -159,7 +159,7 @@ class VMwareVolumeOpsTestCase(test.NoDBTestCase):
 
             get_vm_extra_config_spec.assert_called_once_with(
                 self._volumeops._session.vim.client.factory,
-                {'volume-%s' % volume_uuid: device_uuid})
+                {'volume-{0!s}'.format(volume_uuid): device_uuid})
             reconfigure_vm.assert_called_once_with(self._volumeops._session,
                                                    mock.sentinel.vm_ref,
                                                    mock.sentinel.extra_config)

--- a/nova/tests/unit/virt/xenapi/client/test_session.py
+++ b/nova/tests/unit/virt/xenapi/client/test_session.py
@@ -36,7 +36,7 @@ class SessionTestCase(stubs.XenAPITestBaseNoDB):
 
         session.XenAPISession('http://someserver', 'username', 'password')
 
-        expected_version = '%s %s %s' % (version.vendor_string(),
+        expected_version = '{0!s} {1!s} {2!s}'.format(version.vendor_string(),
                                          version.product_string(),
                                          version.version_string_with_package())
         sess.login_with_password.assert_called_with('username', 'password',

--- a/nova/tests/unit/virt/xenapi/test_driver.py
+++ b/nova/tests/unit/virt/xenapi/test_driver.py
@@ -124,7 +124,7 @@ class XenAPIDriverTestCase(stubs.XenAPITestBaseNoDB):
     def test_get_volume_connector(self):
         ip = '123.123.123.123'
         driver = self._get_driver()
-        self.flags(connection_url='http://%s' % ip,
+        self.flags(connection_url='http://{0!s}'.format(ip),
                    connection_password='test_pass', group='xenserver')
         self.stubs.Set(driver.host_state, 'get_host_stats', self.host_stats)
 
@@ -138,7 +138,7 @@ class XenAPIDriverTestCase(stubs.XenAPITestBaseNoDB):
         my_ip = '123.123.123.123'
         connection_ip = '124.124.124.124'
         driver = self._get_driver()
-        self.flags(connection_url='http://%s' % connection_ip,
+        self.flags(connection_url='http://{0!s}'.format(connection_ip),
                    group='xenserver')
         self.flags(my_ip=my_ip, my_block_storage_ip=my_ip)
 

--- a/nova/tests/unit/virt/xenapi/test_vif.py
+++ b/nova/tests/unit/virt/xenapi/test_vif.py
@@ -58,7 +58,7 @@ def fake_call_xenapi(method, *args):
             return "fake_vif_ref"
         else:
             raise exception.Exception("VIF existed")
-    return "Unexpected call_xenapi: %s.%s" % (method, args)
+    return "Unexpected call_xenapi: {0!s}.{1!s}".format(method, args)
 
 
 class XenVIFDriverTestBase(stubs.XenAPITestBaseNoDB):

--- a/nova/tests/unit/virt/xenapi/test_vm_utils.py
+++ b/nova/tests/unit/virt/xenapi/test_vm_utils.py
@@ -500,7 +500,7 @@ class ResizeHelpersTestCase(VMUtilsTestBase):
         utils.execute('parted', '--script', path, 'rm', '1',
             run_as_root=True)
         utils.execute('parted', '--script', path, 'mkpart',
-            'primary', '%ds' % start, '%ds' % end, run_as_root=True)
+            'primary', '{0:d}s'.format(start), '{0:d}s'.format(end), run_as_root=True)
 
     def _call_parted_boot_flag(self, path):
         utils.execute('parted', '--script', path, 'set', '1',
@@ -511,7 +511,7 @@ class ResizeHelpersTestCase(VMUtilsTestBase):
         self.mox.StubOutWithMock(utils, 'execute')
 
         dev_path = "/dev/fake"
-        partition_path = "%s1" % dev_path
+        partition_path = "{0!s}1".format(dev_path)
         vm_utils._repair_filesystem(partition_path)
         self._call_tune2fs_remove_journal(partition_path)
         utils.execute("resize2fs", partition_path, "10s", run_as_root=True)
@@ -550,13 +550,13 @@ class ResizeHelpersTestCase(VMUtilsTestBase):
         self.mox.StubOutWithMock(utils, 'execute')
 
         dev_path = "/dev/fake"
-        partition_path = "%s1" % dev_path
+        partition_path = "{0!s}1".format(dev_path)
         new_sectors = 10
         vm_utils._repair_filesystem(partition_path)
         self._call_tune2fs_remove_journal(partition_path)
         mobj = utils.execute("resize2fs",
                              partition_path,
-                             "%ss" % new_sectors,
+                             "{0!s}s".format(new_sectors),
                              run_as_root=True)
         mobj.AndRaise(processutils.ProcessExecutionError)
         self.mox.ReplayAll()
@@ -569,7 +569,7 @@ class ResizeHelpersTestCase(VMUtilsTestBase):
         self.mox.StubOutWithMock(utils, 'execute')
 
         dev_path = "/dev/fake"
-        partition_path = "%s1" % dev_path
+        partition_path = "{0!s}1".format(dev_path)
         vm_utils._repair_filesystem(partition_path)
         self._call_tune2fs_remove_journal(partition_path)
         self._call_parted_mkpart(dev_path, 0, 29)
@@ -1772,7 +1772,7 @@ class GetAllVdiForVMTestCase(VMUtilsTestBase):
     def _setup_get_all_vdi_uuids_for_vm(self, vm_get_vbd_refs,
                                        vbd_get_rec, vdi_get_uuid):
         def fake_vbd_get_rec(session, vbd_ref):
-            return {'userdevice': vbd_ref, 'VDI': "vdi_ref_%s" % vbd_ref}
+            return {'userdevice': vbd_ref, 'VDI': "vdi_ref_{0!s}".format(vbd_ref)}
 
         def fake_vdi_get_uuid(session, vdi_ref):
             return vdi_ref
@@ -2021,13 +2021,13 @@ class ImportMigratedDisksTestCase(VMUtilsTestBase):
         inst_uuid = instance.uuid
         inst_name = instance.name
         expected_calls = [mock.call("s", instance,
-                                    "%s_ephemeral_1" % inst_uuid,
+                                    "{0!s}_ephemeral_1".format(inst_uuid),
                                     "ephemeral",
-                                    "%s ephemeral (1)" % inst_name),
+                                    "{0!s} ephemeral (1)".format(inst_name)),
                           mock.call("s", instance,
-                                    "%s_ephemeral_2" % inst_uuid,
+                                    "{0!s}_ephemeral_2".format(inst_uuid),
                                     "ephemeral",
-                                    "%s ephemeral (2)" % inst_name)]
+                                    "{0!s} ephemeral (2)".format(inst_name))]
         self.assertEqual(expected_calls, mock_migrate.call_args_list)
 
     @mock.patch.object(vm_utils, 'get_ephemeral_disk_sizes')
@@ -2135,7 +2135,7 @@ class StripBaseMirrorTestCase(VMUtilsTestBase):
                 return ['VBD_ref_1', 'VBD_ref_2']
             if method == "VBD.get_VDI":
                 return 'VDI' + arg[3:]
-            return "Unexpected call_xenapi: %s.%s" % (method, arg)
+            return "Unexpected call_xenapi: {0!s}.{1!s}".format(method, arg)
 
         session = mock.Mock()
         session.call_xenapi.side_effect = call_xenapi

--- a/nova/tests/unit/virt/xenapi/test_volume_utils.py
+++ b/nova/tests/unit/virt/xenapi/test_volume_utils.py
@@ -152,7 +152,7 @@ class ParseVolumeInfoTestCase(stubs.XenAPITestBaseNoDB):
         for (input, expected) in six.iteritems(cases):
             actual = volume_utils._mountpoint_to_number(input)
             self.assertEqual(actual, expected,
-                    '%s yielded %s, not %s' % (input, actual, expected))
+                    '{0!s} yielded {1!s}, not {2!s}'.format(input, actual, expected))
 
     @classmethod
     def _make_connection_info(cls):

--- a/nova/tests/unit/virt/xenapi/test_xenapi.py
+++ b/nova/tests/unit/virt/xenapi/test_xenapi.py
@@ -470,7 +470,7 @@ class XenAPIVMTestCase(stubs.XenAPITestBase):
         # Note(sulo): We don't care about session id in test
         # they will always differ so strip that out
         actual_path = console.internal_access_path.split('&')[0]
-        expected_path = "/console?ref=%s" % str(vm_ref)
+        expected_path = "/console?ref={0!s}".format(str(vm_ref))
 
         self.assertEqual(expected_path, actual_path)
 
@@ -487,7 +487,7 @@ class XenAPIVMTestCase(stubs.XenAPITestBase):
         # Note(sulo): We don't care about session id in test
         # they will always differ so strip that out
         actual_path = console.internal_access_path.split('&')[0]
-        expected_path = "/console?ref=%s" % str(rescue_vm)
+        expected_path = "/console?ref={0!s}".format(str(rescue_vm))
 
         self.assertEqual(expected_path, actual_path)
 
@@ -708,9 +708,9 @@ class XenAPIVMTestCase(stubs.XenAPITestBase):
                 # there even after the cleanup
                 if 'other_config' in vdi_rec:
                     if 'image-id' not in vdi_rec['other_config']:
-                        self.fail('Found unexpected VDI:%s' % vdi_ref)
+                        self.fail('Found unexpected VDI:{0!s}'.format(vdi_ref))
                 else:
-                    self.fail('Found unexpected VDI:%s' % vdi_ref)
+                    self.fail('Found unexpected VDI:{0!s}'.format(vdi_ref))
 
     def _test_spawn(self, image_ref, kernel_id, ramdisk_id,
                     instance_type_id="3", os_type="linux",
@@ -1284,7 +1284,7 @@ iface eth0 inet6 static
         conn.rescue(self.context, instance, [], image_meta, '')
 
         vm = xenapi_fake.get_record('VM', vm_ref)
-        rescue_name = "%s-rescue" % vm["name_label"]
+        rescue_name = "{0!s}-rescue".format(vm["name_label"])
         rescue_ref = vm_utils.lookup(session, rescue_name)
         rescue_vm = xenapi_fake.get_record('VM', rescue_ref)
 
@@ -2717,7 +2717,7 @@ class XenAPIDom0IptablesFirewallTestCase(stubs.XenAPITestBase):
         for rule in in_rules:
             if 'nova' not in rule:
                 self.assertIn(rule, self._out_rules,
-                              'Rule went missing: %s' % rule)
+                              'Rule went missing: {0!s}'.format(rule))
 
         instance_chain = None
         for rule in self._out_rules:
@@ -2730,7 +2730,7 @@ class XenAPIDom0IptablesFirewallTestCase(stubs.XenAPITestBase):
         security_group_chain = None
         for rule in self._out_rules:
             # This is pretty crude, but it'll do for now
-            if '-A %s -j' % instance_chain in rule:
+            if '-A {0!s} -j'.format(instance_chain) in rule:
                 security_group_chain = rule.split(' ')[-1]
                 break
         self.assertTrue(security_group_chain,
@@ -4145,7 +4145,7 @@ class XenAPIFakeTestCase(test.NoDBTestCase):
 
         for query in tests.keys():
             expected = tests[query]
-            fail_msg = "for test '%s'" % query
+            fail_msg = "for test '{0!s}'".format(query)
             self.assertEqual(xenapi_fake._query_matches(record, query),
                              expected, fail_msg)
 
@@ -4157,6 +4157,6 @@ class XenAPIFakeTestCase(test.NoDBTestCase):
                  ]
 
         for query in tests:
-            fail_msg = "for test '%s'" % query
+            fail_msg = "for test '{0!s}'".format(query)
             self.assertFalse(xenapi_fake._query_matches(record, query),
                              fail_msg)

--- a/nova/tests/unit/volume/encryptors/test_cryptsetup.py
+++ b/nova/tests/unit/volume/encryptors/test_cryptsetup.py
@@ -67,7 +67,7 @@ class CryptsetupEncryptorTestCase(test_base.VolumeEncryptorTestCase):
                       self.dev_path, process_input='0' * 32,
                       run_as_root=True, check_exit_code=True),
             mock.call('ln', '--symbolic', '--force',
-                      '/dev/mapper/%s' % self.dev_name, self.symlink_path,
+                      '/dev/mapper/{0!s}'.format(self.dev_name), self.symlink_path,
                       run_as_root=True, check_exit_code=True),
         ])
         self.assertEqual(2, mock_execute.call_count)

--- a/nova/tests/unit/volume/encryptors/test_luks.py
+++ b/nova/tests/unit/volume/encryptors/test_luks.py
@@ -38,7 +38,7 @@ class LuksEncryptorTestCase(test_cryptsetup.CryptsetupEncryptorTestCase):
     @mock.patch('nova.volume.encryptors.luks.LOG')
     @mock.patch('nova.utils.execute')
     def test_is_luks_with_error(self, mock_execute, mock_log):
-        error_msg = "Device %s is not a valid LUKS device." % self.dev_path
+        error_msg = "Device {0!s} is not a valid LUKS device.".format(self.dev_path)
         mock_execute.side_effect = \
                 processutils.ProcessExecutionError(exit_code=1,
                                                    stderr=error_msg)
@@ -89,7 +89,7 @@ class LuksEncryptorTestCase(test_cryptsetup.CryptsetupEncryptorTestCase):
                       self.dev_name, process_input='0' * 32,
                       run_as_root=True, check_exit_code=True),
             mock.call('ln', '--symbolic', '--force',
-                      '/dev/mapper/%s' % self.dev_name, self.symlink_path,
+                      '/dev/mapper/{0!s}'.format(self.dev_name), self.symlink_path,
                       run_as_root=True, check_exit_code=True),
         ])
         self.assertEqual(2, mock_execute.call_count)
@@ -123,7 +123,7 @@ class LuksEncryptorTestCase(test_cryptsetup.CryptsetupEncryptorTestCase):
                       self.dev_name, process_input='0' * 32,
                       run_as_root=True, check_exit_code=True),
             mock.call('ln', '--symbolic', '--force',
-                      '/dev/mapper/%s' % self.dev_name, self.symlink_path,
+                      '/dev/mapper/{0!s}'.format(self.dev_name), self.symlink_path,
                       run_as_root=True, check_exit_code=True),
         ], any_order=False)
         self.assertEqual(5, mock_execute.call_count)

--- a/nova/utils.py
+++ b/nova/utils.py
@@ -67,7 +67,7 @@ monkey_patch_opts = [
                 help='Whether to apply monkey patching'),
     cfg.ListOpt('monkey_patch_modules',
                 default=[
-                  'nova.compute.api:%s' % (notify_decorator)
+                  'nova.compute.api:{0!s}'.format((notify_decorator))
                   ],
                 help='List of modules/decorators to monkey patch'),
 ]
@@ -250,7 +250,7 @@ def get_root_helper():
     if CONF.workarounds.disable_rootwrap:
         cmd = 'sudo'
     else:
-        cmd = 'sudo nova-rootwrap %s' % CONF.rootwrap_config
+        cmd = 'sudo nova-rootwrap {0!s}'.format(CONF.rootwrap_config)
     return cmd
 
 
@@ -411,7 +411,7 @@ def trycmd(*args, **kwargs):
 def generate_uid(topic, size=8):
     characters = '01234567890abcdefghijklmnopqrstuvwxyz'
     choices = [random.choice(characters) for _x in range(size)]
-    return '%s-%s' % (topic, ''.join(choices))
+    return '{0!s}-{1!s}'.format(topic, ''.join(choices))
 
 
 # Default symbols to use for passwords. Avoids visually confusing characters.
@@ -690,7 +690,7 @@ def safe_ip_format(ip):
     """
     try:
         if netaddr.IPAddress(ip).version == 6:
-            return '[%s]' % ip
+            return '[{0!s}]'.format(ip)
     except (TypeError, netaddr.AddrFormatError):  # hostname
         pass
     # it's IPv4 or hostname
@@ -733,15 +733,15 @@ def monkey_patch():
         for key, value in module_data.items():
             # set the decorator for the class methods
             if isinstance(value, pyclbr.Class):
-                clz = importutils.import_class("%s.%s" % (module, key))
+                clz = importutils.import_class("{0!s}.{1!s}".format(module, key))
                 for method, func in inspect.getmembers(clz, is_method):
                     setattr(clz, method,
-                        decorator("%s.%s.%s" % (module, key, method), func))
+                        decorator("{0!s}.{1!s}.{2!s}".format(module, key, method), func))
             # set the decorator for the function
             if isinstance(value, pyclbr.Function):
-                func = importutils.import_class("%s.%s" % (module, key))
+                func = importutils.import_class("{0!s}.{1!s}".format(module, key))
                 setattr(sys.modules[module], key,
-                    decorator("%s.%s" % (module, key), func))
+                    decorator("{0!s}.{1!s}".format(module, key), func))
 
 
 def make_dev_path(dev, partition=None, base='/dev'):
@@ -860,7 +860,7 @@ def generate_mac_address():
            random.randint(0x00, 0xff),
            random.randint(0x00, 0xff),
            random.randint(0x00, 0xff)]
-    return ':'.join(map(lambda x: "%02x" % x, mac))
+    return ':'.join(map(lambda x: "{0:02x}".format(x), mac))
 
 
 def read_file_as_root(file_path):
@@ -1396,7 +1396,7 @@ def filter_and_format_resource_metadata(resource_type, resource_list,
 
         for (k, v) in metadata.items():
             formatted_metadata_list.append({'key': k, 'value': v,
-                             '%s_id' % resource_type: _get_id(res)})
+                             '{0!s}_id'.format(resource_type): _get_id(res)})
 
     return formatted_metadata_list
 

--- a/nova/version.py
+++ b/nova/version.py
@@ -85,4 +85,4 @@ def version_string_with_package():
     if package_string() is None:
         return version_info.version_string()
     else:
-        return "%s-%s" % (version_info.version_string(), package_string())
+        return "{0!s}-{1!s}".format(version_info.version_string(), package_string())

--- a/nova/virt/configdrive.py
+++ b/nova/virt/configdrive.py
@@ -85,10 +85,10 @@ class ConfigDriveBuilder(object):
             self._add_file(basedir, data[0], data[1])
 
     def _make_iso9660(self, path, tmpdir):
-        publisher = "%(product)s %(version)s" % {
+        publisher = "{product!s} {version!s}".format(**{
             'product': version.product_string(),
             'version': version.version_string_with_package()
-            }
+            })
 
         utils.execute(CONF.mkisofs_cmd,
                       '-o', path,
@@ -118,7 +118,7 @@ class ConfigDriveBuilder(object):
             mounted = False
             try:
                 _, err = utils.trycmd(
-                    'mount', '-o', 'loop,uid=%d,gid=%d' % (os.getuid(),
+                    'mount', '-o', 'loop,uid={0:d},gid={1:d}'.format(os.getuid(),
                                                            os.getgid()),
                     path,
                     mountdir,

--- a/nova/virt/disk/api.py
+++ b/nova/virt/disk/api.py
@@ -451,8 +451,8 @@ def teardown_container(container_dir, container_root_device=None):
                 utils.execute('qemu-nbd', '-d', container_root_device,
                               run_as_root=True)
             else:
-                LOG.debug('No release necessary for block device %s' %
-                          container_root_device)
+                LOG.debug('No release necessary for block device {0!s}'.format(
+                          container_root_device))
     except Exception:
         LOG.exception(_LE('Failed to teardown container filesystem'))
 
@@ -485,7 +485,7 @@ def inject_data_into_fs(fs, key, net, metadata, admin_password, files,
     status = True
     for inject in ('key', 'net', 'metadata', 'admin_password', 'files'):
         inject_val = locals()[inject]
-        inject_func = globals()['_inject_%s_into_fs' % inject]
+        inject_func = globals()['_inject_{0!s}_into_fs'.format(inject)]
         if inject_val:
             try:
                 inject_func(inject_val, fs)
@@ -543,7 +543,7 @@ def _setup_selinux_for_keys(fs, sshdir):
     restorecon = [
         '\n',
         '# Added by Nova to ensure injected ssh keys have the right context\n',
-        'restorecon -RF %s 2>/dev/null || :\n' % sshdir,
+        'restorecon -RF {0!s} 2>/dev/null || :\n'.format(sshdir),
     ]
 
     if not fs.has_file(rclocal):

--- a/nova/virt/disk/mount/api.py
+++ b/nova/virt/disk/mount/api.py
@@ -184,13 +184,13 @@ class Mount(object):
         """Map partitions of the device to the file system namespace."""
         assert(os.path.exists(self.device))
         LOG.debug("Map dev %s", self.device)
-        automapped_path = '/dev/%sp%s' % (os.path.basename(self.device),
+        automapped_path = '/dev/{0!s}p{1!s}'.format(os.path.basename(self.device),
                                               self.partition)
 
         if self.partition == -1:
             self.error = _('partition search unsupported with %s') % self.mode
         elif self.partition and not os.path.exists(automapped_path):
-            map_path = '/dev/mapper/%sp%s' % (os.path.basename(self.device),
+            map_path = '/dev/mapper/{0!s}p{1!s}'.format(os.path.basename(self.device),
                                               self.partition)
             assert(not os.path.exists(map_path))
 

--- a/nova/virt/disk/mount/nbd.py
+++ b/nova/virt/disk/mount/nbd.py
@@ -43,7 +43,7 @@ class NbdMount(api.Mount):
     def _find_unused(self, devices):
         for device in devices:
             if not os.path.exists(os.path.join('/sys/block/', device, 'pid')):
-                if not os.path.exists('/var/lock/qemu-nbd-%s' % device):
+                if not os.path.exists('/var/lock/qemu-nbd-{0!s}'.format(device)):
                     return device
                 else:
                     LOG.error(_LE('NBD error - previous umount did not '
@@ -86,7 +86,7 @@ class NbdMount(api.Mount):
 
         # NOTE(vish): this forks into another process, so give it a chance
         # to set up before continuing
-        pidfile = "/sys/block/%s/pid" % os.path.basename(device)
+        pidfile = "/sys/block/{0!s}/pid".format(os.path.basename(device))
         for _i in range(CONF.timeout_nbd):
             if os.path.exists(pidfile):
                 self.device = device

--- a/nova/virt/disk/vfs/guestfs.py
+++ b/nova/virt/disk/vfs/guestfs.py
@@ -122,7 +122,7 @@ class VFSGuestFS(vfs.VFS):
                   {'image': self.image, 'part': str(self.partition)})
 
         if self.partition:
-            self.handle.mount_options("", "/dev/sda%d" % self.partition, "/")
+            self.handle.mount_options("", "/dev/sda{0:d}".format(self.partition), "/")
         else:
             self.handle.mount_options("", "/dev/sda", "/")
 
@@ -206,7 +206,7 @@ class VFSGuestFS(vfs.VFS):
                 self.handle.add_drive_opts(self.image.path,
                                            format=self.image.format)
             elif isinstance(self.image, imgmodel.RBDImage):
-                self.handle.add_drive_opts("%s/%s" % (self.image.pool,
+                self.handle.add_drive_opts("{0!s}/{1!s}".format(self.image.pool,
                                                       self.image.name),
                                            protocol="rbd",
                                            format=imgmodel.FORMAT_RAW,

--- a/nova/virt/disk/vfs/localfs.py
+++ b/nova/virt/disk/vfs/localfs.py
@@ -138,7 +138,7 @@ class VFSLocalFS(vfs.VFS):
         LOG.debug("Set permissions path=%(path)s mode=%(mode)o",
                   {'path': path, 'mode': mode})
         canonpath = self._canonical_path(path)
-        utils.execute('chmod', "%o" % mode, canonpath, run_as_root=True)
+        utils.execute('chmod', "{0:o}".format(mode), canonpath, run_as_root=True)
 
     def set_ownership(self, path, user, group):
         LOG.debug("Set permissions path=%(path)s "

--- a/nova/virt/event.py
+++ b/nova/virt/event.py
@@ -59,7 +59,7 @@ class Event(object):
         return self.timestamp
 
     def __repr__(self):
-        return "<%s: %s>" % (
+        return "<{0!s}: {1!s}>".format(
             self.__class__.__name__,
             self.timestamp)
 
@@ -82,7 +82,7 @@ class InstanceEvent(Event):
         return self.uuid
 
     def __repr__(self):
-        return "<%s: %s, %s>" % (
+        return "<{0!s}: {1!s}, {2!s}>".format(
             self.__class__.__name__,
             self.timestamp,
             self.uuid)
@@ -110,7 +110,7 @@ class LifecycleEvent(InstanceEvent):
         return NAMES.get(self.transition, _('Unknown'))
 
     def __repr__(self):
-        return "<%s: %s, %s => %s>" % (
+        return "<{0!s}: {1!s}, {2!s} => {3!s}>".format(
             self.__class__.__name__,
             self.timestamp,
             self.uuid,

--- a/nova/virt/firewall.py
+++ b/nova/virt/firewall.py
@@ -162,7 +162,7 @@ class IptablesFirewallDriver(FirewallDriver):
         self.iptables.apply()
 
     def _create_filter(self, ips, chain_name):
-        return ['-d %s -j $%s' % (ip, chain_name) for ip in ips]
+        return ['-d {0!s} -j ${1!s}'.format(ip, chain_name) for ip in ips]
 
     def _get_subnets(self, network_info, version):
         subnets = []
@@ -220,7 +220,7 @@ class IptablesFirewallDriver(FirewallDriver):
             self.iptables.ipv6['filter'].remove_chain(chain_name)
 
     def _instance_chain_name(self, instance):
-        return 'inst-%s' % (instance.id,)
+        return 'inst-{0!s}'.format(instance.id)
 
     def _do_basic_rules(self, ipv4_rules, ipv6_rules, network_info):
         # Always drop invalid packets
@@ -247,11 +247,11 @@ class IptablesFirewallDriver(FirewallDriver):
         v6_subnets = self._get_subnets(network_info, 6)
         cidrs = [subnet['cidr'] for subnet in v4_subnets]
         for cidr in cidrs:
-            ipv4_rules.append('-s %s -j ACCEPT' % (cidr,))
+            ipv4_rules.append('-s {0!s} -j ACCEPT'.format(cidr))
         if CONF.use_ipv6:
             cidrv6s = [subnet['cidr'] for subnet in v6_subnets]
             for cidrv6 in cidrv6s:
-                ipv6_rules.append('-s %s -j ACCEPT' % (cidrv6,))
+                ipv6_rules.append('-s {0!s} -j ACCEPT'.format(cidrv6))
 
     def _do_ra_rules(self, ipv6_rules, network_info):
         v6_subnets = self._get_subnets(network_info, 6)
@@ -259,7 +259,7 @@ class IptablesFirewallDriver(FirewallDriver):
 
         for gateway_v6 in gateways_v6:
             ipv6_rules.append(
-                    '-s %s/128 -p icmpv6 -j ACCEPT' % (gateway_v6,))
+                    '-s {0!s}/128 -p icmpv6 -j ACCEPT'.format(gateway_v6))
 
     def _build_icmp_rule(self, rule, version):
         icmp_type = rule.from_port
@@ -268,9 +268,9 @@ class IptablesFirewallDriver(FirewallDriver):
         if icmp_type == -1:
             icmp_type_arg = None
         else:
-            icmp_type_arg = '%s' % icmp_type
+            icmp_type_arg = '{0!s}'.format(icmp_type)
             if not icmp_code == -1:
-                icmp_type_arg += '/%s' % icmp_code
+                icmp_type_arg += '/{0!s}'.format(icmp_code)
 
         if icmp_type_arg:
             if version == 4:
@@ -282,10 +282,10 @@ class IptablesFirewallDriver(FirewallDriver):
 
     def _build_tcp_udp_rule(self, rule, version):
         if rule.from_port == rule.to_port:
-            return ['--dport', '%s' % (rule.from_port,)]
+            return ['--dport', '{0!s}'.format(rule.from_port)]
         else:
             return ['-m', 'multiport',
-                    '--dports', '%s:%s' % (rule.from_port,
+                    '--dports', '{0!s}:{1!s}'.format(rule.from_port,
                                            rule.to_port)]
 
     def instance_rules(self, instance, network_info):
@@ -364,7 +364,7 @@ class IptablesFirewallDriver(FirewallDriver):
 
                         LOG.debug('ips: %r', ips, instance=inst)
                         for ip in ips:
-                            subrule = args + ['-s %s' % ip]
+                            subrule = args + ['-s {0!s}'.format(ip)]
                             fw_rules += [' '.join(subrule)]
 
         ipv4_rules += ['-j $sg-fallback']

--- a/nova/virt/hardware.py
+++ b/nova/virt/hardware.py
@@ -148,7 +148,7 @@ def format_cpu_spec(cpuset, allow_ranges=True):
             if len(entry) == 1:
                 parts.append(str(entry[0]))
             else:
-                parts.append("%d-%d" % (entry[0], entry[len(entry) - 1]))
+                parts.append("{0:d}-{1:d}".format(entry[0], entry[len(entry) - 1]))
         return ",".join(parts)
     else:
         return ",".join(str(id) for id in sorted(cpuset))
@@ -943,7 +943,7 @@ def _numa_get_flavor_cpu_map_list(flavor):
     hw_numa_cpus_set = False
     extra_specs = flavor.get("extra_specs", {})
     for cellid in range(objects.ImageMetaProps.NUMA_NODES_MAX):
-        cpuprop = "hw:numa_cpus.%d" % cellid
+        cpuprop = "hw:numa_cpus.{0:d}".format(cellid)
         if cpuprop not in extra_specs:
             break
         hw_numa_cpus.append(
@@ -972,7 +972,7 @@ def _numa_get_flavor_mem_map_list(flavor):
     hw_numa_mem_set = False
     extra_specs = flavor.get("extra_specs", {})
     for cellid in range(objects.ImageMetaProps.NUMA_NODES_MAX):
-        memprop = "hw:numa_mem.%d" % cellid
+        memprop = "hw:numa_mem.{0:d}".format(cellid)
         if memprop not in extra_specs:
             break
         hw_numa_mem.append(int(extra_specs[memprop]))

--- a/nova/virt/hyperv/hostops.py
+++ b/nova/virt/hyperv/hostops.py
@@ -183,6 +183,6 @@ class HostOps(object):
         # and number of logged in users.
         # This is done to ensure the format of the returned
         # value is same as in libvirt
-        return "%s up %s,  0 users,  load average: 0, 0, 0" % (
+        return "{0!s} up {1!s},  0 users,  load average: 0, 0, 0".format(
                    str(time.strftime("%H:%M:%S")),
                    str(datetime.timedelta(milliseconds=int(tick_count64))))

--- a/nova/virt/hyperv/imagecache.py
+++ b/nova/virt/hyperv/imagecache.py
@@ -59,7 +59,7 @@ class ImageCache(object):
                 flavor_size=root_vhd_size, image_size=vhd_size)
         if root_vhd_internal_size > vhd_size:
             path_parts = os.path.splitext(vhd_path)
-            resized_vhd_path = '%s_%s%s' % (path_parts[0],
+            resized_vhd_path = '{0!s}_{1!s}{2!s}'.format(path_parts[0],
                                             root_vhd_size_gb,
                                             path_parts[1])
 

--- a/nova/virt/hyperv/migrationops.py
+++ b/nova/virt/hyperv/migrationops.py
@@ -64,7 +64,7 @@ class MigrationOps(object):
             if same_host:
                 # Since source and target are the same, we copy the files to
                 # a temporary location before moving them into place
-                dest_path = '%s_tmp' % instance_path
+                dest_path = '{0!s}_tmp'.format(instance_path)
                 if self._pathutils.exists(dest_path):
                     self._pathutils.rmtree(dest_path)
                 self._pathutils.makedirs(dest_path)

--- a/nova/virt/hyperv/pathutils.py
+++ b/nova/virt/hyperv/pathutils.py
@@ -44,8 +44,8 @@ class PathUtils(pathutils.PathUtils):
             else:
                 # Use an administrative share
                 path = local_instance_path.replace(':', '$')
-            return ('\\\\%(remote_server)s\\%(path)s' %
-                {'remote_server': remote_server, 'path': path})
+            return ('\\\\{remote_server!s}\\{path!s}'.format(**
+                {'remote_server': remote_server, 'path': path}))
         else:
             return local_instance_path
 
@@ -72,7 +72,7 @@ class PathUtils(pathutils.PathUtils):
 
     def get_instance_migr_revert_dir(self, instance_name, create_dir=False,
                                      remove_dir=False):
-        dir_name = '%s_revert' % instance_name
+        dir_name = '{0!s}_revert'.format(instance_name)
         return self._get_instances_sub_dir(dir_name, None, create_dir,
                                            remove_dir)
 

--- a/nova/virt/hyperv/vmops.py
+++ b/nova/virt/hyperv/vmops.py
@@ -602,7 +602,7 @@ class VMOps(object):
         # write it to a file.
         console_log_path = self._pathutils.get_vm_console_log_paths(
             instance_name)[0]
-        pipe_path = r'\\.\pipe\%s' % instance_uuid
+        pipe_path = r'\\.\pipe\{0!s}'.format(instance_uuid)
 
         @utils.synchronized(pipe_path)
         def log_serial_output():
@@ -660,7 +660,7 @@ class VMOps(object):
 
     def _create_vm_com_port_pipe(self, instance):
         # Creates a pipe to the COM 0 serial port of the specified vm.
-        pipe_path = r'\\.\pipe\%s' % instance.uuid
+        pipe_path = r'\\.\pipe\{0!s}'.format(instance.uuid)
         self._vmutils.get_vm_serial_port_connection(
             instance.name, update_connection=pipe_path)
 

--- a/nova/virt/images.py
+++ b/nova/virt/images.py
@@ -110,7 +110,7 @@ def get_info(context, image_href):
 
 
 def fetch_to_raw(context, image_href, path, user_id, project_id, max_size=0):
-    path_tmp = "%s.part" % path
+    path_tmp = "{0!s}.part".format(path)
     fetch(context, image_href, path_tmp, user_id, project_id,
           max_size=max_size)
 
@@ -148,7 +148,7 @@ def fetch_to_raw(context, image_href, path, user_id, project_id, max_size=0):
                 flavor_size=max_size, image_size=disk_size)
 
         if fmt != "raw" and CONF.force_raw_images:
-            staged = "%s.converted" % path
+            staged = "{0!s}.converted".format(path)
             LOG.debug("%s was %s, converting to raw", image_href, fmt)
             with fileutils.remove_path_on_error(staged):
                 try:

--- a/nova/virt/ironic/client_wrapper.py
+++ b/nova/virt/ironic/client_wrapper.py
@@ -90,7 +90,7 @@ class IronicClientWrapper(object):
         # Retries for Conflict exception
         kwargs['max_retries'] = max_retries
         kwargs['retry_interval'] = retry_interval
-        kwargs['os_ironic_api_version'] = '%d.%d' % IRONIC_API_VERSION
+        kwargs['os_ironic_api_version'] = '{0:d}.{1:d}'.format(*IRONIC_API_VERSION)
         try:
             cli = ironic.client.get_client(IRONIC_API_VERSION[0], **kwargs)
             # Cache the client so we don't have to reconstruct and

--- a/nova/virt/ironic/driver.py
+++ b/nova/virt/ironic/driver.py
@@ -98,13 +98,13 @@ def _get_nodes_supported_instances(cpu_arch=None):
 
 def _log_ironic_polling(what, node, instance):
     power_state = (None if node.power_state is None else
-                   '"%s"' % node.power_state)
+                   '"{0!s}"'.format(node.power_state))
     tgt_power_state = (None if node.target_power_state is None else
-                       '"%s"' % node.target_power_state)
+                       '"{0!s}"'.format(node.target_power_state))
     prov_state = (None if node.provision_state is None else
-                  '"%s"' % node.provision_state)
+                  '"{0!s}"'.format(node.provision_state))
     tgt_prov_state = (None if node.target_provision_state is None else
-                      '"%s"' % node.target_provision_state)
+                      '"{0!s}"'.format(node.target_provision_state))
     LOG.debug('Still waiting for ironic node %(node)s to %(what)s: '
               'power_state=%(power_state)s, '
               'target_power_state=%(tgt_power_state)s, '

--- a/nova/virt/libvirt/config.py
+++ b/nova/virt/libvirt/config.py
@@ -1190,10 +1190,10 @@ class LibvirtConfigGuestInterface(LibvirtConfigGuestDevice):
             domain, bus, slot, func = \
                 pci_utils.get_pci_address_fields(self.source_dev)
             addr_elem = etree.Element("address", type='pci')
-            addr_elem.set("domain", "0x%s" % (domain))
-            addr_elem.set("bus", "0x%s" % (bus))
-            addr_elem.set("slot", "0x%s" % (slot))
-            addr_elem.set("function", "0x%s" % (func))
+            addr_elem.set("domain", "0x{0!s}".format((domain)))
+            addr_elem.set("bus", "0x{0!s}".format((bus)))
+            addr_elem.set("slot", "0x{0!s}".format((slot)))
+            addr_elem.set("function", "0x{0!s}".format((func)))
             source_elem.append(addr_elem)
             dev.append(source_elem)
         elif self.net_type == "vhostuser":

--- a/nova/virt/libvirt/driver.py
+++ b/nova/virt/libvirt/driver.py
@@ -322,7 +322,7 @@ CONF.import_group('workarounds', 'nova.utils')
 CONF.import_opt('iscsi_use_multipath', 'nova.virt.libvirt.volume.iscsi',
                 group='libvirt')
 
-DEFAULT_FIREWALL_DRIVER = "%s.%s" % (
+DEFAULT_FIREWALL_DRIVER = "{0!s}.{1!s}".format(
     libvirt_firewall.__name__,
     libvirt_firewall.IptablesFirewallDriver.__name__)
 
@@ -1165,7 +1165,7 @@ class LibvirtDriver(driver.ComputeDriver):
 
         # The 'serial' device is the base for x86 platforms. Other platforms
         # (e.g. kvm on system z = arch.S390X) can only use 'console' devices.
-        xpath_mode = "[@mode='%s']" % mode if mode else ""
+        xpath_mode = "[@mode='{0!s}']".format(mode) if mode else ""
         serial_tcp = "./devices/serial[@type='tcp']/source" + xpath_mode
         console_tcp = "./devices/console[@type='tcp']/source" + xpath_mode
 
@@ -1200,7 +1200,7 @@ class LibvirtDriver(driver.ComputeDriver):
             vg = os.path.join('/dev', CONF.libvirt.images_volume_group)
             if not os.path.exists(vg):
                 return []
-            pattern = '%s_' % instance.uuid
+            pattern = '{0!s}_'.format(instance.uuid)
 
             def belongs_to_instance(disk):
                 return disk.startswith(pattern)
@@ -1987,7 +1987,7 @@ class LibvirtDriver(driver.ComputeDriver):
             snap_disk.snapshot = 'external'
             snap_disk.source_path = new_filename
             old_dir = disk_info['source_name'].split('/')[0]
-            snap_disk.source_name = '%s/%s' % (old_dir, new_filename)
+            snap_disk.source_name = '{0!s}/{1!s}'.format(old_dir, new_filename)
             snap_disk.source_hosts = disk_info['source_hosts']
             snap_disk.source_ports = disk_info['source_ports']
 
@@ -2249,7 +2249,7 @@ class LibvirtDriver(driver.ComputeDriver):
 
             LOG.debug('index of match (%s) is %s', b.source_name, index)
 
-            my_snap_dev = '%s[%s]' % (my_dev, index)
+            my_snap_dev = '{0!s}[{1!s}]'.format(my_dev, index)
             return my_snap_dev
 
         if delete_info['merge_target_file'] is None:
@@ -2779,7 +2779,7 @@ class LibvirtDriver(driver.ComputeDriver):
 
     def _flush_libvirt_console(self, pty):
         out, err = utils.execute('dd',
-                                 'if=%s' % pty,
+                                 'if={0!s}'.format(pty),
                                  'iflag=nonblock',
                                  run_as_root=True,
                                  check_exit_code=False)
@@ -2964,7 +2964,7 @@ class LibvirtDriver(driver.ComputeDriver):
                           fs_label, os_type, is_block_dev=False,
                           max_size=None, context=None, specified_fs=None):
         if not is_block_dev:
-            libvirt_utils.create_image('raw', target, '%dG' % ephemeral_size)
+            libvirt_utils.create_image('raw', target, '{0:d}G'.format(ephemeral_size))
 
         # Run as root only for block devices.
         disk.mkfs(os_type, fs_label, target, run_as_root=is_block_dev,
@@ -2973,7 +2973,7 @@ class LibvirtDriver(driver.ComputeDriver):
     @staticmethod
     def _create_swap(target, swap_mb, max_size=None, context=None):
         """Create a swap file of specified size."""
-        libvirt_utils.create_image('raw', target, '%dM' % swap_mb)
+        libvirt_utils.create_image('raw', target, '{0:d}M'.format(swap_mb))
         utils.mkfs('swap', target)
 
     @staticmethod
@@ -3189,7 +3189,7 @@ class LibvirtDriver(driver.ComputeDriver):
                                    fs_label='ephemeral0',
                                    os_type=instance.os_type,
                                    is_block_dev=disk_image.is_block_dev)
-            fname = "ephemeral_%s_%s" % (ephemeral_gb, file_extension)
+            fname = "ephemeral_{0!s}_{1!s}".format(ephemeral_gb, file_extension)
             size = ephemeral_gb * units.Gi
             disk_image.cache(fetch_func=fn,
                              context=context,
@@ -3207,11 +3207,11 @@ class LibvirtDriver(driver.ComputeDriver):
                 raise exception.InvalidBDMFormat(details=msg)
 
             fn = functools.partial(self._create_ephemeral,
-                                   fs_label='ephemeral%d' % idx,
+                                   fs_label='ephemeral{0:d}'.format(idx),
                                    os_type=instance.os_type,
                                    is_block_dev=disk_image.is_block_dev)
             size = eph['size'] * units.Gi
-            fname = "ephemeral_%s_%s" % (eph['size'], file_extension)
+            fname = "ephemeral_{0!s}_{1!s}".format(eph['size'], file_extension)
             disk_image.cache(fetch_func=fn,
                              context=context,
                              filename=fname,
@@ -3235,7 +3235,7 @@ class LibvirtDriver(driver.ComputeDriver):
                 size = swap_mb * units.Mi
                 image('disk.swap').cache(fetch_func=self._create_swap,
                                          context=context,
-                                         filename="swap_%s" % swap_mb,
+                                         filename="swap_{0!s}".format(swap_mb),
                                          size=size,
                                          swap_mb=swap_mb)
 
@@ -4072,9 +4072,9 @@ class LibvirtDriver(driver.ComputeDriver):
         if rescue.get('kernel_id'):
             guest.os_kernel = os.path.join(inst_path, "kernel.rescue")
             if virt_type == "xen":
-                guest.os_cmdline = "ro root=%s" % root_device_name
+                guest.os_cmdline = "ro root={0!s}".format(root_device_name)
             else:
-                guest.os_cmdline = ("root=%s %s" % (root_device_name, CONSOLE))
+                guest.os_cmdline = ("root={0!s} {1!s}".format(root_device_name, CONSOLE))
                 if virt_type == "qemu":
                     guest.os_cmdline += " no_timer_check"
         if rescue.get('ramdisk_id'):
@@ -4084,9 +4084,9 @@ class LibvirtDriver(driver.ComputeDriver):
                                 root_device_name, image_meta):
         guest.os_kernel = os.path.join(inst_path, "kernel")
         if virt_type == "xen":
-            guest.os_cmdline = "ro root=%s" % root_device_name
+            guest.os_cmdline = "ro root={0!s}".format(root_device_name)
         else:
-            guest.os_cmdline = ("root=%s %s" % (root_device_name, CONSOLE))
+            guest.os_cmdline = ("root={0!s} {1!s}".format(root_device_name, CONSOLE))
             if virt_type == "qemu":
                 guest.os_cmdline += " no_timer_check"
         if instance.ramdisk_id:
@@ -4249,8 +4249,7 @@ class LibvirtDriver(driver.ComputeDriver):
         qga = vconfig.LibvirtConfigGuestChannel()
         qga.type = "unix"
         qga.target_name = "org.qemu.guest_agent.0"
-        qga.source_path = ("/var/lib/libvirt/qemu/%s.%s.sock" %
-                          ("org.qemu.guest_agent.0", instance.name))
+        qga.source_path = ("/var/lib/libvirt/qemu/{0!s}.{1!s}.sock".format("org.qemu.guest_agent.0", instance.name))
         guest.add_device(qga)
 
     def _add_rng_device(self, guest, flavor):
@@ -5084,7 +5083,7 @@ class LibvirtDriver(driver.ComputeDriver):
                     }
                 if (fun_cap.type == 'phys_function' and
                     len(fun_cap.device_addrs) != 0):
-                    phys_address = "%04x:%02x:%02x.%01x" % (
+                    phys_address = "{0:04x}:{1:02x}:{2:02x}.{3:01x}".format(
                         fun_cap.device_addrs[0][0],
                         fun_cap.device_addrs[0][1],
                         fun_cap.device_addrs[0][2],
@@ -5112,7 +5111,7 @@ class LibvirtDriver(driver.ComputeDriver):
         cfgdev = vconfig.LibvirtConfigNodeDevice()
         cfgdev.parse_str(xmlstr)
 
-        address = "%04x:%02x:%02x.%1x" % (
+        address = "{0:04x}:{1:02x}:{2:02x}.{3:1x}".format(
             cfgdev.pci_capability.domain,
             cfgdev.pci_capability.bus,
             cfgdev.pci_capability.slot,
@@ -5121,14 +5120,14 @@ class LibvirtDriver(driver.ComputeDriver):
         device = {
             "dev_id": cfgdev.name,
             "address": address,
-            "product_id": "%04x" % cfgdev.pci_capability.product_id,
-            "vendor_id": "%04x" % cfgdev.pci_capability.vendor_id,
+            "product_id": "{0:04x}".format(cfgdev.pci_capability.product_id),
+            "vendor_id": "{0:04x}".format(cfgdev.pci_capability.vendor_id),
             }
 
         device["numa_node"] = cfgdev.pci_capability.numa_node
 
         # requirement by DataBase Model
-        device['label'] = 'label_%(vendor_id)s_%(product_id)s' % device
+        device['label'] = 'label_{vendor_id!s}_{product_id!s}'.format(**device)
         device.update(_get_device_type(cfgdev, address))
         return device
 
@@ -6799,7 +6798,7 @@ class LibvirtDriver(driver.ComputeDriver):
                     inst_type = instance.get_flavor()
                     swap_mb = inst_type.swap
                     image.cache(fetch_func=self._create_swap,
-                                filename="swap_%s" % swap_mb,
+                                filename="swap_{0!s}".format(swap_mb),
                                 size=swap_mb * units.Mi,
                                 swap_mb=swap_mb)
                 else:

--- a/nova/virt/libvirt/firewall.py
+++ b/nova/virt/libvirt/firewall.py
@@ -80,12 +80,12 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
                   <!-- no nd reflection -->
                   <!-- drop if destination mac is v6 mcast mac addr and
                        we sent it. -->
-                  <uuid>%s</uuid>
+                  <uuid>{0!s}</uuid>
                   <rule action='drop' direction='in'>
                       <mac dstmacaddr='33:33:00:00:00:00'
                            dstmacmask='ff:ff:00:00:00:00' srcmacaddr='$MAC'/>
                   </rule>
-                  </filter>''' % uuid
+                  </filter>'''.format(uuid)
 
     def nova_dhcp_filter(self):
         """The standard allow-dhcp-server filter is an <ip> one, so it uses
@@ -94,7 +94,7 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
         """
         uuid = self._get_filter_uuid('nova-allow-dhcp-server')
         return '''<filter name='nova-allow-dhcp-server' chain='ipv4'>
-                    <uuid>%s</uuid>
+                    <uuid>{0!s}</uuid>
                     <rule action='accept' direction='out'
                           priority='100'>
                       <udp srcipaddr='0.0.0.0'
@@ -108,7 +108,7 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
                            srcportstart='67'
                            dstportstart='68'/>
                     </rule>
-                  </filter>''' % uuid
+                  </filter>'''.format(uuid)
 
     def setup_basic_filtering(self, instance, network_info):
         """Set up basic filtering (MAC, IP, and ARP spoofing protection)."""
@@ -140,7 +140,7 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
         parameters = []
 
         def format_parameter(parameter, value):
-            return ("<parameter name='%s' value='%s'/>" % (parameter, value))
+            return ("<parameter name='{0!s}' value='{1!s}'/>".format(parameter, value))
 
         network = vif['network']
         if not vif['network'] or not vif['network']['subnets']:
@@ -184,10 +184,10 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
         instance_filter_name = self._instance_filter_name(instance, nic_id)
         parameters = self._get_instance_filter_parameters(vif)
         uuid = self._get_filter_uuid(instance_filter_name)
-        xml = '''<filter name='%s' chain='root'>''' % instance_filter_name
-        xml += '<uuid>%s</uuid>' % uuid
+        xml = '''<filter name='{0!s}' chain='root'>'''.format(instance_filter_name)
+        xml += '<uuid>{0!s}</uuid>'.format(uuid)
         for f in filters:
-            xml += '''<filterref filter='%s'>''' % f
+            xml += '''<filterref filter='{0!s}'>'''.format(f)
             xml += ''.join(parameters)
             xml += '</filterref>'
         xml += '</filter>'
@@ -237,11 +237,11 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
 
     def _filter_container(self, name, filters):
         uuid = self._get_filter_uuid(name)
-        xml = '''<filter name='%s' chain='root'>
-                   <uuid>%s</uuid>
-                   %s
-                 </filter>''' % (name, uuid,
-                 ''.join(["<filterref filter='%s'/>" % (f,) for f in filters]))
+        xml = '''<filter name='{0!s}' chain='root'>
+                   <uuid>{1!s}</uuid>
+                   {2!s}
+                 </filter>'''.format(name, uuid,
+                 ''.join(["<filterref filter='{0!s}'/>".format(f) for f in filters]))
         return xml
 
     def _get_filter_uuid(self, name):
@@ -300,8 +300,8 @@ class NWFilterFirewall(base_firewall.FirewallDriver):
     @staticmethod
     def _instance_filter_name(instance, nic_id=None):
         if not nic_id:
-            return 'nova-instance-%s' % (instance.name)
-        return 'nova-instance-%s-%s' % (instance.name, nic_id)
+            return 'nova-instance-{0!s}'.format((instance.name))
+        return 'nova-instance-{0!s}-{1!s}'.format(instance.name, nic_id)
 
     def instance_filter_exists(self, instance, network_info):
         """Check nova-instance-instance-xxx exists."""

--- a/nova/virt/libvirt/guest.py
+++ b/nova/virt/libvirt/guest.py
@@ -86,11 +86,11 @@ class Guest(object):
         self._domain = domain
 
     def __repr__(self):
-        return "<Guest %(id)d %(name)s %(uuid)s>" % {
+        return "<Guest {id:d} {name!s} {uuid!s}>".format(**{
             'id': self.id,
             'name': self.name,
             'uuid': self.uuid
-        }
+        })
 
     @property
     def id(self):
@@ -160,7 +160,7 @@ class Guest(object):
             for interface in interfaces:
                 utils.execute(
                     'tee',
-                    '/sys/class/net/%s/brport/hairpin_mode' % interface,
+                    '/sys/class/net/{0!s}/brport/hairpin_mode'.format(interface),
                     process_input='1',
                     run_as_root=True,
                     check_exit_code=[0, 1])
@@ -258,7 +258,7 @@ class Guest(object):
             doc = etree.fromstring(self._domain.XMLDesc(0))
         except Exception:
             return None
-        node = doc.find("./devices/disk/target[@dev='%s'].." % device)
+        node = doc.find("./devices/disk/target[@dev='{0!s}']..".format(device))
         if node is not None:
             conf = vconfig.LibvirtConfigGuestDisk()
             conf.parse_dom(node)

--- a/nova/virt/libvirt/host.py
+++ b/nova/virt/libvirt/host.py
@@ -883,7 +883,7 @@ class Host(object):
 
         xml = secret_conf.to_xml()
         try:
-            LOG.debug('Secret XML: %s' % xml)
+            LOG.debug('Secret XML: {0!s}'.format(xml))
             conn = self.get_connection()
             secret = conn.secretDefineXML(xml)
             if password is not None:

--- a/nova/virt/libvirt/imagecache.py
+++ b/nova/virt/libvirt/imagecache.py
@@ -162,7 +162,7 @@ def read_stored_info(target, field=None, timestamped=False):
             d = {}
 
     else:
-        lock_name = 'info-%s' % os.path.split(target)[-1]
+        lock_name = 'info-{0!s}'.format(os.path.split(target)[-1])
         lock_path = os.path.join(CONF.instances_path, 'locks')
 
         @utils.synchronized(lock_name, external=True, lock_path=lock_path)
@@ -176,7 +176,7 @@ def read_stored_info(target, field=None, timestamped=False):
 
     if field:
         if timestamped:
-            return (d.get(field, None), d.get('%s-timestamp' % field, None))
+            return (d.get(field, None), d.get('{0!s}-timestamp'.format(field), None))
         else:
             return d.get(field, None)
     return d
@@ -192,7 +192,7 @@ def write_stored_info(target, field=None, value=None):
     LOG.info(_LI('Writing stored info to %s'), info_file)
     fileutils.ensure_tree(os.path.dirname(info_file))
 
-    lock_name = 'info-%s' % os.path.split(target)[-1]
+    lock_name = 'info-{0!s}'.format(os.path.split(target)[-1])
     lock_path = os.path.join(CONF.instances_path, 'locks')
 
     @utils.synchronized(lock_name, external=True, lock_path=lock_path)
@@ -204,7 +204,7 @@ def write_stored_info(target, field=None, value=None):
                 d = _read_possible_json(f.read(), info_file)
 
         d[field] = value
-        d['%s-timestamp' % field] = time.time()
+        d['{0!s}-timestamp'.format(field)] = time.time()
 
         with open(info_file, 'w') as f:
             f.write(jsonutils.dumps(d))
@@ -359,7 +359,7 @@ class ImageCacheManager(imagecache.ImageCacheManager):
             yield base_file, True, False
 
         # Resized images
-        resize_re = re.compile('.*/%s_[0-9]+$' % fingerprint)
+        resize_re = re.compile('.*/{0!s}_[0-9]+$'.format(fingerprint))
         for img in self.unexplained_images:
             m = resize_re.match(img)
             if m:
@@ -376,7 +376,7 @@ class ImageCacheManager(imagecache.ImageCacheManager):
         if not CONF.libvirt.checksum_base_images:
             return None
 
-        lock_name = 'hash-%s' % os.path.split(base_file)[-1]
+        lock_name = 'hash-{0!s}'.format(os.path.split(base_file)[-1])
 
         # Protect against other nova-computes performing checksums at the same
         # time if we are using shared storage

--- a/nova/virt/libvirt/storage/dmcrypt.py
+++ b/nova/virt/libvirt/storage/dmcrypt.py
@@ -61,7 +61,7 @@ def create_volume(target, device, cipher, key_size, key):
            '--cipher=' + cipher,
            '--key-size=' + str(key_size),
            '--key-file=-')
-    key = ''.join(map(lambda byte: "%02x" % byte, key))
+    key = ''.join(map(lambda byte: "{0:02x}".format(byte), key))
     try:
         utils.execute(*cmd, process_input=key, run_as_root=True)
     except processutils.ProcessExecutionError as e:

--- a/nova/virt/libvirt/storage/lvm.py
+++ b/nova/virt/libvirt/storage/lvm.py
@@ -85,11 +85,11 @@ def create_volume(vg, lv, size, sparse=False):
                          'size': size,
                          'lv': lv})
 
-        cmd = ('lvcreate', '-L', '%db' % preallocated_space,
-                '--virtualsize', '%db' % size, '-n', lv, vg)
+        cmd = ('lvcreate', '-L', '{0:d}b'.format(preallocated_space),
+                '--virtualsize', '{0:d}b'.format(size), '-n', lv, vg)
     else:
         check_size(vg, lv, size)
-        cmd = ('lvcreate', '-L', '%db' % size, '-n', lv, vg)
+        cmd = ('lvcreate', '-L', '{0:d}b'.format(size), '-n', lv, vg)
     utils.execute(*cmd, run_as_root=True, attempts=3)
 
 
@@ -194,9 +194,9 @@ def _zero_volume(path, volume_size):
     while remaining_bytes:
         zero_blocks = remaining_bytes / bs
         seek_blocks = (volume_size - remaining_bytes) / bs
-        zero_cmd = ('dd', 'bs=%s' % bs,
-                    'if=/dev/zero', 'of=%s' % path,
-                    'seek=%s' % seek_blocks, 'count=%s' % zero_blocks)
+        zero_cmd = ('dd', 'bs={0!s}'.format(bs),
+                    'if=/dev/zero', 'of={0!s}'.format(path),
+                    'seek={0!s}'.format(seek_blocks), 'count={0!s}'.format(zero_blocks))
         zero_cmd += direct_flags
         zero_cmd += sync_flags
         if zero_blocks:
@@ -235,7 +235,7 @@ def clear_volume(path):
         # with -n0 -z, however only versions >= 8.22 perform as well as dd
         _zero_volume(path, volume_size)
     elif volume_clear == 'shred':
-        utils.execute('shred', '-n3', '-s%d' % volume_size, path,
+        utils.execute('shred', '-n3', '-s{0:d}'.format(volume_size), path,
                       run_as_root=True)
 
 

--- a/nova/virt/libvirt/storage/rbd_utils.py
+++ b/nova/virt/libvirt/storage/rbd_utils.py
@@ -190,7 +190,7 @@ class RBDDriver(object):
             return False
 
         if self.get_fsid() != fsid:
-            reason = '%s is in a different ceph cluster' % url
+            reason = '{0!s} is in a different ceph cluster'.format(url)
             LOG.debug(reason)
             return False
 
@@ -205,8 +205,8 @@ class RBDDriver(object):
         try:
             return self.exists(image, pool=pool, snapshot=snapshot)
         except rbd.Error as e:
-            LOG.debug('Unable to open image %(loc)s: %(err)s' %
-                      dict(loc=url, err=e))
+            LOG.debug('Unable to open image {loc!s}: {err!s}'.format(**
+                      dict(loc=url, err=e)))
             return False
 
     def clone(self, image_location, dest_name, dest_pool=None):

--- a/nova/virt/libvirt/utils.py
+++ b/nova/virt/libvirt/utils.py
@@ -86,7 +86,7 @@ def create_cow_image(backing_file, path, size=None):
     base_cmd = ['qemu-img', 'create', '-f', 'qcow2']
     cow_opts = []
     if backing_file:
-        cow_opts += ['backing_file=%s' % backing_file]
+        cow_opts += ['backing_file={0!s}'.format(backing_file)]
         base_details = images.qemu_img_info(backing_file)
     else:
         base_details = None
@@ -96,9 +96,9 @@ def create_cow_image(backing_file, path, size=None):
     # value or cases when images were created with very old QEMU
     # versions which had a different default 'cluster_size'.
     if base_details and base_details.cluster_size is not None:
-        cow_opts += ['cluster_size=%s' % base_details.cluster_size]
+        cow_opts += ['cluster_size={0!s}'.format(base_details.cluster_size)]
     if size is not None:
-        cow_opts += ['size=%s' % size]
+        cow_opts += ['size={0!s}'.format(size)]
     if cow_opts:
         # Format as a comma separated list
         csv_opts = ",".join(cow_opts)
@@ -211,9 +211,9 @@ def copy_image(src, dest, host=None, receive=False,
         execute('cp', src, dest)
     else:
         if receive:
-            src = "%s:%s" % (utils.safe_ip_format(host), src)
+            src = "{0!s}:{1!s}".format(utils.safe_ip_format(host), src)
         else:
-            dest = "%s:%s" % (utils.safe_ip_format(host), dest)
+            dest = "{0!s}:{1!s}".format(utils.safe_ip_format(host), dest)
 
         remote_filesystem_driver = remotefs.RemoteFilesystem()
         remote_filesystem_driver.copy_file(src, dest,
@@ -257,7 +257,7 @@ def update_mtime(path):
 
 
 def _id_map_to_config(id_map):
-    return "%s:%s:%s" % (id_map.start, id_map.target, id_map.count)
+    return "{0!s}:{1!s}:{2!s}".format(id_map.start, id_map.target, id_map.count)
 
 
 def chown_for_id_maps(path, id_maps):

--- a/nova/virt/libvirt/vif.py
+++ b/nova/virt/libvirt/vif.py
@@ -170,8 +170,8 @@ class LibvirtGenericVIFDriver(object):
         return ("qbr" + iface_id)[:network_model.NIC_NAME_LEN]
 
     def get_veth_pair_names(self, iface_id):
-        return (("qvb%s" % iface_id)[:network_model.NIC_NAME_LEN],
-                ("qvo%s" % iface_id)[:network_model.NIC_NAME_LEN])
+        return (("qvb{0!s}".format(iface_id))[:network_model.NIC_NAME_LEN],
+                ("qvo{0!s}".format(iface_id))[:network_model.NIC_NAME_LEN])
 
     def get_firewall_required(self, vif):
         if vif.is_neutron_filtering_enabled():
@@ -448,7 +448,7 @@ class LibvirtGenericVIFDriver(object):
                 _("vif_type parameter must be present "
                   "for this vif_driver implementation"))
         vif_slug = self._normalize_vif_type(vif_type)
-        func = getattr(self, 'get_config_%s' % vif_slug, None)
+        func = getattr(self, 'get_config_{0!s}'.format(vif_slug), None)
         if not func:
             raise exception.NovaException(
                 _("Unexpected vif_type=%s") % vif_type)
@@ -494,12 +494,12 @@ class LibvirtGenericVIFDriver(object):
             utils.execute('brctl', 'setfd', br_name, 0, run_as_root=True)
             utils.execute('brctl', 'stp', br_name, 'off', run_as_root=True)
             utils.execute('tee',
-                          ('/sys/class/net/%s/bridge/multicast_snooping' %
-                           br_name),
+                          ('/sys/class/net/{0!s}/bridge/multicast_snooping'.format(
+                           br_name)),
                           process_input='0',
                           run_as_root=True,
                           check_exit_code=[0, 1])
-            disv6 = '/proc/sys/net/ipv6/conf/%s/disable_ipv6' % br_name
+            disv6 = '/proc/sys/net/ipv6/conf/{0!s}/disable_ipv6'.format(br_name)
             if os.path.exists(disv6):
                 utils.execute('tee',
                               disv6,
@@ -636,8 +636,8 @@ class LibvirtGenericVIFDriver(object):
             utils.execute('ifc_ctl', 'gateway', 'ifup', dev,
                           'access_vm',
                           vif['network']['label'] + "_" + iface_id,
-                          vif['address'], 'pgtag2=%s' % net_id,
-                          'pgtag1=%s' % tenant_id, run_as_root=True)
+                          vif['address'], 'pgtag2={0!s}'.format(net_id),
+                          'pgtag1={0!s}'.format(tenant_id), run_as_root=True)
         except processutils.ProcessExecutionError:
             LOG.exception(_LE("Failed while plugging vif"), instance=instance)
 
@@ -758,7 +758,7 @@ class LibvirtGenericVIFDriver(object):
                 _("vif_type parameter must be present "
                   "for this vif_driver implementation"))
         vif_slug = self._normalize_vif_type(vif_type)
-        func = getattr(self, 'plug_%s' % vif_slug, None)
+        func = getattr(self, 'plug_{0!s}'.format(vif_slug), None)
         if not func:
             raise exception.VirtualInterfacePlugException(
                 _("Plug vif failed because of unexpected "
@@ -957,7 +957,7 @@ class LibvirtGenericVIFDriver(object):
         Unbind the vif from a Contrail virtual port.
         """
         dev = self.get_vif_devname(vif)
-        cmd_args = ("--oper=delete --uuid=%s" % (vif['id']))
+        cmd_args = ("--oper=delete --uuid={0!s}".format((vif['id'])))
         try:
             utils.execute('vrouter-port-control', cmd_args, run_as_root=True)
             linux_net.delete_net_dev(dev)
@@ -978,7 +978,7 @@ class LibvirtGenericVIFDriver(object):
                 _("vif_type parameter must be present "
                   "for this vif_driver implementation"))
         vif_slug = self._normalize_vif_type(vif_type)
-        func = getattr(self, 'unplug_%s' % vif_slug, None)
+        func = getattr(self, 'unplug_{0!s}'.format(vif_slug), None)
         if not func:
             raise exception.NovaException(
                 _("Unexpected vif_type=%s") % vif_type)

--- a/nova/virt/libvirt/volume/glusterfs.py
+++ b/nova/virt/libvirt/volume/glusterfs.py
@@ -60,7 +60,7 @@ class LibvirtGlusterfsVolumeDriver(fs.LibvirtBaseFileSystemVolumeDriver):
             conf.source_type = 'network'
             conf.source_protocol = 'gluster'
             conf.source_hosts = [source_host]
-            conf.source_name = '%s/%s' % (vol_name, data['name'])
+            conf.source_name = '{0!s}/{1!s}'.format(vol_name, data['name'])
         else:
             conf.source_type = 'file'
             conf.source_path = connection_info['data']['device_path']

--- a/nova/virt/libvirt/volume/net.py
+++ b/nova/virt/libvirt/volume/net.py
@@ -55,8 +55,8 @@ class LibvirtNetVolumeDriver(libvirt_volume.LibvirtBaseVolumeDriver):
             return
         elif source_protocol == 'iscsi':
             usage_type = 'iscsi'
-            usage_name = ("%(target_iqn)s/%(target_lun)s" %
-                          netdisk_properties)
+            usage_name = ("{target_iqn!s}/{target_lun!s}".format(**
+                          netdisk_properties))
             self.connection._host.delete_secret(usage_type, usage_name)
 
     def get_config(self, connection_info, disk_info):
@@ -79,8 +79,8 @@ class LibvirtNetVolumeDriver(libvirt_volume.LibvirtBaseVolumeDriver):
                 conf.auth_username = CONF.libvirt.rbd_user
         if conf.source_protocol == 'iscsi':
             try:
-                conf.source_name = ("%(target_iqn)s/%(target_lun)s" %
-                                    netdisk_properties)
+                conf.source_name = ("{target_iqn!s}/{target_lun!s}".format(**
+                                    netdisk_properties))
                 target_portal = netdisk_properties['target_portal']
             except KeyError:
                 raise exception.NovaException(_("Invalid volume source data"))

--- a/nova/virt/libvirt/volume/remotefs.py
+++ b/nova/virt/libvirt/volume/remotefs.py
@@ -277,7 +277,7 @@ class RsyncDriver(RemoteFilesystemDriver):
         # Remove remote directory's content
         utils.execute('rsync', '--archive', '--delete-excluded',
                       kwargs['tmp_dir_path'] + os.path.sep,
-                      '%s:%s' % (host, dst),
+                      '{0!s}:{1!s}'.format(host, dst),
                       on_execute=on_execute, on_completion=on_completion)
 
         # Delete empty directory
@@ -300,7 +300,7 @@ class RsyncDriver(RemoteFilesystemDriver):
                       '--include', os.path.basename(os.path.normpath(dst)),
                       '--exclude', '*',
                       os.path.normpath(src) + os.path.sep,
-                      '%s:%s' % (host, os.path.dirname(os.path.normpath(dst))),
+                      '{0!s}:{1!s}'.format(host, os.path.dirname(os.path.normpath(dst))),
                       on_execute=on_execute, on_completion=on_completion)
 
     @staticmethod
@@ -329,7 +329,7 @@ class RsyncDriver(RemoteFilesystemDriver):
 
         # Do relative rsync local directory with remote root directory
         utils.execute('rsync', '--archive', '--relative', '--no-implied-dirs',
-                      relative_tmp_file_path, '%s:%s' % (host, os.path.sep),
+                      relative_tmp_file_path, '{0!s}:{1!s}'.format(host, os.path.sep),
                       on_execute=on_execute, on_completion=on_completion)
 
     def copy_file(self, src, dst, on_execute, on_completion, compression):

--- a/nova/virt/libvirt/volume/scality.py
+++ b/nova/virt/libvirt/volume/scality.py
@@ -105,7 +105,7 @@ class LibvirtScalityVolumeDriver(fs.LibvirtBaseFileSystemVolumeDriver):
         # config can be a file path or a URL, check it
         if urlparse.urlparse(config).scheme == '':
             # turn local path into URL
-            config = 'file://%s' % config
+            config = 'file://{0!s}'.format(config)
         try:
             urllib.request.urlopen(config, timeout=5).close()
         except urllib.error.URLError as e:

--- a/nova/virt/netutils.py
+++ b/nova/virt/netutils.py
@@ -143,7 +143,7 @@ def get_injected_network_template(network_info, use_ipv6=None, template=None,
                     gateway_v6 = subnet_v6['gateway']['address']
                 dns_v6 = ' '.join([i['address'] for i in subnet_v6['dns']])
 
-        net_info = {'name': 'eth%d' % ifc_num,
+        net_info = {'name': 'eth{0:d}'.format(ifc_num),
                     'hwaddress': hwaddress,
                     'address': address,
                     'netmask': netmask,
@@ -246,7 +246,7 @@ def _get_eth_link(vif, ifc_num):
     """
     link_id = vif.get('devname')
     if not link_id:
-        link_id = 'interface%d' % ifc_num
+        link_id = 'interface{0:d}'.format(ifc_num)
 
     # Use 'phy' for physical links. Ethernet can be confusing
     if vif.get('type') == 'ethernet':
@@ -276,8 +276,8 @@ def _get_nets(vif, subnet, version, net_num, link_id):
     """
     if subnet.get_meta('dhcp_server') is not None:
         net_info = {
-            'id': 'network%d' % net_num,
-            'type': 'ipv%d_dhcp' % version,
+            'id': 'network{0:d}'.format(net_num),
+            'type': 'ipv{0:d}_dhcp'.format(version),
             'link': link_id,
             'network_id': vif['network']['id']
         }
@@ -291,8 +291,8 @@ def _get_nets(vif, subnet, version, net_num, link_id):
         netmask = str(subnet.as_netaddr().netmask)
 
     net_info = {
-        'id': 'network%d' % net_num,
-        'type': 'ipv%d' % version,
+        'id': 'network{0:d}'.format(net_num),
+        'type': 'ipv{0:d}'.format(version),
         'link': link_id,
         'ip_address': address,
         'netmask': netmask,

--- a/nova/virt/vmwareapi/driver.py
+++ b/nova/virt/vmwareapi/driver.py
@@ -332,7 +332,7 @@ class VMwareVCDriver(driver.ComputeDriver):
           domain-26.9d51f082-58a4-4449-beed-6fd205a5726b
         """
 
-        return '%s.%s' % (mo_id, self._vcenter_uuid)
+        return '{0!s}.{1!s}'.format(mo_id, self._vcenter_uuid)
 
     def _get_available_resources(self, host_stats):
         return {'vcpus': host_stats['vcpus'],

--- a/nova/virt/vmwareapi/imagecache.py
+++ b/nova/virt/vmwareapi/imagecache.py
@@ -109,7 +109,7 @@ class ImageCacheManager(imagecache.ImageCacheManager):
                     return file
 
     def _get_timestamp_filename(self):
-        return '%s%s' % (TIMESTAMP_PREFIX,
+        return '{0!s}{1!s}'.format(TIMESTAMP_PREFIX,
                          timeutils.utcnow().strftime(TIMESTAMP_FORMAT))
 
     def _get_datetime_from_filename(self, timestamp_filename):

--- a/nova/virt/vmwareapi/images.py
+++ b/nova/virt/vmwareapi/images.py
@@ -314,7 +314,7 @@ def _build_shadow_vm_config_spec(session, name, size_kb, disk_type, ds_name):
         disk_device_bkng.eagerlyScrub = True
     elif disk_type == constants.DISK_TYPE_THIN:
         disk_device_bkng.thinProvisioned = True
-    disk_device_bkng.fileName = '[%s]' % ds_name
+    disk_device_bkng.fileName = '[{0!s}]'.format(ds_name)
     disk_device_bkng.diskMode = 'persistent'
     disk_device.backing = disk_device_bkng
     disk_spec = cf.create('ns0:VirtualDeviceConfigSpec')
@@ -323,7 +323,7 @@ def _build_shadow_vm_config_spec(session, name, size_kb, disk_type, ds_name):
     disk_spec.device = disk_device
 
     vm_file_info = cf.create('ns0:VirtualMachineFileInfo')
-    vm_file_info.vmPathName = '[%s]' % ds_name
+    vm_file_info.vmPathName = '[{0!s}]'.format(ds_name)
 
     create_spec = cf.create('ns0:VirtualMachineConfigSpec')
     create_spec.name = name
@@ -390,14 +390,14 @@ def get_vmdk_name_from_ovf(xmlstr):
     """Parse the OVA descriptor to extract the vmdk name."""
 
     ovf = etree.fromstring(xmlstr)
-    nsovf = "{%s}" % ovf.nsmap["ovf"]
+    nsovf = "{{{0!s}}}".format(ovf.nsmap["ovf"])
 
-    disk = ovf.find("./%sDiskSection/%sDisk" % (nsovf, nsovf))
-    file_id = disk.get("%sfileRef" % nsovf)
+    disk = ovf.find("./{0!s}DiskSection/{1!s}Disk".format(nsovf, nsovf))
+    file_id = disk.get("{0!s}fileRef".format(nsovf))
 
-    file = ovf.find('./%sReferences/%sFile[@%sid="%s"]' % (nsovf, nsovf,
+    file = ovf.find('./{0!s}References/{1!s}File[@{2!s}id="{3!s}"]'.format(nsovf, nsovf,
                                                            nsovf, file_id))
-    vmdk_name = file.get("%shref" % nsovf)
+    vmdk_name = file.get("{0!s}href".format(nsovf))
     return vmdk_name
 
 

--- a/nova/virt/vmwareapi/read_write_util.py
+++ b/nova/virt/vmwareapi/read_write_util.py
@@ -43,10 +43,10 @@ class VMwareHTTPReadFile(rw_handles.FileHandle):
 
     def _get_base_url(self, scheme, host, port, file_path):
         if netutils.is_valid_ipv6(host):
-            base_url = "%s://[%s]:%s/folder/%s" % (scheme, host, port,
+            base_url = "{0!s}://[{1!s}]:{2!s}/folder/{3!s}".format(scheme, host, port,
                                                 urllib.pathname2url(file_path))
         else:
-            base_url = "%s://%s:%s/folder/%s" % (scheme, host, port,
+            base_url = "{0!s}://{1!s}:{2!s}/folder/{3!s}".format(scheme, host, port,
                                               urllib.pathname2url(file_path))
         return base_url
 

--- a/nova/virt/vmwareapi/vm_util.py
+++ b/nova/virt/vmwareapi/vm_util.py
@@ -170,7 +170,7 @@ VmdkInfo = collections.namedtuple('VmdkInfo', ['path', 'adapter_type',
 
 def _iface_id_option_value(client_factory, iface_id, port_index):
     opt = client_factory.create('ns0:OptionValue')
-    opt.key = "nvp.iface-id.%d" % port_index
+    opt.key = "nvp.iface-id.{0:d}".format(port_index)
     opt.value = iface_id
     return opt
 
@@ -644,7 +644,7 @@ def get_vmdk_info(session, vm_ref, uuid=None):
     root_disk = None
     root_device = None
     if uuid:
-        root_disk = '%s.vmdk' % uuid
+        root_disk = '{0!s}.vmdk'.format(uuid)
     vmdk_device = None
 
     adapter_type_dict = {}
@@ -1518,7 +1518,7 @@ def find_rescue_device(hardware_devices, instance):
 
 
 def get_ephemeral_name(id):
-    return 'ephemeral_%d.vmdk' % id
+    return 'ephemeral_{0:d}.vmdk'.format(id)
 
 
 def _detach_and_delete_devices_config_spec(client_factory, devices):
@@ -1629,7 +1629,7 @@ def folder_ref_cache_get(path):
 
 def _get_vm_name(display_name, id):
     if display_name:
-        return '%s (%s)' % (display_name[:41], id[:36])
+        return '{0!s} ({1!s})'.format(display_name[:41], id[:36])
     else:
         return id[:36]
 

--- a/nova/virt/vmwareapi/vmops.py
+++ b/nova/virt/vmwareapi/vmops.py
@@ -114,7 +114,7 @@ class VirtualMachineInstanceConfigInfo(object):
     def cache_image_path(self):
         if self.ii.image_id is None:
             return
-        cached_image_file_name = "%s.%s" % (self.ii.image_id,
+        cached_image_file_name = "{0!s}.{1!s}".format(self.ii.image_id,
                                             self.ii.file_type)
         return self.cache_image_folder.join(cached_image_file_name)
 
@@ -166,11 +166,11 @@ class VMwareVMOps(object):
     def _get_base_folder(self):
         # Enable more than one compute node to run on the same host
         if CONF.vmware.cache_prefix:
-            base_folder = '%s%s' % (CONF.vmware.cache_prefix,
+            base_folder = '{0!s}{1!s}'.format(CONF.vmware.cache_prefix,
                                     CONF.image_cache_subdirectory_name)
         # Ensure that the base folder is unique per compute node
         elif CONF.remove_unused_base_images:
-            base_folder = '%s%s' % (CONF.my_ip,
+            base_folder = '{0!s}{1!s}'.format(CONF.my_ip,
                                     CONF.image_cache_subdirectory_name)
         else:
             # Aging disable ensures backward compatibility
@@ -289,7 +289,7 @@ class VMwareVMOps(object):
         # Maximum folder length must be less than 80 characters.
         # The 'id' length is 36. The maximum prefix for name is 40.
         # We cannot truncate the 'id' as this is unique across OpenStack.
-        return '%s (%s)' % (name[:40], id[:36])
+        return '{0!s} ({1!s})'.format(name[:40], id[:36])
 
     def build_virtual_machine(self, instance, image_info,
                               dc_info, datastore, network_info, extra_specs,
@@ -318,7 +318,7 @@ class VMwareVMOps(object):
 
         folder_name = self._get_folder_name('Project',
                                             instance.project_id)
-        folder_path = 'OpenStack/%s/Instances' % folder_name
+        folder_path = 'OpenStack/{0!s}/Instances'.format(folder_name)
         folder = self._create_folders(dc_info.vmFolder, folder_path)
 
         # Create the VM
@@ -474,10 +474,10 @@ class VMwareVMOps(object):
         return tmp_dir_loc, flat_vmdk_ds_loc
 
     def _prepare_stream_optimized_image(self, vi):
-        vm_name = "%s_%s" % (constants.IMAGE_VM_PREFIX,
+        vm_name = "{0!s}_{1!s}".format(constants.IMAGE_VM_PREFIX,
                              uuidutils.generate_uuid())
         tmp_dir_loc = vi.datastore.build_path(vm_name)
-        tmp_image_ds_loc = tmp_dir_loc.join("%s.vmdk" % tmp_dir_loc.basename)
+        tmp_image_ds_loc = tmp_dir_loc.join("{0!s}.vmdk".format(tmp_dir_loc.basename))
         return tmp_dir_loc, tmp_image_ds_loc
 
     def _prepare_iso_image(self, vi):
@@ -528,7 +528,7 @@ class VMwareVMOps(object):
                             vi.cache_image_folder)
 
     def _cache_stream_optimized_image(self, vi, tmp_image_ds_loc):
-        dst_path = vi.cache_image_folder.join("%s.vmdk" % vi.ii.image_id)
+        dst_path = vi.cache_image_folder.join("{0!s}.vmdk".format(vi.ii.image_id))
         ds_util.mkdir(self._session, vi.cache_image_folder, vi.dc_info.ref)
         try:
             ds_util.disk_move(self._session, vi.dc_info.ref,
@@ -692,7 +692,7 @@ class VMwareVMOps(object):
         # image. This ensures that further operations involving size checks
         # and disk resizing will work as expected.
         ds_browser = self._get_ds_browser(vi.datastore.ref)
-        flat_file = "%s-flat.vmdk" % vi.ii.image_id
+        flat_file = "{0!s}-flat.vmdk".format(vi.ii.image_id)
         new_size = ds_util.file_size(self._session, ds_browser,
                                      vi.cache_image_folder, flat_file)
         if new_size is not None:
@@ -755,7 +755,7 @@ class VMwareVMOps(object):
                 self._use_disk_image_as_full_clone(vm_ref, vi)
 
         if block_device_mapping:
-            msg = "Block device information present: %s" % block_device_info
+            msg = "Block device information present: {0!s}".format(block_device_info)
             # NOTE(mriedem): block_device_info can contain an auth_password
             # so we have to scrub the message before logging it.
             LOG.debug(strutils.mask_password(msg), instance=instance)
@@ -833,8 +833,8 @@ class VMwareVMOps(object):
                 with utils.tempdir() as tmp_path:
                     tmp_file = os.path.join(tmp_path, 'configdrive.iso')
                     cdb.make_drive(tmp_file)
-                    upload_iso_path = "%s/configdrive.iso" % (
-                        upload_folder)
+                    upload_iso_path = "{0!s}/configdrive.iso".format((
+                        upload_folder))
                     images.upload_iso_to_datastore(
                         tmp_file, instance,
                         host=self._session._host,
@@ -879,7 +879,7 @@ class VMwareVMOps(object):
         snapshot_task = self._session._call_method(
                     self._session.vim,
                     "CreateSnapshot_Task", vm_ref,
-                    name="%s-snapshot" % instance.uuid,
+                    name="{0!s}-snapshot".format(instance.uuid),
                     description="Taking Snapshot of the VM",
                     memory=False,
                     quiesce=True)
@@ -914,7 +914,7 @@ class VMwareVMOps(object):
                 disk_move_type="createNewChildDiskBacking")
         clone_spec = vm_util.clone_vm_spec(client_factory, rel_spec,
                 power_on=False, snapshot=snapshot_ref, template=True)
-        vm_name = "%s_%s" % (constants.SNAPSHOT_VM_PREFIX,
+        vm_name = "{0!s}_{1!s}".format(constants.SNAPSHOT_VM_PREFIX,
                              uuidutils.generate_uuid())
 
         LOG.debug("Creating linked-clone VM from snapshot", instance=instance)
@@ -1194,7 +1194,7 @@ class VMwareVMOps(object):
 
         # Get the rescue disk path
         rescue_disk_path = datastore.build_path(instance.uuid,
-                "%s-rescue.%s" % (image_info.image_id, image_info.file_type))
+                "{0!s}-rescue.{1!s}".format(image_info.image_id, image_info.file_type))
 
         # Copy the cached image to the be the rescue disk. This will be used
         # as the rescue disk for the instance.
@@ -1791,7 +1791,7 @@ class VMwareVMOps(object):
         """Uses cached image disk by copying it into the VM directory."""
 
         instance_folder = vi.instance.uuid
-        root_disk_name = "%s.vmdk" % vi.instance.uuid
+        root_disk_name = "{0!s}.vmdk".format(vi.instance.uuid)
         root_disk_ds_loc = vi.datastore.build_path(instance_folder,
                                                    root_disk_name)
 
@@ -1820,9 +1820,9 @@ class VMwareVMOps(object):
     def _use_disk_image_as_linked_clone(self, vm_ref, vi):
         """Uses cached image as parent of a COW child in the VM directory."""
 
-        sized_image_disk_name = "%s.vmdk" % vi.ii.image_id
+        sized_image_disk_name = "{0!s}.vmdk".format(vi.ii.image_id)
         if vi.root_gb > 0:
-            sized_image_disk_name = "%s.%s.vmdk" % (vi.ii.image_id, vi.root_gb)
+            sized_image_disk_name = "{0!s}.{1!s}.vmdk".format(vi.ii.image_id, vi.root_gb)
         sized_disk_ds_loc = vi.cache_image_folder.join(sized_image_disk_name)
 
         # Ensure only a single thread extends the image at once.
@@ -1895,7 +1895,7 @@ class VMwareVMOps(object):
         # Optionally create and attach blank disk
         if vi.root_gb > 0:
             instance_folder = vi.instance.uuid
-            root_disk_name = "%s.vmdk" % vi.instance.uuid
+            root_disk_name = "{0!s}.vmdk".format(vi.instance.uuid)
             root_disk_ds_loc = vi.datastore.build_path(instance_folder,
                                                        root_disk_name)
 

--- a/nova/virt/vmwareapi/volumeops.py
+++ b/nova/virt/vmwareapi/volumeops.py
@@ -78,7 +78,7 @@ class VMwareVolumeOps(object):
 
     def _update_volume_details(self, vm_ref, volume_uuid, device_uuid):
         # Store the uuid of the volume_device
-        volume_option = 'volume-%s' % volume_uuid
+        volume_option = 'volume-{0!s}'.format(volume_uuid)
         extra_opts = {volume_option: device_uuid}
 
         client_factory = self._session.vim.client.factory
@@ -87,7 +87,7 @@ class VMwareVolumeOps(object):
         vm_util.reconfigure_vm(self._session, vm_ref, extra_config_specs)
 
     def _get_volume_uuid(self, vm_ref, volume_uuid):
-        prop = 'config.extraConfig["volume-%s"]' % volume_uuid
+        prop = 'config.extraConfig["volume-{0!s}"]'.format(volume_uuid)
         opt_val = self._session._call_method(vutil,
                                              'get_object_property',
                                              vm_ref,
@@ -222,7 +222,7 @@ class VMwareVolumeOps(object):
                     # Check if iscsi host is already in the send target host
                     # list
                     send_targets = getattr(hba, 'configuredSendTarget', [])
-                    send_tgt_portals = ['%s:%s' % (s.address, s.port) for s in
+                    send_tgt_portals = ['{0!s}:{1!s}'.format(s.address, s.port) for s in
                                         send_targets]
                     if target_portal not in send_tgt_portals:
                         self._iscsi_add_send_target_host(storage_system_mor,

--- a/nova/virt/xenapi/agent.py
+++ b/nova/virt/xenapi/agent.py
@@ -419,7 +419,7 @@ class SimpleDH(object):
 
     def _run_ssl(self, text, decrypt=False):
         cmd = ['openssl', 'aes-128-cbc', '-A', '-a', '-pass',
-               'pass:%s' % self._shared, '-nosalt']
+               'pass:{0!s}'.format(self._shared), '-nosalt']
         if decrypt:
             cmd.append('-d')
         out, err = utils.execute(*cmd, process_input=text)

--- a/nova/virt/xenapi/client/objects.py
+++ b/nova/virt/xenapi/client/objects.py
@@ -55,7 +55,7 @@ class XenAPISessionObject(object):
         self.name = name
 
     def _call_method(self, method_name, *args):
-        call = "%s.%s" % (self.name, method_name)
+        call = "{0!s}.{1!s}".format(self.name, method_name)
         return self.session.call_xenapi(call, *args)
 
     def __getattr__(self, method_name):

--- a/nova/virt/xenapi/client/session.py
+++ b/nova/virt/xenapi/client/session.py
@@ -302,7 +302,7 @@ class XenAPISession(object):
 
     def get_rec(self, record_type, ref):
         try:
-            return self.call_xenapi('%s.get_record' % record_type, ref)
+            return self.call_xenapi('{0!s}.get_record'.format(record_type), ref)
         except self.XenAPI.Failure as e:
             if e.details[0] != 'HANDLE_INVALID':
                 raise
@@ -316,4 +316,4 @@ class XenAPISession(object):
         the `get_all` call and the `get_record` call.
         """
 
-        return self.call_xenapi('%s.get_all_records' % record_type).items()
+        return self.call_xenapi('{0!s}.get_all_records'.format(record_type)).items()

--- a/nova/virt/xenapi/fake.py
+++ b/nova/virt/xenapi/fake.py
@@ -256,7 +256,7 @@ def after_VM_create(vm_ref, vm_rec):
 
 
 def create_pbd(host_ref, sr_ref, attached):
-    config = {'path': '/var/run/sr-mount/%s' % sr_ref}
+    config = {'path': '/var/run/sr-mount/{0!s}'.format(sr_ref)}
     return _create_object('PBD',
                           {'device_config': config,
                            'host': host_ref,
@@ -438,15 +438,15 @@ def get_record(table, ref):
 
 def check_for_session_leaks():
     if len(_db_content['session']) > 0:
-        raise exception.NovaException('Sessions have leaked: %s' %
-                              _db_content['session'])
+        raise exception.NovaException('Sessions have leaked: {0!s}'.format(
+                              _db_content['session']))
 
 
 def as_value(s):
     """Helper function for simulating XenAPI plugin responses.  It
     escapes and wraps the given argument.
     """
-    return '<value>%s</value>' % saxutils.escape(s)
+    return '<value>{0!s}</value>'.format(saxutils.escape(s))
 
 
 def as_json(*args, **kwargs):
@@ -467,7 +467,7 @@ class Failure(Exception):
         try:
             return str(self.details)
         except Exception:
-            return "XenAPI Fake Failure: %s" % str(self.details)
+            return "XenAPI Fake Failure: {0!s}".format(str(self.details))
 
     def _details_map(self):
         return {str(i): self.details[i] for i in range(len(self.details))}
@@ -646,8 +646,8 @@ class SessionBase(object):
     def _plugin_agent_agentupdate(self, method, args):
         url = args["url"]
         md5 = args["md5sum"]
-        message = "success with %(url)s and hash:%(md5)s" % dict(url=url,
-                                                                 md5=md5)
+        message = "success with {url!s} and hash:{md5!s}".format(**dict(url=url,
+                                                                 md5=md5))
         return as_json(returncode='0', message=message)
 
     def _plugin_noop(self, method, args):
@@ -758,7 +758,7 @@ class SessionBase(object):
         dom_id = args["dom_id"]
         if dom_id == 0:
             raise Failure('Guest does not have a console')
-        return base64.b64encode(zlib.compress("dom_id: %s" % dom_id))
+        return base64.b64encode(zlib.compress("dom_id: {0!s}".format(dom_id)))
 
     def _plugin_nova_plugin_version_get_version(self, method, args):
         return pickle.dumps("1.3")
@@ -767,10 +767,9 @@ class SessionBase(object):
         return pickle.dumps("False")
 
     def host_call_plugin(self, _1, _2, plugin, method, args):
-        func = getattr(self, '_plugin_%s_%s' % (plugin, method), None)
+        func = getattr(self, '_plugin_{0!s}_{1!s}'.format(plugin, method), None)
         if not func:
-            raise Exception('No simulation in host_call_plugin for %s,%s' %
-                            (plugin, method))
+            raise Exception('No simulation in host_call_plugin for {0!s},{1!s}'.format(plugin, method))
 
         return func(method, args)
 
@@ -993,7 +992,7 @@ class SessionBase(object):
                _create_object(cls, params[1]))
 
         # Call hook to provide any fixups needed (ex. creating backrefs)
-        after_hook = 'after_%s_create' % cls
+        after_hook = 'after_{0!s}_create'.format(cls)
         if after_hook in globals():
             globals()[after_hook](ref, params[1])
 
@@ -1013,7 +1012,7 @@ class SessionBase(object):
             raise Failure(['HANDLE_INVALID', table, ref])
 
         # Call destroy function (if exists)
-        destroy_func = globals().get('destroy_%s' % table.lower())
+        destroy_func = globals().get('destroy_{0!s}'.format(table.lower()))
         if destroy_func:
             destroy_func(ref)
         else:
@@ -1077,7 +1076,7 @@ class _Dispatcher(object):
 
     def __repr__(self):
         if self.__name:
-            return '<xenapi.fake._Dispatcher for %s>' % self.__name
+            return '<xenapi.fake._Dispatcher for {0!s}>'.format(self.__name)
         else:
             return '<xenapi.fake._Dispatcher>'
 
@@ -1085,7 +1084,7 @@ class _Dispatcher(object):
         if self.__name is None:
             return _Dispatcher(self.__send, name)
         else:
-            return _Dispatcher(self.__send, "%s.%s" % (self.__name, name))
+            return _Dispatcher(self.__send, "{0!s}.{1!s}".format(self.__name, name))
 
     def __call__(self, *args):
         return self.__send(self.__name, args)

--- a/nova/virt/xenapi/firewall.py
+++ b/nova/virt/xenapi/firewall.py
@@ -49,8 +49,8 @@ class Dom0IptablesFirewallDriver(firewall.IptablesFirewallDriver):
 
     def _build_tcp_udp_rule(self, rule, version):
         if rule.from_port == rule.to_port:
-            return ['--dport', '%s' % (rule.from_port,)]
+            return ['--dport', '{0!s}'.format(rule.from_port)]
         else:
             #  No multiport needed for XS!
-            return ['--dport', '%s:%s' % (rule.from_port,
+            return ['--dport', '{0!s}:{1!s}'.format(rule.from_port,
                                            rule.to_port)]

--- a/nova/virt/xenapi/image/bittorrent.py
+++ b/nova/virt/xenapi/image/bittorrent.py
@@ -78,7 +78,7 @@ class BittorrentStore(object):
 
             def _default_torrent_url_fn(image_id):
                 return urlparse.urljoin(CONF.xenserver.torrent_base_url,
-                                        "%s.torrent" % image_id)
+                                        "{0!s}.torrent".format(image_id))
 
             return _default_torrent_url_fn
 

--- a/nova/virt/xenapi/network_utils.py
+++ b/nova/virt/xenapi/network_utils.py
@@ -39,8 +39,7 @@ def find_network_with_bridge(session, bridge):
     The bridge is defined in the nova db and can be found either in the
     'bridge' or 'name_label' fields of the XenAPI network record.
     """
-    expr = ('field "name__label" = "%s" or field "bridge" = "%s"' %
-            (bridge, bridge))
+    expr = ('field "name__label" = "{0!s}" or field "bridge" = "{1!s}"'.format(bridge, bridge))
     networks = session.network.get_all_records_where(expr)
     if len(networks) == 1:
         return list(networks.keys())[0]

--- a/nova/virt/xenapi/pool.py
+++ b/nova/virt/xenapi/pool.py
@@ -240,4 +240,4 @@ class ResourcePool(object):
 def swap_xapi_host(url, host_addr):
     """Replace the XenServer address present in 'url' with 'host_addr'."""
     temp_url = urlparse.urlparse(url)
-    return url.replace(temp_url.hostname, '%s' % host_addr)
+    return url.replace(temp_url.hostname, '{0!s}'.format(host_addr))

--- a/nova/virt/xenapi/vif.py
+++ b/nova/virt/xenapi/vif.py
@@ -137,7 +137,7 @@ class XenAPIBridgeDriver(XenVIFDriver):
         if network_ref is None:
             # If bridge does not exists
             # 1 - create network
-            description = 'network for nova bridge %s' % bridge
+            description = 'network for nova bridge {0!s}'.format(bridge)
             network_rec = {'name_label': bridge,
                            'name_description': description,
                            'other_config': {}}
@@ -146,8 +146,8 @@ class XenAPIBridgeDriver(XenVIFDriver):
             # 2 - find PIF for VLAN NOTE(salvatore-orlando): using double
             # quotes inside single quotes as xapi filter only support
             # tokens in double quotes
-            expr = ('field "device" = "%s" and field "VLAN" = "-1"' %
-                    bridge_interface)
+            expr = ('field "device" = "{0!s}" and field "VLAN" = "-1"'.format(
+                    bridge_interface))
             pifs = self._session.call_xenapi('PIF.get_all_records_where',
                                              expr)
 

--- a/nova/virt/xenapi/volume_utils.py
+++ b/nova/virt/xenapi/volume_utils.py
@@ -53,7 +53,7 @@ def parse_sr_info(connection_data, description=''):
     params = {}
     if 'sr_uuid' not in connection_data:
         params = _parse_volume_info(connection_data)
-        sr_identity = "%s/%s/%s" % (params['target'], params['port'],
+        sr_identity = "{0!s}/{1!s}/{2!s}".format(params['target'], params['port'],
                                     params['targetIQN'])
         # PY2 can only support taking an ascii string to uuid5
         if six.PY2 and isinstance(sr_identity, unicode):
@@ -65,7 +65,7 @@ def parse_sr_info(connection_data, description=''):
             params[k] = connection_data[k]
 
     label = connection_data.pop('name_label',
-                                'tempSR-%s' % sr_uuid)
+                                'tempSR-{0!s}'.format(sr_uuid))
     params['name_description'] = connection_data.get('name_description',
                                                      description)
 
@@ -345,7 +345,7 @@ def find_vbd_by_number(session, vm_ref, dev_number):
                 if user_device == requested_device:
                     return vbd_ref
             except session.XenAPI.Failure:
-                msg = "Error looking up VBD %s for %s" % (vbd_ref, vm_ref)
+                msg = "Error looking up VBD {0!s} for {1!s}".format(vbd_ref, vm_ref)
                 LOG.debug(msg, exc_info=True)
 
 

--- a/nova/virt/xenapi/volumeops.py
+++ b/nova/virt/xenapi/volumeops.py
@@ -83,7 +83,7 @@ class VolumeOps(object):
 
     def _connect_to_volume_provider(self, connection_data, instance_name):
         sr_uuid, sr_label, sr_params = volume_utils.parse_sr_info(
-                connection_data, 'Disk-for:%s' % instance_name)
+                connection_data, 'Disk-for:{0!s}'.format(instance_name))
         sr_ref = volume_utils.find_sr_by_uuid(self._session, sr_uuid)
         if not sr_ref:
             # introduce SR because not already present
@@ -204,7 +204,7 @@ class VolumeOps(object):
             except self._session.XenAPI.Failure as exc:
                 if exc.details[0] == 'SR_BACKEND_FAILURE_40':
                     device = self._session.VBD.get_device(vbd_ref)
-                    bad_devices.append('/dev/%s' % device)
+                    bad_devices.append('/dev/{0!s}'.format(device))
                 else:
                     raise
 
@@ -224,5 +224,5 @@ class VolumeOps(object):
                 # Forget (i.e. disconnect) SR only if not in use
                 volume_utils.purge_sr(self._session, sr_ref)
             except Exception:
-                LOG.debug('Ignoring error while purging sr: %s' % sr_ref,
+                LOG.debug('Ignoring error while purging sr: {0!s}'.format(sr_ref),
                         exc_info=True)

--- a/nova/vnc/xvp_proxy.py
+++ b/nova/vnc/xvp_proxy.py
@@ -71,8 +71,8 @@ class XCPVNCProxy(object):
 
         # Handshake as necessary
         if connect_info.get('internal_access_path'):
-            server.sendall("CONNECT %s HTTP/1.1\r\n\r\n" %
-                        connect_info['internal_access_path'])
+            server.sendall("CONNECT {0!s} HTTP/1.1\r\n\r\n".format(
+                        connect_info['internal_access_path']))
 
             data = ""
             while True:

--- a/nova/volume/encryptors/cryptsetup.py
+++ b/nova/volume/encryptors/cryptsetup.py
@@ -98,7 +98,7 @@ class CryptsetupEncryptor(base.VolumeEncryptor):
 
         # modify the original symbolic link to refer to the decrypted device
         utils.execute('ln', '--symbolic', '--force',
-                      '/dev/mapper/%s' % self.dev_name, self.symlink_path,
+                      '/dev/mapper/{0!s}'.format(self.dev_name), self.symlink_path,
                       run_as_root=True, check_exit_code=True)
 
     def _close_volume(self, **kwargs):

--- a/nova/volume/encryptors/luks.py
+++ b/nova/volume/encryptors/luks.py
@@ -116,7 +116,7 @@ class LuksEncryptor(cryptsetup.CryptsetupEncryptor):
 
         # modify the original symbolic link to refer to the decrypted device
         utils.execute('ln', '--symbolic', '--force',
-                      '/dev/mapper/%s' % self.dev_name, self.symlink_path,
+                      '/dev/mapper/{0!s}'.format(self.dev_name), self.symlink_path,
                       run_as_root=True, check_exit_code=True)
 
     def _close_volume(self, **kwargs):

--- a/nova/weights.py
+++ b/nova/weights.py
@@ -60,7 +60,7 @@ class WeighedObject(object):
         self.weight = weight
 
     def __repr__(self):
-        return "<WeighedObject '%s': %s>" % (self.obj, self.weight)
+        return "<WeighedObject '{0!s}': {1!s}>".format(self.obj, self.weight)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/nova/wsgi.py
+++ b/nova/wsgi.py
@@ -74,7 +74,7 @@ class Server(service.ServiceBase):
         self._protocol = protocol
         self.pool_size = pool_size or self.default_pool_size
         self._pool = eventlet.GreenPool(self.pool_size)
-        self._logger = logging.getLogger("nova.%s.wsgi.server" % self.name)
+        self._logger = logging.getLogger("nova.{0!s}.wsgi.server".format(self.name))
         self._use_ssl = use_ssl
         self._max_url_len = max_url_len
         self.client_socket_timeout = CONF.wsgi.client_socket_timeout or None
@@ -494,7 +494,7 @@ class Loader(object):
         try:
             LOG.debug("Loading app %(name)s from %(path)s",
                       {'name': name, 'path': self.config_path})
-            return deploy.loadapp("config:%s" % self.config_path, name=name)
+            return deploy.loadapp("config:{0!s}".format(self.config_path), name=name)
         except LookupError:
             LOG.exception(_LE("Couldn't lookup app: %s"), name)
             raise exception.PasteAppNotFound(name=name, path=self.config_path)

--- a/nova/wsgi/nova-api.py
+++ b/nova/wsgi/nova-api.py
@@ -37,6 +37,6 @@ objects.register_all()
 conf = config_files[0]
 name = "osapi_compute"
 
-options = deploy.appconfig('config:%s' % conf, name=name)
+options = deploy.appconfig('config:{0!s}'.format(conf), name=name)
 
-application = deploy.loadapp('config:%s' % conf, name=name)
+application = deploy.loadapp('config:{0!s}'.format(conf), name=name)

--- a/nova/wsgi/nova-metadata.py
+++ b/nova/wsgi/nova-metadata.py
@@ -37,6 +37,6 @@ objects.register_all()
 conf = config_files[0]
 name = "metadata"
 
-options = deploy.appconfig('config:%s' % conf, name=name)
+options = deploy.appconfig('config:{0!s}'.format(conf), name=name)
 
-application = deploy.loadapp('config:%s' % conf, name=name)
+application = deploy.loadapp('config:{0!s}'.format(conf), name=name)

--- a/plugins/xenserver/networking/etc/xensource/scripts/ovs_configure_base_flows.py
+++ b/plugins/xenserver/networking/etc/xensource/scripts/ovs_configure_base_flows.py
@@ -43,7 +43,7 @@ def main(command, phys_dev_name):
         # allow all traffic from the physical NIC, as it is trusted (i.e.,
         # from a filtered vif, or from the physical infrastructure)
         ovs_ofctl('add-flow', bridge_name,
-                  "priority=2,in_port=%s,actions=normal" % pnic_ofport)
+                  "priority=2,in_port={0!s},actions=normal".format(pnic_ofport))
 
         # Allow traffic from dom0 if there is a management interface
         # present (its IP address is on the bridge itself)
@@ -63,8 +63,8 @@ if __name__ == "__main__":
         print(sys.argv)
         script_name = os.path.basename(sys.argv[0])
         print("This script configures base ovs flows.")
-        print("usage: %s [online|offline|reset] phys-dev-name" % script_name)
-        print("   ex: %s online eth0" % script_name)
+        print("usage: {0!s} [online|offline|reset] phys-dev-name".format(script_name))
+        print("   ex: {0!s} online eth0".format(script_name))
         sys.exit(1)
     else:
         command, phys_dev_name = sys.argv[1:3]

--- a/plugins/xenserver/networking/etc/xensource/scripts/ovs_configure_vif_flows.py
+++ b/plugins/xenserver/networking/etc/xensource/scripts/ovs_configure_vif_flows.py
@@ -41,7 +41,7 @@ class OvsFlow(object):
 
     def clear_flows(self, ofport):
         novalib.execute(OVS_OFCTL, 'del-flows',
-                                        self.bridge, "in_port=%s" % ofport)
+                                        self.bridge, "in_port={0!s}".format(ofport))
 
 
 def main(command, vif_raw, net_type):
@@ -49,25 +49,24 @@ def main(command, vif_raw, net_type):
         return
 
     vif_name, dom_id, vif_index = vif_raw.split('-')
-    vif = "%s%s.%s" % (vif_name, dom_id, vif_index)
+    vif = "{0!s}{1!s}.{2!s}".format(vif_name, dom_id, vif_index)
 
     bridge = novalib.execute_get_output('/usr/bin/ovs-vsctl',
                                                     'iface-to-br', vif)
 
     xsls = novalib.execute_get_output('/usr/bin/xenstore-ls',
-                              '/local/domain/%s/vm-data/networking' % dom_id)
+                              '/local/domain/{0!s}/vm-data/networking'.format(dom_id))
     macs = [line.split("=")[0].strip() for line in xsls.splitlines()]
 
     for mac in macs:
         xsread = novalib.execute_get_output('/usr/bin/xenstore-read',
-                                    '/local/domain/%s/vm-data/networking/%s' %
-                                    (dom_id, mac))
+                                    '/local/domain/{0!s}/vm-data/networking/{1!s}'.format(dom_id, mac))
         data = json.loads(xsread)
         if data["label"] == "public":
-            this_vif = "vif%s.0" % dom_id
+            this_vif = "vif{0!s}.0".format(dom_id)
             phys_dev = "eth0"
         else:
-            this_vif = "vif%s.1" % dom_id
+            this_vif = "vif{0!s}.1".format(dom_id)
             phys_dev = "eth1"
 
         if vif == this_vif:
@@ -227,8 +226,8 @@ def apply_ovs_ipv6_flows(ovs, bridge, params):
 
 if __name__ == "__main__":
     if len(sys.argv) != 4:
-        print ("usage: %s [online|offline] vif-domid-idx [ipv4|ipv6|all] " %
-               os.path.basename(sys.argv[0]))
+        print ("usage: {0!s} [online|offline] vif-domid-idx [ipv4|ipv6|all] ".format(
+               os.path.basename(sys.argv[0])))
         sys.exit(1)
     else:
         command, vif_raw, net_type = sys.argv[1:4]

--- a/plugins/xenserver/networking/etc/xensource/scripts/vif_rules.py
+++ b/plugins/xenserver/networking/etc/xensource/scripts/vif_rules.py
@@ -30,19 +30,18 @@ import novalib  # noqa
 
 def main(dom_id, command, only_this_vif=None):
     xsls = novalib.execute_get_output('/usr/bin/xenstore-ls',
-                              '/local/domain/%s/vm-data/networking' % dom_id)
+                              '/local/domain/{0!s}/vm-data/networking'.format(dom_id))
     macs = [line.split("=")[0].strip() for line in xsls.splitlines()]
 
     for mac in macs:
         xsread = novalib.execute_get_output('/usr/bin/xenstore-read',
-                                    '/local/domain/%s/vm-data/networking/%s' %
-                                    (dom_id, mac))
+                                    '/local/domain/{0!s}/vm-data/networking/{1!s}'.format(dom_id, mac))
         data = json.loads(xsread)
         for ip in data['ips']:
             if data["label"] == "public":
-                vif = "vif%s.0" % dom_id
+                vif = "vif{0!s}.0".format(dom_id)
             else:
-                vif = "vif%s.1" % dom_id
+                vif = "vif{0!s}.1".format(dom_id)
 
             if (only_this_vif is None) or (vif == only_this_vif):
                 params = dict(IP=ip['ip'], VIF=vif, MAC=data['mac'])
@@ -123,8 +122,8 @@ def apply_ebtables_rules(command, params):
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
-        print ("usage: %s dom_id online|offline [vif]" %
-               os.path.basename(sys.argv[0]))
+        print ("usage: {0!s} dom_id online|offline [vif]".format(
+               os.path.basename(sys.argv[0])))
         sys.exit(1)
     else:
         dom_id, command = sys.argv[1:3]

--- a/plugins/xenserver/xenapi/etc/xapi.d/plugins/pluginlib_nova.py
+++ b/plugins/xenserver/xenapi/etc/xapi.d/plugins/pluginlib_nova.py
@@ -41,7 +41,7 @@ def configure_logging(name):
     log.setLevel(logging.DEBUG)
     sysh = logging.handlers.SysLogHandler('/dev/log')
     sysh.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%s: %%(levelname)-8s %%(message)s' % name)
+    formatter = logging.Formatter('{0!s}: %(levelname)-8s %(message)s'.format(name))
     sysh.setFormatter(formatter)
     log.addHandler(sysh)
 

--- a/plugins/xenserver/xenapi/etc/xapi.d/plugins/utils.py
+++ b/plugins/xenserver/xenapi/etc/xapi.d/plugins/utils.py
@@ -45,18 +45,18 @@ def delete_if_exists(path):
         os.unlink(path)
     except OSError, e:  # noqa
         if e.errno == errno.ENOENT:
-            LOG.warning("'%s' was already deleted, skipping delete" % path)
+            LOG.warning("'{0!s}' was already deleted, skipping delete".format(path))
         else:
             raise
 
 
 def _link(src, dst):
-    LOG.info("Hard-linking file '%s' -> '%s'" % (src, dst))
+    LOG.info("Hard-linking file '{0!s}' -> '{1!s}'".format(src, dst))
     os.link(src, dst)
 
 
 def _rename(src, dst):
-    LOG.info("Renaming file '%s' -> '%s'" % (src, dst))
+    LOG.info("Renaming file '{0!s}' -> '{1!s}'".format(src, dst))
     try:
         os.rename(src, dst)
     except OSError, e:  # noqa
@@ -70,7 +70,7 @@ def make_subprocess(cmdline, stdout=False, stderr=False, stdin=False,
                     universal_newlines=False, close_fds=True, env=None):
     """Make a subprocess according to the given command-line string
     """
-    LOG.info("Running cmd '%s'" % " ".join(cmdline))
+    LOG.info("Running cmd '{0!s}'".format(" ".join(cmdline)))
     kwargs = {}
     kwargs['stdout'] = stdout and subprocess.PIPE or None
     kwargs['stderr'] = stderr and subprocess.PIPE or None
@@ -132,11 +132,11 @@ def run_command(cmd, cmd_input=None, ok_exit_codes=None):
 def try_kill_process(proc):
     """Sends the given process the SIGKILL signal."""
     pid = proc.pid
-    LOG.info("Killing process %s" % pid)
+    LOG.info("Killing process {0!s}".format(pid))
     try:
         os.kill(pid, signal.SIGKILL)
     except Exception:
-        LOG.exception("Failed to kill %s" % pid)
+        LOG.exception("Failed to kill {0!s}".format(pid))
 
 
 def make_staging_area(sr_path):
@@ -204,7 +204,7 @@ def _handle_old_style_images(staging_path):
     for filename in ('snap.vhd', 'image.vhd', 'base.vhd'):
         path = os.path.join(staging_path, filename)
         if os.path.exists(path):
-            _rename(path, os.path.join(staging_path, "%d.vhd" % file_num))
+            _rename(path, os.path.join(staging_path, "{0:d}.vhd".format(file_num)))
             file_num += 1
 
     # Rename any format of name to 0.vhd when there is only single one
@@ -231,7 +231,7 @@ def _assert_vhd_not_hidden(path):
             value = line.split(':')[1].strip()
             if value == "1":
                 raise Exception(
-                    "VHD %s is marked as hidden without child" % path)
+                    "VHD {0!s} is marked as hidden without child".format(path))
 
 
 def _vhd_util_check(vdi_path):
@@ -279,14 +279,14 @@ def _validate_vhd(vdi_path):
             extra = (" ensure source and destination host machines have "
                      "time set correctly")
 
-        LOG.info("VDI Error details: %s" % out)
+        LOG.info("VDI Error details: {0!s}".format(out))
 
         raise Exception(
             "VDI '%(vdi_path)s' has an invalid %(part)s: '%(details)s'"
             "%(extra)s" % {'vdi_path': vdi_path, 'part': part,
                            'details': details, 'extra': extra})
 
-    LOG.info("VDI is valid: %s" % vdi_path)
+    LOG.info("VDI is valid: {0!s}".format(vdi_path))
 
 
 def _validate_vdi_chain(vdi_path):
@@ -308,7 +308,7 @@ def _validate_vdi_chain(vdi_path):
             raise Exception("VDI '%s' not present which breaks"
                             " the VDI chain, bailing out" % path)
         else:
-            raise Exception("Unexpected output '%s' from vhd-util" % out)
+            raise Exception("Unexpected output '{0!s}' from vhd-util".format(out))
 
     cur_path = vdi_path
     while cur_path:
@@ -330,10 +330,9 @@ def _validate_sequenced_vhds(staging_path):
         if filename == "swap.vhd":
             continue
 
-        vhd_path = os.path.join(staging_path, "%d.vhd" % seq_num)
+        vhd_path = os.path.join(staging_path, "{0:d}.vhd".format(seq_num))
         if not os.path.exists(vhd_path):
-            raise Exception("Corrupt image. Expected seq number: %d. Files: %s"
-                            % (seq_num, filenames))
+            raise Exception("Corrupt image. Expected seq number: {0:d}. Files: {1!s}".format(seq_num, filenames))
 
         seq_num += 1
 
@@ -358,13 +357,13 @@ def import_vhds(sr_path, staging_path, uuid_stack):
     # Collect sequenced VHDs and assign UUIDs to them
     seq_num = 0
     while True:
-        orig_vhd_path = os.path.join(staging_path, "%d.vhd" % seq_num)
+        orig_vhd_path = os.path.join(staging_path, "{0:d}.vhd".format(seq_num))
         if not os.path.exists(orig_vhd_path):
             break
 
         # Rename (0, 1 .. N).vhd -> aaaa-bbbb-cccc-dddd.vhd
         vhd_uuid = uuid_stack.pop()
-        vhd_path = os.path.join(staging_path, "%s.vhd" % vhd_uuid)
+        vhd_path = os.path.join(staging_path, "{0!s}.vhd".format(vhd_uuid))
         _rename(orig_vhd_path, vhd_path)
 
         if seq_num == 0:
@@ -401,8 +400,8 @@ def import_vhds(sr_path, staging_path, uuid_stack):
 def prepare_staging_area(sr_path, staging_path, vdi_uuids, seq_num=0):
     """Hard-link VHDs into staging area."""
     for vdi_uuid in vdi_uuids:
-        source = os.path.join(sr_path, "%s.vhd" % vdi_uuid)
-        link_name = os.path.join(staging_path, "%d.vhd" % seq_num)
+        source = os.path.join(sr_path, "{0!s}.vhd".format(vdi_uuid))
+        link_name = os.path.join(staging_path, "{0:d}.vhd".format(seq_num))
         _link(source, link_name)
         seq_num += 1
 
@@ -416,10 +415,10 @@ def create_tarball(fileobj, path, callback=None, compression_level=None):
     :param callback: optional callback to call on each chunk written
     :param compression_level: compression level, e.g., 9 for gzip -9.
     """
-    tar_cmd = ["tar", "-zc", "--directory=%s" % path, "."]
+    tar_cmd = ["tar", "-zc", "--directory={0!s}".format(path), "."]
     env = os.environ.copy()
     if compression_level and 1 <= compression_level <= 9:
-        env["GZIP"] = "-%d" % compression_level
+        env["GZIP"] = "-{0:d}".format(compression_level)
     tar_proc = make_subprocess(tar_cmd, stdout=True, stderr=True, env=env)
 
     try:
@@ -447,7 +446,7 @@ def extract_tarball(fileobj, path, callback=None):
     :param path: path to extract tarball into
     :param callback: optional callback to call on each chunk read
     """
-    tar_cmd = ["tar", "-zx", "--directory=%s" % path]
+    tar_cmd = ["tar", "-zx", "--directory={0!s}".format(path)]
     tar_proc = make_subprocess(tar_cmd, stderr=True, stdin=True)
 
     try:
@@ -479,7 +478,7 @@ def extract_tarball(fileobj, path, callback=None):
         # no need to kill already dead process
         raise
     except Exception:
-        LOG.exception("Failed while sending data to tar pid: %s" % tar_pid)
+        LOG.exception("Failed while sending data to tar pid: {0!s}".format(tar_pid))
         try_kill_process(tar_proc)
         raise
 

--- a/plugins/xenserver/xenapi/etc/xapi.d/plugins/xenstore.py
+++ b/plugins/xenserver/xenapi/etc/xapi.d/plugins/xenstore.py
@@ -69,7 +69,7 @@ def record_exists(arg_dict):
     """Returns whether or not the given record exists. The record path
     is determined from the given path and dom_id in the arg_dict.
     """
-    cmd = ["xenstore-exists", "/local/domain/%(dom_id)s/%(path)s" % arg_dict]
+    cmd = ["xenstore-exists", "/local/domain/{dom_id!s}/{path!s}".format(**arg_dict)]
     try:
         _run_command(cmd)
         return True
@@ -89,7 +89,7 @@ def read_record(self, arg_dict):
     and boolean True, attempting to read a non-existent path will return
     the string 'None' instead of raising an exception.
     """
-    cmd = ["xenstore-read", "/local/domain/%(dom_id)s/%(path)s" % arg_dict]
+    cmd = ["xenstore-read", "/local/domain/{dom_id!s}/{path!s}".format(**arg_dict)]
     try:
         result = _run_command(cmd)
         return result.strip()
@@ -114,7 +114,7 @@ def write_record(self, arg_dict):
     you can json-ify more complex values and store the json output.
     """
     cmd = ["xenstore-write",
-           "/local/domain/%(dom_id)s/%(path)s" % arg_dict,
+           "/local/domain/{dom_id!s}/{path!s}".format(**arg_dict),
            arg_dict["value"]]
     _run_command(cmd)
     return arg_dict["value"]
@@ -127,7 +127,7 @@ def list_records(self, arg_dict):
     path as the key and the stored value as the value. If the path
     doesn't exist, an empty dict is returned.
     """
-    dirpath = "/local/domain/%(dom_id)s/%(path)s" % arg_dict
+    dirpath = "/local/domain/{dom_id!s}/{path!s}".format(**arg_dict)
     cmd = ["xenstore-ls", dirpath.rstrip("/")]
     try:
         recs = _run_command(cmd)
@@ -143,7 +143,7 @@ def list_records(self, arg_dict):
     ret = {}
     for path in paths:
         if base_path:
-            arg_dict["path"] = "%s/%s" % (base_path, path)
+            arg_dict["path"] = "{0!s}/{1!s}".format(base_path, path)
         else:
             arg_dict["path"] = path
         rec = read_record(self, arg_dict)
@@ -160,7 +160,7 @@ def delete_record(self, arg_dict):
     """Just like it sounds: it removes the record for the specified
     VM and the specified path from xenstore.
     """
-    cmd = ["xenstore-rm", "/local/domain/%(dom_id)s/%(path)s" % arg_dict]
+    cmd = ["xenstore-rm", "/local/domain/{dom_id!s}/{path!s}".format(**arg_dict)]
     try:
         return _run_command(cmd)
     except XenstoreError, e:    # noqa
@@ -189,14 +189,14 @@ def _paths_from_ls(recs):
             path = []
         elif this_level == level:
             # child of same parent
-            ret.append("%s/%s" % ("/".join(path), barename))
+            ret.append("{0!s}/{1!s}".format("/".join(path), barename))
         elif this_level > level:
             path.append(last_nm)
-            ret.append("%s/%s" % ("/".join(path), barename))
+            ret.append("{0!s}/{1!s}".format("/".join(path), barename))
             level = this_level
         elif this_level < level:
             path = path[:this_level]
-            ret.append("%s/%s" % ("/".join(path), barename))
+            ret.append("{0!s}/{1!s}".format("/".join(path), barename))
             level = this_level
         last_nm = barename
     return ret

--- a/tools/colorizer.py
+++ b/tools/colorizer.py
@@ -90,7 +90,7 @@ class _AnsiColorizer(object):
         @param color: A string label for a color. e.g. 'red', 'white'.
         """
         color = self._colors[color]
-        self.stream.write('\x1b[%s;1m%s\x1b[0m' % (color, text))
+        self.stream.write('\x1b[{0!s};1m{1!s}\x1b[0m'.format(color, text))
 
 
 class _Win32Colorizer(object):
@@ -186,7 +186,7 @@ class NovaTestResult(testtools.TestResult):
 
     def _writeElapsedTime(self, elapsed):
         color = get_elapsed_time_color(elapsed)
-        self.colorizer.write("  %.2f" % elapsed, color)
+        self.colorizer.write("  {0:.2f}".format(elapsed), color)
 
     def _addResult(self, test, *args):
         try:
@@ -210,7 +210,7 @@ class NovaTestResult(testtools.TestResult):
     def _writeResult(self, test_name, elapsed, long_result, color,
                      short_result, success):
         if self.showAll:
-            self.stream.write('    %s' % str(test_name).ljust(66))
+            self.stream.write('    {0!s}'.format(str(test_name).ljust(66)))
             self.colorizer.write(long_result, color)
             if success:
                 self._writeElapsedTime(elapsed)
@@ -279,8 +279,7 @@ class NovaTestResult(testtools.TestResult):
                       if get_elapsed_time_color(item[0]) != 'green']
         if slow_tests:
             slow_total_time = sum(item[0] for item in slow_tests)
-            slow = ("Slowest %i tests took %.2f secs:"
-                    % (len(slow_tests), slow_total_time))
+            slow = ("Slowest {0:d} tests took {1:.2f} secs:".format(len(slow_tests), slow_total_time))
             self.colorizer.write(slow, 'yellow')
             self.stream.writeln()
             last_cls = None
@@ -291,7 +290,7 @@ class NovaTestResult(testtools.TestResult):
                     self.colorizer.write(cls, 'white')
                     self.stream.writeln()
                 last_cls = cls
-                self.stream.write('    %s' % str(name).ljust(68))
+                self.stream.write('    {0!s}'.format(str(name).ljust(68)))
                 self._writeElapsedTime(elapsed)
                 self.stream.writeln()
 
@@ -306,10 +305,10 @@ class NovaTestResult(testtools.TestResult):
             self.colorizer.write("=" * 70, 'red')
             self.stream.writeln()
             self.colorizer.write(flavor, 'red')
-            self.stream.writeln(": %s" % test.id())
+            self.stream.writeln(": {0!s}".format(test.id()))
             self.colorizer.write("-" * 70, 'red')
             self.stream.writeln()
-            self.stream.writeln("%s" % err)
+            self.stream.writeln("{0!s}".format(err))
 
 
 test = subunit.ProtocolTestCase(sys.stdin, passthrough=None)

--- a/tools/db/schema_diff.py
+++ b/tools/db/schema_diff.py
@@ -77,8 +77,7 @@ def dump_db(db_driver, db_name, db_url, migration_version, dump_filename):
 
 
 def diff_files(filename1, filename2):
-    pipeline = ['diff -U 3 %(filename1)s %(filename2)s'
-                % {'filename1': filename1, 'filename2': filename2}]
+    pipeline = ['diff -U 3 {filename1!s} {filename2!s}'.format(**{'filename1': filename1, 'filename2': filename2})]
 
     # Use colordiff if available
     if subprocess.call(['which', 'colordiff']) == 0:
@@ -102,8 +101,7 @@ class Mysql(object):
 
     def dump(self, name, dump_filename):
         subprocess.check_call(
-                'mysqldump -u root %(name)s > %(dump_filename)s'
-                % {'name': name, 'dump_filename': dump_filename},
+                'mysqldump -u root {name!s} > {dump_filename!s}'.format(**{'name': name, 'dump_filename': dump_filename}),
                 shell=True)
 
 
@@ -116,8 +114,7 @@ class Postgresql(object):
 
     def dump(self, name, dump_filename):
         subprocess.check_call(
-                'pg_dump %(name)s > %(dump_filename)s'
-                % {'name': name, 'dump_filename': dump_filename},
+                'pg_dump {name!s} > {dump_filename!s}'.format(**{'name': name, 'dump_filename': dump_filename}),
                 shell=True)
 
 
@@ -126,20 +123,20 @@ class Ibm_db_sa(object):
     @classmethod
     def db2cmd(cls, cmd):
         """Wraps a command to be run under the DB2 instance user."""
-        subprocess.check_call('su - $(db2ilist) -c "%s"' % cmd, shell=True)
+        subprocess.check_call('su - $(db2ilist) -c "{0!s}"'.format(cmd), shell=True)
 
     def create(self, name):
-        self.db2cmd('db2 \'create database %s\'' % name)
+        self.db2cmd('db2 \'create database {0!s}\''.format(name))
 
     def drop(self, name):
-        self.db2cmd('db2 \'drop database %s\'' % name)
+        self.db2cmd('db2 \'drop database {0!s}\''.format(name))
 
     def dump(self, name, dump_filename):
-        self.db2cmd('db2look -d %(name)s -e -o %(dump_filename)s' %
-                    {'name': name, 'dump_filename': dump_filename})
+        self.db2cmd('db2look -d {name!s} -e -o {dump_filename!s}'.format(**
+                    {'name': name, 'dump_filename': dump_filename}))
         # The output file gets dumped to the db2 instance user's home directory
         # so we have to copy it back to our current working directory.
-        subprocess.check_call('cp /home/$(db2ilist)/%s ./' % dump_filename,
+        subprocess.check_call('cp /home/$(db2ilist)/{0!s} ./'.format(dump_filename),
                               shell=True)
 
 
@@ -176,8 +173,8 @@ def _migrate_cmd(db_url, *cmd):
 
     args = ['python', manage_py]
     args += cmd
-    args += ['--repository=%s' % MIGRATE_REPO,
-             '--url=%s' % db_url]
+    args += ['--repository={0!s}'.format(MIGRATE_REPO),
+             '--url={0!s}'.format(db_url)]
 
     subprocess.check_call(args)
 
@@ -229,19 +226,19 @@ def git_has_uncommited_changes():
 
 
 def die(msg):
-    print("ERROR: %s" % msg, file=sys.stderr)
+    print("ERROR: {0!s}".format(msg), file=sys.stderr)
     sys.exit(1)
 
 
 def usage(msg=None):
     if msg:
-        print("ERROR: %s" % msg, file=sys.stderr)
+        print("ERROR: {0!s}".format(msg), file=sys.stderr)
 
     prog = "schema_diff.py"
     args = ["<db-url>", "<orig-branch:orig-version>",
             "<new-branch:new-version>"]
 
-    print("usage: %s %s" % (prog, ' '.join(args)), file=sys.stderr)
+    print("usage: {0!s} {1!s}".format(prog, ' '.join(args)), file=sys.stderr)
     sys.exit(1)
 
 
@@ -267,8 +264,8 @@ def parse_options():
 def main():
     timestamp = datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
 
-    ORIG_DB = 'orig_db_%s' % timestamp
-    NEW_DB = 'new_db_%s' % timestamp
+    ORIG_DB = 'orig_db_{0!s}'.format(timestamp)
+    NEW_DB = 'new_db_{0!s}'.format(timestamp)
 
     ORIG_DUMP = ORIG_DB + ".dump"
     NEW_DUMP = NEW_DB + ".dump"

--- a/tools/install_venv.py
+++ b/tools/install_venv.py
@@ -58,7 +58,7 @@ def main(argv):
 
     pip_requires = os.path.join(root, 'requirements.txt')
     test_requires = os.path.join(root, 'test-requirements.txt')
-    py_version = "python%s.%s" % (sys.version_info[0], sys.version_info[1])
+    py_version = "python{0!s}.{1!s}".format(sys.version_info[0], sys.version_info[1])
     project = 'Nova'
     install = install_venv.InstallVenv(root, venv, pip_requires, test_requires,
                              py_version, project)

--- a/tools/regression_tester.py
+++ b/tools/regression_tester.py
@@ -39,7 +39,7 @@ import sys
 
 
 def run(cmd, fail_ok=False):
-    print("running: %s" % cmd)
+    print("running: {0!s}".format(cmd))
     obj = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                            shell=True)
     obj.wait()
@@ -60,7 +60,7 @@ def main():
     (options, args) = parser.parse_args()
     if options.review:
         original_branch = run("git rev-parse --abbrev-ref HEAD")
-        run("git review -d %s" % options.review)
+        run("git review -d {0!s}".format(options.review))
     else:
         print ("no gerrit review number specified, running on latest commit"
                "on current branch.")
@@ -83,7 +83,7 @@ def main():
         expect_failure = ""
     else:
         # run new tests, expect them to fail
-        expect_failure = run(("tox -epy27 %s 2>&1" % string.join(test_list)),
+        expect_failure = run(("tox -epy27 {0!s} 2>&1".format(string.join(test_list))),
                              fail_ok=True)
         if "FAILED (id=" in expect_failure:
             test_works = True
@@ -92,8 +92,8 @@ def main():
     run("git checkout HEAD nova")
     if options.review:
         new_branch = run("git status | head -1 | cut -d ' ' -f 4")
-        run("git checkout %s" % original_branch)
-        run("git branch -D %s" % new_branch)
+        run("git checkout {0!s}".format(original_branch))
+        run("git branch -D {0!s}".format(new_branch))
 
     print(expect_failure)
     print("")

--- a/tools/reserve-migrations.py
+++ b/tools/reserve-migrations.py
@@ -43,13 +43,13 @@ def get_last_migration(base):
 def reserve_migrations(base, number, git_add):
     last = get_last_migration(base)
     for i in range(last + 1, last + number + 1):
-        name = '%03i_placeholder.py' % i
+        name = '{0:03d}_placeholder.py'.format(i)
         path = os.path.join(*tuple(base + [name]))
         with open(path, 'w') as f:
             f.write(STUB)
-        print('Created %s' % path)
+        print('Created {0!s}'.format(path))
         if git_add:
-            subprocess.call('git add %s' % path, shell=True)
+            subprocess.call('git add {0!s}'.format(path), shell=True)
 
 
 def main():

--- a/tools/xenserver/cleanup_sm_locks.py
+++ b/tools/xenserver/cleanup_sm_locks.py
@@ -89,7 +89,7 @@ def main():
                 removed += 1
 
                 if options.verbose:
-                    print 'Removing old lock: %03d %s' % (lock_age_days,
+                    print 'Removing old lock: {0:03d} {1!s}'.format(lock_age_days,
                                                           lockpath)
 
                 if not options.dry_run:
@@ -100,7 +100,7 @@ def main():
             nspaths_removed += 1
 
             if options.verbose:
-                print 'Removing empty namespace: %s' % nspath
+                print 'Removing empty namespace: {0!s}'.format(nspath)
 
             if not options.dry_run:
                 try:

--- a/tools/xenserver/destroy_cached_images.py
+++ b/tools/xenserver/destroy_cached_images.py
@@ -69,7 +69,7 @@ def main():
     if '--verbose' in sys.argv:
         print '\n'.join(destroyed)
 
-    print "Destroyed %d cached VDIs" % len(destroyed)
+    print "Destroyed {0:d} cached VDIs".format(len(destroyed))
 
 
 if __name__ == "__main__":

--- a/tools/xenserver/populate_other_config.py
+++ b/tools/xenserver/populate_other_config.py
@@ -79,7 +79,7 @@ def main():
         # Parse out UUID
         instance_uuid = name_label.replace('instance-', '')[:36]
         if not uuidutils.is_uuid_like(instance_uuid):
-            print "error: name label '%s' wasn't UUID-like" % name_label
+            print "error: name label '{0!s}' wasn't UUID-like".format(name_label)
             continue
 
         vdi_type = vdi_rec['name_description']
@@ -92,7 +92,7 @@ def main():
                                    vdi_type, instance)
 
         if CONF.verbose:
-            print "Setting other_config for instance_uuid=%s vdi_uuid=%s" % (
+            print "Setting other_config for instance_uuid={0!s} vdi_uuid={1!s}".format(
                     instance_uuid, vdi_rec['uuid'])
 
         if CONF.dry_run:

--- a/tools/xenserver/stress_test.py
+++ b/tools/xenserver/stress_test.py
@@ -26,7 +26,7 @@ DOM0_CLEANUP_SCRIPT = "/tmp/destroy_cache_vdis"
 def run(cmd):
     ret = subprocess.call(cmd, shell=True)
     if ret != 0:
-        print >> sys.stderr, "Command exited non-zero: %s" % cmd
+        print >> sys.stderr, "Command exited non-zero: {0!s}".format(cmd)
 
 
 @contextlib.contextmanager
@@ -37,7 +37,7 @@ def server_built(server_name, image_name, flavor=1, cleanup=True):
         yield
     finally:
         if cleanup:
-            run("nova delete %(server_name)s" % locals())
+            run("nova delete {server_name!s}".format(**locals()))
 
 
 @contextlib.contextmanager
@@ -48,29 +48,28 @@ def snapshot_taken(server_name, snapshot_name, cleanup=True):
         yield
     finally:
         if cleanup:
-            run("nova image-delete %(snapshot_name)s" % locals())
+            run("nova image-delete {snapshot_name!s}".format(**locals()))
 
 
 def migrate_server(server_name):
-    run("nova migrate %(server_name)s --poll" % locals())
+    run("nova migrate {server_name!s} --poll".format(**locals()))
 
-    cmd = "nova list | grep %(server_name)s | awk '{print $6}'" % locals()
+    cmd = "nova list | grep {server_name!s} | awk '{{print $6}}'".format(**locals())
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     stdout, stderr = proc.communicate()
     status = stdout.strip()
     if status.upper() != 'VERIFY_RESIZE':
-        print >> sys.stderr, "Server %(server_name)s failed to rebuild"\
-                             % locals()
+        print >> sys.stderr, "Server {server_name!s} failed to rebuild".format(**locals())
         return False
 
     # Confirm the resize
-    run("nova resize-confirm %(server_name)s" % locals())
+    run("nova resize-confirm {server_name!s}".format(**locals()))
     return True
 
 
 def test_migrate(context):
     count, args = context
-    server_name = "server%d" % count
+    server_name = "server{0:d}".format(count)
     cleanup = args.cleanup
     with server_built(server_name, args.image, cleanup=cleanup):
         # Migrate A -> B
@@ -83,15 +82,14 @@ def test_migrate(context):
 
 
 def rebuild_server(server_name, snapshot_name):
-    run("nova rebuild %(server_name)s %(snapshot_name)s --poll" % locals())
+    run("nova rebuild {server_name!s} {snapshot_name!s} --poll".format(**locals()))
 
-    cmd = "nova list | grep %(server_name)s | awk '{print $6}'" % locals()
+    cmd = "nova list | grep {server_name!s} | awk '{{print $6}}'".format(**locals())
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     stdout, stderr = proc.communicate()
     status = stdout.strip()
     if status != 'ACTIVE':
-        print >> sys.stderr, "Server %(server_name)s failed to rebuild"\
-                             % locals()
+        print >> sys.stderr, "Server {server_name!s} failed to rebuild".format(**locals())
         return False
 
     return True
@@ -99,8 +97,8 @@ def rebuild_server(server_name, snapshot_name):
 
 def test_rebuild(context):
     count, args = context
-    server_name = "server%d" % count
-    snapshot_name = "snap%d" % count
+    server_name = "server{0:d}".format(count)
+    snapshot_name = "snap{0:d}".format(count)
     cleanup = args.cleanup
     with server_built(server_name, args.image, cleanup=cleanup):
         with snapshot_taken(server_name, snapshot_name, cleanup=cleanup):
@@ -144,9 +142,9 @@ def main():
 
     results = []
     for test in args.tests:
-        test_func = globals().get("test_%s" % test)
+        test_func = globals().get("test_{0!s}".format(test))
         if not test_func:
-            print >> sys.stderr, "test '%s' not found" % test
+            print >> sys.stderr, "test '{0!s}' not found".format(test)
             sys.exit(1)
 
         contexts = [(x, args) for x in range(args.num_runs)]
@@ -156,14 +154,13 @@ def main():
         finally:
             if args.cleanup:
                 for dom0_ip in dom0_ips:
-                    run("ssh root@%(dom0_ip)s %(dom0_cleanup_script)s"
-                        % locals())
+                    run("ssh root@{dom0_ip!s} {dom0_cleanup_script!s}".format(**locals()))
 
     success = all(results)
     result = "SUCCESS" if success else "FAILED"
 
     duration = time.time() - start_time
-    print "%s, finished in %.2f secs" % (result, duration)
+    print "{0!s}, finished in {1:.2f} secs".format(result, duration)
 
     sys.exit(0 if success else 1)
 

--- a/tools/xenserver/vdi_chain_cleanup.py
+++ b/tools/xenserver/vdi_chain_cleanup.py
@@ -40,7 +40,7 @@ class ExecutionFailed(Exception):
         self.max_stream_length = max_stream_length
 
     def __repr__(self):
-        return "<ExecutionFailed returncode=%s out='%s' stderr='%s'>" % (
+        return "<ExecutionFailed returncode={0!s} out='{1!s}' stderr='{2!s}'>".format(
             self.returncode, self.stdout, self.stderr)
 
     __str__ = __repr__
@@ -62,7 +62,7 @@ def execute(cmd, ok_exit_codes=None):
 
 
 def usage():
-    print "usage: %s <SR PATH> <print|delete|move>" % sys.argv[0]
+    print "usage: {0!s} <SR PATH> <print|delete|move>".format(sys.argv[0])
     sys.exit(1)
 
 
@@ -121,7 +121,7 @@ def main():
                                         os.path.basename(bad_vhd))
                 os.rename(bad_vhd, new_path)
             else:
-                raise Exception("invalid action %s" % action)
+                raise Exception("invalid action {0!s}".format(action))
 
 
 if __name__ == '__main__':

--- a/tools/xenserver/vm_vdi_cleaner.py
+++ b/tools/xenserver/vm_vdi_cleaner.py
@@ -130,7 +130,7 @@ def print_xen_object(obj_type, obj, indent_level=0, spaces_per_indent=4):
         name_label = obj["name_label"]
     except KeyError:
         name_label = ""
-    msg = "%(obj_type)s (%(uuid)s) '%(name_label)s'" % locals()
+    msg = "{obj_type!s} ({uuid!s}) '{name_label!s}'".format(**locals())
     indent = " " * spaces_per_indent * indent_level
     print "".join([indent, msg])
 
@@ -247,7 +247,7 @@ def list_orphaned_vdis(vdi_uuids):
     """List orphaned VDIs."""
     for vdi_uuid in vdi_uuids:
         if CONF.verbose:
-            print "ORPHANED VDI (%s)" % vdi_uuid
+            print "ORPHANED VDI ({0!s})".format(vdi_uuid)
         else:
             print vdi_uuid
 
@@ -256,20 +256,20 @@ def clean_orphaned_vdis(xenapi, vdi_uuids):
     """Clean orphaned VDIs."""
     for vdi_uuid in vdi_uuids:
         if CONF.verbose:
-            print "CLEANING VDI (%s)" % vdi_uuid
+            print "CLEANING VDI ({0!s})".format(vdi_uuid)
 
         vdi_ref = call_xenapi(xenapi, 'VDI.get_by_uuid', vdi_uuid)
         try:
             call_xenapi(xenapi, 'VDI.destroy', vdi_ref)
         except XenAPI.Failure, exc:
-            print >> sys.stderr, "Skipping %s: %s" % (vdi_uuid, exc)
+            print >> sys.stderr, "Skipping {0!s}: {1!s}".format(vdi_uuid, exc)
 
 
 def list_orphaned_instances(orphaned_instances):
     """List orphaned instances."""
     for vm_ref, vm_rec, orphaned_instance in orphaned_instances:
         if CONF.verbose:
-            print "ORPHANED INSTANCE (%s)" % orphaned_instance.name
+            print "ORPHANED INSTANCE ({0!s})".format(orphaned_instance.name)
         else:
             print orphaned_instance.name
 
@@ -278,7 +278,7 @@ def clean_orphaned_instances(xenapi, orphaned_instances):
     """Clean orphaned instances."""
     for vm_ref, vm_rec, instance in orphaned_instances:
         if CONF.verbose:
-            print "CLEANING INSTANCE (%s)" % instance.name
+            print "CLEANING INSTANCE ({0!s})".format(instance.name)
 
         cleanup_instance(xenapi, instance, vm_ref, vm_rec)
 
@@ -321,7 +321,7 @@ def main():
     elif command == "test":
         doctest.testmod()
     else:
-        print "Unknown command '%s'" % command
+        print "Unknown command '{0!s}'".format(command)
         sys.exit(1)
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:nova?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:nova?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
